### PR TITLE
clippy: rename Montgomery conversion methods

### DIFF
--- a/src/field.rs
+++ b/src/field.rs
@@ -270,7 +270,7 @@ macro_rules! make_field {
                 if int >= $fp.p {
                     return Err(FieldError::ModulusOverflow);
                 }
-                Ok(Self($fp.elem(int)))
+                Ok(Self($fp.map(int)))
             }
         }
 
@@ -279,7 +279,7 @@ macro_rules! make_field {
                 // The fields included in this comparison MUST match the fields
                 // used in Hash::hash
                 // https://doc.rust-lang.org/std/hash/trait.Hash.html#hash-and-eq
-                $fp.from_elem(self.0) == $fp.from_elem(rhs.0)
+                $fp.inverse_map(self.0) == $fp.inverse_map(rhs.0)
             }
         }
 
@@ -288,7 +288,7 @@ macro_rules! make_field {
                 // The fields included in this hash MUST match the fields used
                 // in PartialEq::eq
                 // https://doc.rust-lang.org/std/hash/trait.Hash.html#hash-and-eq
-                $fp.from_elem(self.0).hash(state);
+                $fp.inverse_map(self.0).hash(state);
             }
         }
 
@@ -391,19 +391,19 @@ macro_rules! make_field {
 
         impl From<$int> for $elem {
             fn from(x: $int) -> Self {
-                Self($fp.elem(u128::try_from(x).unwrap()))
+                Self($fp.map(u128::try_from(x).unwrap()))
             }
         }
 
         impl From<$elem> for $int {
             fn from(x: $elem) -> Self {
-                $int::try_from($fp.from_elem(x.0)).unwrap()
+                $int::try_from($fp.inverse_map(x.0)).unwrap()
             }
         }
 
         impl PartialEq<$int> for $elem {
             fn eq(&self, rhs: &$int) -> bool {
-                $fp.from_elem(self.0) == u128::try_from(*rhs).unwrap()
+                $fp.inverse_map(self.0) == u128::try_from(*rhs).unwrap()
             }
         }
 
@@ -417,7 +417,7 @@ macro_rules! make_field {
 
         impl From<$elem> for [u8; $elem::ENCODED_SIZE] {
             fn from(elem: $elem) -> Self {
-                let int = $fp.from_elem(elem.0);
+                let int = $fp.inverse_map(elem.0);
                 let mut slice = [0; $elem::ENCODED_SIZE];
                 for i in 0..$elem::ENCODED_SIZE {
                     let j = match $encoding_order {
@@ -439,13 +439,13 @@ macro_rules! make_field {
 
         impl Display for $elem {
             fn fmt(&self, f: &mut Formatter) -> std::fmt::Result {
-                write!(f, "{}", $fp.from_elem(self.0))
+                write!(f, "{}", $fp.inverse_map(self.0))
             }
         }
 
         impl Debug for $elem {
             fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
-                write!(f, "{}", $fp.from_elem(self.0))
+                write!(f, "{}", $fp.inverse_map(self.0))
             }
         }
 

--- a/src/field.rs
+++ b/src/field.rs
@@ -270,7 +270,7 @@ macro_rules! make_field {
                 if int >= $fp.p {
                     return Err(FieldError::ModulusOverflow);
                 }
-                Ok(Self($fp.map_to_montgomery(int)))
+                Ok(Self($fp.montgomery(int)))
             }
         }
 
@@ -279,7 +279,7 @@ macro_rules! make_field {
                 // The fields included in this comparison MUST match the fields
                 // used in Hash::hash
                 // https://doc.rust-lang.org/std/hash/trait.Hash.html#hash-and-eq
-                $fp.map_to_residue(self.0) == $fp.map_to_residue(rhs.0)
+                $fp.residue(self.0) == $fp.residue(rhs.0)
             }
         }
 
@@ -288,7 +288,7 @@ macro_rules! make_field {
                 // The fields included in this hash MUST match the fields used
                 // in PartialEq::eq
                 // https://doc.rust-lang.org/std/hash/trait.Hash.html#hash-and-eq
-                $fp.map_to_residue(self.0).hash(state);
+                $fp.residue(self.0).hash(state);
             }
         }
 
@@ -391,19 +391,19 @@ macro_rules! make_field {
 
         impl From<$int> for $elem {
             fn from(x: $int) -> Self {
-                Self($fp.map_to_montgomery(u128::try_from(x).unwrap()))
+                Self($fp.montgomery(u128::try_from(x).unwrap()))
             }
         }
 
         impl From<$elem> for $int {
             fn from(x: $elem) -> Self {
-                $int::try_from($fp.map_to_residue(x.0)).unwrap()
+                $int::try_from($fp.residue(x.0)).unwrap()
             }
         }
 
         impl PartialEq<$int> for $elem {
             fn eq(&self, rhs: &$int) -> bool {
-                $fp.map_to_residue(self.0) == u128::try_from(*rhs).unwrap()
+                $fp.residue(self.0) == u128::try_from(*rhs).unwrap()
             }
         }
 
@@ -417,7 +417,7 @@ macro_rules! make_field {
 
         impl From<$elem> for [u8; $elem::ENCODED_SIZE] {
             fn from(elem: $elem) -> Self {
-                let int = $fp.map_to_residue(elem.0);
+                let int = $fp.residue(elem.0);
                 let mut slice = [0; $elem::ENCODED_SIZE];
                 for i in 0..$elem::ENCODED_SIZE {
                     let j = match $encoding_order {
@@ -439,13 +439,13 @@ macro_rules! make_field {
 
         impl Display for $elem {
             fn fmt(&self, f: &mut Formatter) -> std::fmt::Result {
-                write!(f, "{}", $fp.map_to_residue(self.0))
+                write!(f, "{}", $fp.residue(self.0))
             }
         }
 
         impl Debug for $elem {
             fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
-                write!(f, "{}", $fp.map_to_residue(self.0))
+                write!(f, "{}", $fp.residue(self.0))
             }
         }
 

--- a/src/field.rs
+++ b/src/field.rs
@@ -270,7 +270,7 @@ macro_rules! make_field {
                 if int >= $fp.p {
                     return Err(FieldError::ModulusOverflow);
                 }
-                Ok(Self($fp.map(int)))
+                Ok(Self($fp.map_to_montgomery(int)))
             }
         }
 
@@ -279,7 +279,7 @@ macro_rules! make_field {
                 // The fields included in this comparison MUST match the fields
                 // used in Hash::hash
                 // https://doc.rust-lang.org/std/hash/trait.Hash.html#hash-and-eq
-                $fp.inverse_map(self.0) == $fp.inverse_map(rhs.0)
+                $fp.map_to_residue(self.0) == $fp.map_to_residue(rhs.0)
             }
         }
 
@@ -288,7 +288,7 @@ macro_rules! make_field {
                 // The fields included in this hash MUST match the fields used
                 // in PartialEq::eq
                 // https://doc.rust-lang.org/std/hash/trait.Hash.html#hash-and-eq
-                $fp.inverse_map(self.0).hash(state);
+                $fp.map_to_residue(self.0).hash(state);
             }
         }
 
@@ -391,19 +391,19 @@ macro_rules! make_field {
 
         impl From<$int> for $elem {
             fn from(x: $int) -> Self {
-                Self($fp.map(u128::try_from(x).unwrap()))
+                Self($fp.map_to_montgomery(u128::try_from(x).unwrap()))
             }
         }
 
         impl From<$elem> for $int {
             fn from(x: $elem) -> Self {
-                $int::try_from($fp.inverse_map(x.0)).unwrap()
+                $int::try_from($fp.map_to_residue(x.0)).unwrap()
             }
         }
 
         impl PartialEq<$int> for $elem {
             fn eq(&self, rhs: &$int) -> bool {
-                $fp.inverse_map(self.0) == u128::try_from(*rhs).unwrap()
+                $fp.map_to_residue(self.0) == u128::try_from(*rhs).unwrap()
             }
         }
 
@@ -417,7 +417,7 @@ macro_rules! make_field {
 
         impl From<$elem> for [u8; $elem::ENCODED_SIZE] {
             fn from(elem: $elem) -> Self {
-                let int = $fp.inverse_map(elem.0);
+                let int = $fp.map_to_residue(elem.0);
                 let mut slice = [0; $elem::ENCODED_SIZE];
                 for i in 0..$elem::ENCODED_SIZE {
                     let j = match $encoding_order {
@@ -439,13 +439,13 @@ macro_rules! make_field {
 
         impl Display for $elem {
             fn fmt(&self, f: &mut Formatter) -> std::fmt::Result {
-                write!(f, "{}", $fp.inverse_map(self.0))
+                write!(f, "{}", $fp.map_to_residue(self.0))
             }
         }
 
         impl Debug for $elem {
             fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
-                write!(f, "{}", $fp.inverse_map(self.0))
+                write!(f, "{}", $fp.map_to_residue(self.0))
             }
         }
 

--- a/src/fp.rs
+++ b/src/fp.rs
@@ -71,8 +71,10 @@ impl FieldParameters {
     /// described
     /// [here](https://www.ams.org/journals/mcom/1985-44-170/S0025-5718-1985-0777282-X/S0025-5718-1985-0777282-X.pdf).
     ///
-    /// Example usage:
-    /// assert_eq!(fp.from_elem(fp.mul(fp.elem(23), fp.elem(2))), 46);
+    /// # Example usage
+    /// ```text
+    /// assert_eq!(fp.inverse_map(fp.mul(fp.map(23), fp.map(2))), 46);
+    /// ```
     pub fn mul(&self, x: u128, y: u128) -> u128 {
         let x = [lo64(x), hi64(x)];
         let y = [lo64(y), hi64(y)];
@@ -207,7 +209,7 @@ impl FieldParameters {
     /// Modular exponentiation, i.e., `x^exp (mod p)` where `p` is the modulus. Note that the
     /// runtime of this algorithm is linear in the bit length of `exp`.
     pub fn pow(&self, x: u128, exp: u128) -> u128 {
-        let mut t = self.elem(1);
+        let mut t = self.map(1);
         for i in (0..128 - exp.leading_zeros()).rev() {
             t = self.mul(t, t);
             if (exp >> i) & 1 != 0 {
@@ -231,11 +233,13 @@ impl FieldParameters {
     /// Maps an integer to its internal representation. Field elements are mapped to the Montgomery
     /// domain in order to carry out field arithmetic.
     ///
-    /// Example usage:
+    /// # Example usage
+    /// ```text
     /// let integer = 1; // Standard integer representation
-    /// let elem = fp.elem(integer); // Internal representation in the Montgomery domain
+    /// let elem = fp.map(integer); // Internal representation in the Montgomery domain
     /// assert_eq!(elem, 2564090464);
-    pub fn elem(&self, x: u128) -> u128 {
+    /// ```
+    pub fn map(&self, x: u128) -> u128 {
         modp(self.mul(x, self.r2), self.p)
     }
 
@@ -243,16 +247,18 @@ impl FieldParameters {
     #[cfg(test)]
     pub fn rand_elem<R: Rng + ?Sized>(&self, rng: &mut R) -> u128 {
         let uniform = rand::distributions::Uniform::from(0..self.p);
-        self.elem(uniform.sample(rng))
+        self.map(uniform.sample(rng))
     }
 
     /// Maps a field element to its representation as an integer.
     ///
-    /// Example usage:
+    /// #Example usage
+    /// ```text
     /// let elem = 2564090464; // Internal representation in the Montgomery domain
-    /// let integer = fp.from_elem(elem); // Standard integer representation
+    /// let integer = fp.inverse_map(elem); // Standard integer representation
     /// assert_eq!(integer, 1);
-    pub fn from_elem(&self, x: u128) -> u128 {
+    /// ```
+    pub fn inverse_map(&self, x: u128) -> u128 {
         modp(self.mul(x, 1), self.p)
     }
 
@@ -281,9 +287,9 @@ impl FieldParameters {
         }
         assert_eq!(self.r2, r2, "r2 mismatch");
 
-        assert_eq!(self.g, self.elem(g), "g mismatch");
+        assert_eq!(self.g, self.map(g), "g mismatch");
         assert_eq!(
-            self.from_elem(self.pow(self.g, order)),
+            self.inverse_map(self.pow(self.g, order)),
             1,
             "g order incorrect"
         );
@@ -293,12 +299,12 @@ impl FieldParameters {
         assert_eq!(self.num_roots, num_roots, "num_roots mismatch");
 
         let mut roots = vec![0; max(num_roots, MAX_ROOTS) + 1];
-        roots[num_roots] = self.elem(g);
+        roots[num_roots] = self.map(g);
         for i in (0..num_roots).rev() {
             roots[i] = self.mul(roots[i + 1], roots[i + 1]);
         }
         assert_eq!(&self.roots, &roots[..MAX_ROOTS + 1], "roots mismatch");
-        assert_eq!(self.from_elem(self.roots[0]), 1, "first root is not one");
+        assert_eq!(self.inverse_map(self.roots[0]), 1, "first root is not one");
 
         let bit_mask = (BigInt::from(1) << big_p.bits()) - BigInt::from(1);
         assert_eq!(
@@ -461,8 +467,8 @@ mod tests {
     struct TestFieldParametersData {
         fp: FieldParameters,  // The paramters being tested
         expected_p: u128,     // Expected fp.p
-        expected_g: u128,     // Expected fp.from_elem(fp.g)
-        expected_order: u128, // Expect fp.from_elem(fp.pow(fp.g, expected_order)) == 1
+        expected_g: u128,     // Expected fp.inverse_map(fp.g)
+        expected_order: u128, // Expect fp.inverse_map(fp.pow(fp.g, expected_order)) == 1
     }
 
     #[test]
@@ -499,7 +505,7 @@ mod tests {
             t.fp.check(t.expected_p, t.expected_g, t.expected_order);
 
             // Check that the generator has the correct order.
-            assert_eq!(t.fp.from_elem(t.fp.pow(t.fp.g, t.expected_order)), 1);
+            assert_eq!(t.fp.inverse_map(t.fp.pow(t.fp.g, t.expected_order)), 1);
 
             // Test arithmetic using the field parameters.
             arithmetic_test(&t.fp);
@@ -513,13 +519,13 @@ mod tests {
         for _ in 0..100 {
             let x = fp.rand_elem(&mut rng);
             let y = fp.rand_elem(&mut rng);
-            let big_x = &fp.from_elem(x).to_bigint().unwrap();
-            let big_y = &fp.from_elem(y).to_bigint().unwrap();
+            let big_x = &fp.inverse_map(x).to_bigint().unwrap();
+            let big_y = &fp.inverse_map(y).to_bigint().unwrap();
 
             // Test addition.
             let got = fp.add(x, y);
             let want = (big_x + big_y) % big_p;
-            assert_eq!(fp.from_elem(got).to_bigint().unwrap(), want);
+            assert_eq!(fp.inverse_map(got).to_bigint().unwrap(), want);
 
             // Test subtraction.
             let got = fp.sub(x, y);
@@ -528,24 +534,24 @@ mod tests {
             } else {
                 big_p - big_y + big_x
             };
-            assert_eq!(fp.from_elem(got).to_bigint().unwrap(), want);
+            assert_eq!(fp.inverse_map(got).to_bigint().unwrap(), want);
 
             // Test multiplication.
             let got = fp.mul(x, y);
             let want = (big_x * big_y) % big_p;
-            assert_eq!(fp.from_elem(got).to_bigint().unwrap(), want);
+            assert_eq!(fp.inverse_map(got).to_bigint().unwrap(), want);
 
             // Test inversion.
             let got = fp.inv(x);
             let want = big_x.modpow(&(big_p - 2u128), big_p);
-            assert_eq!(fp.from_elem(got).to_bigint().unwrap(), want);
-            assert_eq!(fp.from_elem(fp.mul(got, x)), 1);
+            assert_eq!(fp.inverse_map(got).to_bigint().unwrap(), want);
+            assert_eq!(fp.inverse_map(fp.mul(got, x)), 1);
 
             // Test negation.
             let got = fp.neg(x);
             let want = (big_p - big_x) % big_p;
-            assert_eq!(fp.from_elem(got).to_bigint().unwrap(), want);
-            assert_eq!(fp.from_elem(fp.add(got, x)), 0);
+            assert_eq!(fp.inverse_map(got).to_bigint().unwrap(), want);
+            assert_eq!(fp.inverse_map(fp.add(got, x)), 0);
         }
     }
 }

--- a/src/fp.rs
+++ b/src/fp.rs
@@ -73,7 +73,7 @@ impl FieldParameters {
     ///
     /// # Example usage
     /// ```text
-    /// assert_eq!(fp.map_to_residue(fp.mul(fp.map_to_montgomery(23), fp.map_to_montgomery(2))), 46);
+    /// assert_eq!(fp.residue(fp.mul(fp.montgomery(23), fp.montgomery(2))), 46);
     /// ```
     pub fn mul(&self, x: u128, y: u128) -> u128 {
         let x = [lo64(x), hi64(x)];
@@ -209,7 +209,7 @@ impl FieldParameters {
     /// Modular exponentiation, i.e., `x^exp (mod p)` where `p` is the modulus. Note that the
     /// runtime of this algorithm is linear in the bit length of `exp`.
     pub fn pow(&self, x: u128, exp: u128) -> u128 {
-        let mut t = self.map_to_montgomery(1);
+        let mut t = self.montgomery(1);
         for i in (0..128 - exp.leading_zeros()).rev() {
             t = self.mul(t, t);
             if (exp >> i) & 1 != 0 {
@@ -236,10 +236,10 @@ impl FieldParameters {
     /// # Example usage
     /// ```text
     /// let integer = 1; // Standard integer representation
-    /// let elem = fp.map_to_montgomery(integer); // Internal representation in the Montgomery domain
+    /// let elem = fp.montgomery(integer); // Internal representation in the Montgomery domain
     /// assert_eq!(elem, 2564090464);
     /// ```
-    pub fn map_to_montgomery(&self, x: u128) -> u128 {
+    pub fn montgomery(&self, x: u128) -> u128 {
         modp(self.mul(x, self.r2), self.p)
     }
 
@@ -247,7 +247,7 @@ impl FieldParameters {
     #[cfg(test)]
     pub fn rand_elem<R: Rng + ?Sized>(&self, rng: &mut R) -> u128 {
         let uniform = rand::distributions::Uniform::from(0..self.p);
-        self.map_to_montgomery(uniform.sample(rng))
+        self.montgomery(uniform.sample(rng))
     }
 
     /// Maps a field element to its representation as an integer.
@@ -255,10 +255,10 @@ impl FieldParameters {
     /// #Example usage
     /// ```text
     /// let elem = 2564090464; // Internal representation in the Montgomery domain
-    /// let integer = fp.map_to_residue(elem); // Standard integer representation
+    /// let integer = fp.residue(elem); // Standard integer representation
     /// assert_eq!(integer, 1);
     /// ```
-    pub fn map_to_residue(&self, x: u128) -> u128 {
+    pub fn residue(&self, x: u128) -> u128 {
         modp(self.mul(x, 1), self.p)
     }
 
@@ -287,9 +287,9 @@ impl FieldParameters {
         }
         assert_eq!(self.r2, r2, "r2 mismatch");
 
-        assert_eq!(self.g, self.map_to_montgomery(g), "g mismatch");
+        assert_eq!(self.g, self.montgomery(g), "g mismatch");
         assert_eq!(
-            self.map_to_residue(self.pow(self.g, order)),
+            self.residue(self.pow(self.g, order)),
             1,
             "g order incorrect"
         );
@@ -299,16 +299,12 @@ impl FieldParameters {
         assert_eq!(self.num_roots, num_roots, "num_roots mismatch");
 
         let mut roots = vec![0; max(num_roots, MAX_ROOTS) + 1];
-        roots[num_roots] = self.map_to_montgomery(g);
+        roots[num_roots] = self.montgomery(g);
         for i in (0..num_roots).rev() {
             roots[i] = self.mul(roots[i + 1], roots[i + 1]);
         }
         assert_eq!(&self.roots, &roots[..MAX_ROOTS + 1], "roots mismatch");
-        assert_eq!(
-            self.map_to_residue(self.roots[0]),
-            1,
-            "first root is not one"
-        );
+        assert_eq!(self.residue(self.roots[0]), 1, "first root is not one");
 
         let bit_mask = (BigInt::from(1) << big_p.bits()) - BigInt::from(1);
         assert_eq!(
@@ -471,8 +467,8 @@ mod tests {
     struct TestFieldParametersData {
         fp: FieldParameters,  // The paramters being tested
         expected_p: u128,     // Expected fp.p
-        expected_g: u128,     // Expected fp.map_to_residue(fp.g)
-        expected_order: u128, // Expect fp.map_to_residue(fp.pow(fp.g, expected_order)) == 1
+        expected_g: u128,     // Expected fp.residue(fp.g)
+        expected_order: u128, // Expect fp.residue(fp.pow(fp.g, expected_order)) == 1
     }
 
     #[test]
@@ -509,7 +505,7 @@ mod tests {
             t.fp.check(t.expected_p, t.expected_g, t.expected_order);
 
             // Check that the generator has the correct order.
-            assert_eq!(t.fp.map_to_residue(t.fp.pow(t.fp.g, t.expected_order)), 1);
+            assert_eq!(t.fp.residue(t.fp.pow(t.fp.g, t.expected_order)), 1);
 
             // Test arithmetic using the field parameters.
             arithmetic_test(&t.fp);
@@ -523,13 +519,13 @@ mod tests {
         for _ in 0..100 {
             let x = fp.rand_elem(&mut rng);
             let y = fp.rand_elem(&mut rng);
-            let big_x = &fp.map_to_residue(x).to_bigint().unwrap();
-            let big_y = &fp.map_to_residue(y).to_bigint().unwrap();
+            let big_x = &fp.residue(x).to_bigint().unwrap();
+            let big_y = &fp.residue(y).to_bigint().unwrap();
 
             // Test addition.
             let got = fp.add(x, y);
             let want = (big_x + big_y) % big_p;
-            assert_eq!(fp.map_to_residue(got).to_bigint().unwrap(), want);
+            assert_eq!(fp.residue(got).to_bigint().unwrap(), want);
 
             // Test subtraction.
             let got = fp.sub(x, y);
@@ -538,24 +534,24 @@ mod tests {
             } else {
                 big_p - big_y + big_x
             };
-            assert_eq!(fp.map_to_residue(got).to_bigint().unwrap(), want);
+            assert_eq!(fp.residue(got).to_bigint().unwrap(), want);
 
             // Test multiplication.
             let got = fp.mul(x, y);
             let want = (big_x * big_y) % big_p;
-            assert_eq!(fp.map_to_residue(got).to_bigint().unwrap(), want);
+            assert_eq!(fp.residue(got).to_bigint().unwrap(), want);
 
             // Test inversion.
             let got = fp.inv(x);
             let want = big_x.modpow(&(big_p - 2u128), big_p);
-            assert_eq!(fp.map_to_residue(got).to_bigint().unwrap(), want);
-            assert_eq!(fp.map_to_residue(fp.mul(got, x)), 1);
+            assert_eq!(fp.residue(got).to_bigint().unwrap(), want);
+            assert_eq!(fp.residue(fp.mul(got, x)), 1);
 
             // Test negation.
             let got = fp.neg(x);
             let want = (big_p - big_x) % big_p;
-            assert_eq!(fp.map_to_residue(got).to_bigint().unwrap(), want);
-            assert_eq!(fp.map_to_residue(fp.add(got, x)), 0);
+            assert_eq!(fp.residue(got).to_bigint().unwrap(), want);
+            assert_eq!(fp.residue(fp.add(got, x)), 0);
         }
     }
 }


### PR DESCRIPTION
Our CI is failing with [`clippy::wrong_self_convention`](https://rust-lang.github.io/rust-clippy/master/index.html#wrong_self_convention). This PR renames `FieldParameters::elem()` to `FieldParameters::map()`, and `FieldParameters::from_elem()` to `FieldParameters::inverse_map()` to resolve the issue.