### PR TITLE
Refactor PrepareTransition<S, M, O> to PrepareTransition<V: Aggregator>.

### DIFF
--- a/src/vdaf.rs
+++ b/src/vdaf.rs
@@ -194,7 +194,7 @@ where
         &self,
         state: Self::PrepareStep,
         input: Option<Self::PrepareMessage>,
-    ) -> PrepareTransition<Self::PrepareStep, Self::PrepareMessage, Self::OutputShare>;
+    ) -> PrepareTransition<Self>;
 
     /// Aggregates a sequence of output shares into an aggregate share.
     fn aggregate<M: IntoIterator<Item = Self::OutputShare>>(
@@ -219,12 +219,15 @@ where
 
 /// A state transition of an Aggregator during the Prepare process.
 #[derive(Debug)]
-pub enum PrepareTransition<S, M, O> {
+pub enum PrepareTransition<V: Aggregator>
+where
+    for<'a> &'a V::AggregateShare: Into<Vec<u8>>,
+{
     /// Continue processing.
-    Continue(S, M),
+    Continue(V::PrepareStep, V::PrepareMessage),
 
     /// Finish processing and return the output share.
-    Finish(O),
+    Finish(V::OutputShare),
 
     /// Fail and return an error.
     Fail(VdafError),

--- a/src/vdaf/poplar1.rs
+++ b/src/vdaf/poplar1.rs
@@ -627,11 +627,7 @@ where
         &self,
         mut state: Poplar1PrepareStep<I::Field>,
         input: Option<Poplar1PrepareMessage<I::Field>>,
-    ) -> PrepareTransition<
-        Poplar1PrepareStep<I::Field>,
-        Poplar1PrepareMessage<I::Field>,
-        OutputShare<I::Field>,
-    > {
+    ) -> PrepareTransition<Self> {
         match (&state.sketch, input) {
             (SketchState::Ready, None) => {
                 let z_share = state.z.to_vec();

--- a/src/vdaf/prio3.rs
+++ b/src/vdaf/prio3.rs
@@ -810,11 +810,7 @@ where
         &self,
         mut step: Prio3PrepareStep<T::Field, L>,
         input: Option<Prio3PrepareMessage<T::Field, L>>,
-    ) -> PrepareTransition<
-        Prio3PrepareStep<T::Field, L>,
-        Prio3PrepareMessage<T::Field, L>,
-        OutputShare<T::Field>,
-    > {
+    ) -> PrepareTransition<Self> {
         match (step.state, input) {
             (PrepareStep::Ready(verifier_msg), None) => {
                 step.state = PrepareStep::Waiting;


### PR DESCRIPTION
This makes the relation between the internal types clearer: in
practices, S was a V::PrepareStep, M was a V::PrepareMessage, and O was
a V::OutputShare for some V: Aggregator. This is now explicit in the
type definition.

Please let me know if I should hold off on merging this, as it is a breaking change.

Closes #231.