### PR TITLE
vdaf: Drop public param and refactor verify param

### DIFF
--- a/benches/speed_tests.rs
+++ b/benches/speed_tests.rs
@@ -133,11 +133,11 @@ pub fn prio3_client(c: &mut Criterion) {
     let measurement = 1;
     println!(
         "prio3 count size = {}",
-        prio3_input_share_size(&prio3.shard(&(), &measurement).unwrap())
+        prio3_input_share_size(&prio3.shard(&measurement).unwrap())
     );
     c.bench_function("prio3 count", |b| {
         b.iter(|| {
-            prio3.shard(&(), &1).unwrap();
+            prio3.shard(&1).unwrap();
         })
     });
 
@@ -147,13 +147,13 @@ pub fn prio3_client(c: &mut Criterion) {
     println!(
         "prio3 histogram ({} buckets) size = {}",
         buckets.len() + 1,
-        prio3_input_share_size(&prio3.shard(&(), &measurement).unwrap())
+        prio3_input_share_size(&prio3.shard(&measurement).unwrap())
     );
     c.bench_function(
         &format!("prio3 histogram ({} buckets)", buckets.len() + 1),
         |b| {
             b.iter(|| {
-                prio3.shard(&(), &measurement).unwrap();
+                prio3.shard(&measurement).unwrap();
             })
         },
     );
@@ -164,11 +164,11 @@ pub fn prio3_client(c: &mut Criterion) {
     println!(
         "prio3 sum ({} bits) size = {}",
         bits,
-        prio3_input_share_size(&prio3.shard(&(), &measurement).unwrap())
+        prio3_input_share_size(&prio3.shard(&measurement).unwrap())
     );
     c.bench_function(&format!("prio3 sum ({} bits)", bits), |b| {
         b.iter(|| {
-            prio3.shard(&(), &measurement).unwrap();
+            prio3.shard(&measurement).unwrap();
         })
     });
 
@@ -178,11 +178,11 @@ pub fn prio3_client(c: &mut Criterion) {
     println!(
         "prio3 countvec ({} len) size = {}",
         len,
-        prio3_input_share_size(&prio3.shard(&(), &measurement).unwrap())
+        prio3_input_share_size(&prio3.shard(&measurement).unwrap())
     );
     c.bench_function(&format!("prio3 countvec ({} len)", len), |b| {
         b.iter(|| {
-            prio3.shard(&(), &measurement).unwrap();
+            prio3.shard(&measurement).unwrap();
         })
     });
 
@@ -193,11 +193,11 @@ pub fn prio3_client(c: &mut Criterion) {
         println!(
             "prio3 countvec multithreaded ({} len) size = {}",
             len,
-            prio3_input_share_size(&prio3.shard(&(), &measurement).unwrap())
+            prio3_input_share_size(&prio3.shard(&measurement).unwrap())
         );
         c.bench_function(&format!("prio3 parallel countvec ({} len)", len), |b| {
             b.iter(|| {
-                prio3.shard(&(), &measurement).unwrap();
+                prio3.shard(&measurement).unwrap();
             })
         });
     }


### PR DESCRIPTION
Based on #226 (merge that first).
Partially addresses #216.

Aligns the API with the syntax in vdaf-01 by removing the public parameter and replacing the verification parameter with an aggregator key and ID.

2022-05-25: Ready for review.
2022-05-20: The PR is currently a draft. Befor merging I need to fix up Poplar1 as well. Before I get to deep, I wanted to get folks' feedback on the API changes and think through any rough edges they might create for applications. (On the whole I think this is a huge improvement.)