### PR TITLE
Rename PrepareStep to PrepareState.

### DIFF
--- a/src/vdaf.rs
+++ b/src/vdaf.rs
@@ -161,12 +161,12 @@ where
     for<'a> &'a Self::AggregateShare: Into<Vec<u8>>,
 {
     /// State of the Aggregator during the Prepare process.
-    type PrepareStep: Clone + Debug;
+    type PrepareState: Clone + Debug;
 
     /// The type of messages exchanged among the Aggregators during the Prepare process.
-    type PrepareMessage: Clone + Debug + ParameterizedDecode<Self::PrepareStep> + Encode;
+    type PrepareMessage: Clone + Debug + ParameterizedDecode<Self::PrepareState> + Encode;
 
-    /// Begins the Prepare process with the other Aggregators. The [`Self::PrepareStep`] returned
+    /// Begins the Prepare process with the other Aggregators. The [`Self::PrepareState`] returned
     /// is passed to [`Aggregator::prepare_step`] to get this aggregator's first-round prepare
     /// message.
     fn prepare_init(
@@ -175,7 +175,7 @@ where
         agg_param: &Self::AggregationParam,
         nonce: &[u8],
         input_share: &Self::InputShare,
-    ) -> Result<Self::PrepareStep, VdafError>;
+    ) -> Result<Self::PrepareState, VdafError>;
 
     /// Preprocess a round of prepare messages into a single input to [`Aggregator::prepare_step`].
     fn prepare_preprocess<M: IntoIterator<Item = Self::PrepareMessage>>(
@@ -192,9 +192,9 @@ where
     /// consider its input share invalid and not attempt to process it any further.
     fn prepare_step(
         &self,
-        state: Self::PrepareStep,
+        state: Self::PrepareState,
         input: Option<Self::PrepareMessage>,
-    ) -> PrepareTransition<Self::PrepareStep, Self::PrepareMessage, Self::OutputShare>;
+    ) -> PrepareTransition<Self::PrepareState, Self::PrepareMessage, Self::OutputShare>;
 
     /// Aggregates a sequence of output shares into an aggregate share.
     fn aggregate<M: IntoIterator<Item = Self::OutputShare>>(

--- a/src/vdaf/poplar1.rs
+++ b/src/vdaf/poplar1.rs
@@ -511,7 +511,7 @@ where
     I: Idpf<2, 2>,
     P: Prg<L>,
 {
-    type PrepareStep = Poplar1PrepareStep<I::Field>;
+    type PrepareState = Poplar1PrepareState<I::Field>;
     type PrepareMessage = Poplar1PrepareMessage<I::Field>;
 
     fn prepare_init(
@@ -520,7 +520,7 @@ where
         agg_param: &BTreeSet<IdpfInput>,
         nonce: &[u8],
         input_share: &Self::InputShare,
-    ) -> Result<Poplar1PrepareStep<I::Field>, VdafError> {
+    ) -> Result<Poplar1PrepareState<I::Field>, VdafError> {
         let level = get_level(agg_param)?;
 
         // Derive the verification randomness.
@@ -576,7 +576,7 @@ where
             I::Field::zero()
         };
 
-        Ok(Poplar1PrepareStep {
+        Ok(Poplar1PrepareState {
             sketch: SketchState::Ready,
             output_share: OutputShare(output_share),
             z,
@@ -625,10 +625,10 @@ where
     #[allow(clippy::type_complexity)]
     fn prepare_step(
         &self,
-        mut state: Poplar1PrepareStep<I::Field>,
+        mut state: Poplar1PrepareState<I::Field>,
         input: Option<Poplar1PrepareMessage<I::Field>>,
     ) -> PrepareTransition<
-        Poplar1PrepareStep<I::Field>,
+        Poplar1PrepareState<I::Field>,
         Poplar1PrepareMessage<I::Field>,
         OutputShare<I::Field>,
     > {
@@ -716,9 +716,9 @@ impl<F: FieldElement> Encode for Poplar1PrepareMessage<F> {
     }
 }
 
-impl<F: FieldElement> ParameterizedDecode<Poplar1PrepareStep<F>> for Poplar1PrepareMessage<F> {
+impl<F: FieldElement> ParameterizedDecode<Poplar1PrepareState<F>> for Poplar1PrepareMessage<F> {
     fn decode_with_param(
-        _decoding_parameter: &Poplar1PrepareStep<F>,
+        _decoding_parameter: &Poplar1PrepareState<F>,
         bytes: &mut Cursor<&[u8]>,
     ) -> Result<Self, CodecError> {
         // TODO: This is decoded as a variable length vector of F, but we may be
@@ -732,7 +732,7 @@ impl<F: FieldElement> ParameterizedDecode<Poplar1PrepareStep<F>> for Poplar1Prep
 
 /// The state of each Aggregator during the Prepare process.
 #[derive(Clone, Debug)]
-pub struct Poplar1PrepareStep<F> {
+pub struct Poplar1PrepareState<F> {
     /// State of the secure sketching protocol.
     sketch: SketchState,
 


### PR DESCRIPTION
This is a more accurate name -- the type was already documented & used
as the private state held by a participant in a VDAF evaluation.

Please let me know if I should hold off on merging this, as it is a breaking change.

Closes #229.