### PR TITLE
Update transitive dependencies with cargo-audit findings

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1071,9 +1071,9 @@ dependencies = [
 
 [[package]]
 name = "thread_local"
-version = "1.1.3"
+version = "1.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8018d24e04c95ac8790716a5987d0fec4f8b27249ffa0f7d33f1369bdfb88cbd"
+checksum = "5516c27b78311c50bf42c071425c560ac799b11c30b31f87e3081965fe5e0180"
 dependencies = [
  "once_cell",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -855,9 +855,9 @@ dependencies = [
 
 [[package]]
 name = "regex"
-version = "1.5.4"
+version = "1.5.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d07a8629359eb56f1e2fb1652bb04212c072a87ba68546a04065d525673ac461"
+checksum = "d83f127d94bdbcda4c8cc2e50f6f84f4b611f69c902699ca385a39c3a75f9ff1"
 dependencies = [
  "regex-syntax",
 ]
@@ -870,9 +870,9 @@ checksum = "6c230d73fb8d8c1b9c0b3135c5142a8acee3a0558fb8db5cf1cb65f8d7862132"
 
 [[package]]
 name = "regex-syntax"
-version = "0.6.25"
+version = "0.6.26"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f497285884f3fcff424ffc933e56d7cbca511def0c9831a7f9b5f6153e3cc89b"
+checksum = "49b3de9ec5dc0a3417da371aab17d729997c15010e7fd24ff707773a33bddb64"
 
 [[package]]
 name = "ring"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -329,9 +329,9 @@ dependencies = [
 
 [[package]]
 name = "crossbeam-utils"
-version = "0.8.5"
+version = "0.8.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d82cfc11ce7f2c3faef78d8a684447b40d503d9681acebed6cb728d45940c4db"
+checksum = "0bf124c720b7686e3c2663cf54062ab0f68a88af2fb6a030e87e30bf721fcb38"
 dependencies = [
  "cfg-if",
  "lazy_static",


### PR DESCRIPTION
This updates the `crossbeam-utils`, `regex`, and `thread_local` crates in `Cargo.lock` to resolve findings from `cargo-audit`. As described below, these findings are not of immediate concern for production consumers of this library, but it would be good to make these upgrades as a matter of hygiene.

With the default feature set, `crossbeam-utils` only appears in the dependency tree below `criterion`. If the `multithreaded` feature is enabled, then `rayon` pulls in `crossbeam-utils` as well. (rayon is used in `Prio3Aes128CountVecMultithreaded`) The relevant issue, CVE-2022-23639, only applies to certain targets (32-bit x86 and 32-bit iOS). I have not looked any further to see how `AtomicCell` is used, but to my knowledge, currently deployed configurations should not be affected.

`regex` only appears in the dependency tree below `criterion`. The REDoS is not a concern for us, as Criterion does not process untrusted regular expressions.

`thread_local` only appears in the dependency tree of the `prio-binaries` crate, below `color-eyre`. I have not checked whether the affected `Iter::next()`/`IterMut::next()` methods are used by `tracing-subscriber` here, but the `crypt` and `generate_test_vector` binaries in this crate are only used for development and maintenance.