### PR TITLE
Cleanup (currently)-final Clippy complaint.

### DIFF
--- a/src/prng.rs
+++ b/src/prng.rs
@@ -195,9 +195,9 @@ mod tests {
             &Seed::get_decoded(&[0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1, 95]).unwrap(),
             b"",
         );
-        let prng = Prng::<Field96, _>::from_seed_stream(seed_stream);
+        let mut prng = Prng::<Field96, _>::from_seed_stream(seed_stream);
         let expected = Field96::from(39729620190871453347343769187);
-        let actual = prng.skip(145).next().unwrap();
+        let actual = prng.nth(145).unwrap();
         assert_eq!(actual, expected);
     }
 }


### PR DESCRIPTION
The complaint was:
```
error: called `skip(..).next()` on an iterator
   --> src/prng.rs:200:26
    |
200 |         let actual = prng.skip(145).next().unwrap();
    |                          ^^^^^^^^^^^^^^^^^ help: use `nth` instead: `.nth(145)`
    |
    = note: `-D clippy::iter-skip-next` implied by `-D warnings`
help: for this change `prng` has to be mutable
   --> src/prng.rs:198:13
    |
198 |         let prng = Prng::<Field96, _>::from_seed_stream(seed_stream);
    |             ^^^^
    = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#iter_skip_next
```