### PR TITLE
vdaf: Distinguish prep shares from prep messages

### DIFF
--- a/src/vdaf/poplar1.rs
+++ b/src/vdaf/poplar1.rs
@@ -512,6 +512,7 @@ where
     P: Prg<L>,
 {
     type PrepareState = Poplar1PrepareState<I::Field>;
+    type PrepareShare = Poplar1PrepareMessage<I::Field>;
     type PrepareMessage = Poplar1PrepareMessage<I::Field>;
 
     fn prepare_init(

--- a/src/vdaf/prio3.rs
+++ b/src/vdaf/prio3.rs
@@ -644,6 +644,7 @@ where
     P: Prg<L>,
 {
     type PrepareState = Prio3PrepareState<T::Field, L>;
+    type PrepareShare = Prio3PrepareMessage<T::Field, L>;
     type PrepareMessage = Prio3PrepareMessage<T::Field, L>;
 
     /// Begins the Prep process with the other aggregators. The result of this process is


### PR DESCRIPTION
Based on #224 (merge that first).
Closes #220.

Modifies `Aggregator` by adding a new associated type, `PrepareShare`,
that is output by each Aggregator at each step of the Prepare
computation. The `prepare_preprocess()` method takes a sequence of
`PrepareShare` and outputs the `PrepareMessage` consumed by the
Aggregator in the next round.