### PR TITLE
Implement Encode & Decode for OutputShare.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -510,9 +510,9 @@ dependencies = [
 
 [[package]]
 name = "itertools"
-version = "0.10.1"
+version = "0.10.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "69ddb889f9d0d08a67338271fa9b62996bc788c7796a5c18cf057420aaed5eaf"
+checksum = "a9a9d19fa1e79b6215ff29b9d6880b706147f16e9b1dbb1e4e5947b5b02bc5e3"
 dependencies = [
  "either",
 ]
@@ -733,6 +733,7 @@ dependencies = [
  "ctr 0.9.1",
  "getrandom",
  "hex",
+ "itertools",
  "modinverse",
  "num-bigint",
  "prio",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -32,6 +32,7 @@ rayon = { version = "1.5.1", optional = true }
 [dev-dependencies]
 assert_matches = "1.5.0"
 criterion = "0.3"
+itertools = "0.10.3"
 modinverse = "0.1.0"
 num-bigint = "0.4.3"
 serde_json = "1.0"

--- a/src/vdaf.rs
+++ b/src/vdaf.rs
@@ -125,7 +125,7 @@ pub trait Vdaf: Clone + Debug {
     type InputShare: Clone + Debug + ParameterizedDecode<Self::VerifyParam> + Encode;
 
     /// An output share recovered from an input share by an Aggregator.
-    type OutputShare: Clone + Debug + Decode + Encode;
+    type OutputShare: Clone + Debug;
 
     /// An Aggregator's share of the aggregate result.
     type AggregateShare: Aggregatable<OutputShare = Self::OutputShare>

--- a/src/vdaf.rs
+++ b/src/vdaf.rs
@@ -233,7 +233,7 @@ pub trait Aggregatable: Clone + Debug + From<Self::OutputShare> {
 }
 
 /// An output share comprised of a vector of `F` elements.
-#[derive(Clone, Debug)]
+#[derive(Clone, Debug, PartialEq, Eq)]
 pub struct OutputShare<F>(Vec<F>);
 
 impl<F> AsRef<[F]> for OutputShare<F> {

--- a/src/vdaf.rs
+++ b/src/vdaf.rs
@@ -356,7 +356,7 @@ fn fieldvec_try_from_bytes<F: FieldElement, T: From<Vec<F>>>(
 /// fieldvec_to_vec converts a type that is equivalent to a vector of field elements into a vector
 /// of bytes.
 #[inline(always)]
-fn fieldvec_to_vec<'a, F: FieldElement, T: AsRef<[F]>>(val: T) -> Vec<u8> {
+fn fieldvec_to_vec<F: FieldElement, T: AsRef<[F]>>(val: T) -> Vec<u8> {
     F::slice_into_byte_vec(val.as_ref())
 }
 


### PR DESCRIPTION
Users of a VDAF need to store output shares for some time, so it makes
sense to implement Encode/Decode.

I also added a requirement that Vdaf::OutputShare implement Encode & Decode, following the lead of a few other types related to Vdaf. But I could drop this at the cost of slightly complexifying the trait bounds in implementations--I'm not opinionated here.

I also arbitrarily guess that 64KiB is enough to encode an OutputShare. I think this is probably OK, but if folks are worried we could bump to `encode_u32_items` at the cost of a few bytes per encoded OutputShare.