### PR TITLE
vdaf: Replace the `PrepareTransition::Fail` variant

### DIFF
--- a/src/vdaf/prio3_test.rs
+++ b/src/vdaf/prio3_test.rs
@@ -111,7 +111,7 @@ fn check_prep_test_vec<M, T, A, P, const L: usize>(
 
     let mut out_shares = Vec::new();
     for state in states.iter_mut() {
-        match prio3.prepare_step(state.clone(), inbound.clone()) {
+        match prio3.prepare_step(state.clone(), inbound.clone()).unwrap() {
             PrepareTransition::Finish(out_share) => {
                 out_shares.push(out_share);
             }


### PR DESCRIPTION
Based on #218 (merge that first).
Closes #221.

Removes the `PrepareTransition::Fail` variant and has `prepare_step()`
output a `Result<PrepareTransition, VdafError>`. Instead of returning
`PrepareTransition::Fail(e)`, implementations of this method now simply
return `Err(e)`.