### PR TITLE
Update Prio3 constructors to improve generated docs.

### DIFF
--- a/benches/speed_tests.rs
+++ b/benches/speed_tests.rs
@@ -16,8 +16,6 @@ use prio::flp::{
 };
 use prio::server::{generate_verification_message, ValidationMemory};
 use prio::vdaf::prio3::Prio3;
-#[cfg(feature = "multithreaded")]
-use prio::vdaf::prio3::Prio3Aes128CountVecMultithreaded;
 use prio::vdaf::{prio3::Prio3InputShare, Client as Prio3Client};
 
 /// This benchmark compares the performance of recursive and iterative FFT.
@@ -240,7 +238,7 @@ pub fn prio3_client(c: &mut Criterion) {
 
     #[cfg(feature = "multithreaded")]
     {
-        let prio3 = Prio3Aes128CountVecMultithreaded::new(num_shares, len).unwrap();
+        let prio3 = Prio3::new_aes128_count_vec_multithreaded(num_shares, len).unwrap();
         let measurement = vec![0; len];
         println!(
             "prio3 countvec multithreaded ({} len) size = {}",

--- a/benches/speed_tests.rs
+++ b/benches/speed_tests.rs
@@ -15,13 +15,9 @@ use prio::flp::{
     Type,
 };
 use prio::server::{generate_verification_message, ValidationMemory};
-use prio::vdaf::prg::PrgAes128;
+use prio::vdaf::prio3::Prio3;
 #[cfg(feature = "multithreaded")]
 use prio::vdaf::prio3::Prio3Aes128CountVecMultithreaded;
-use prio::vdaf::prio3::{
-    new_prio3_aes128_count, new_prio3_aes128_count_vec, new_prio3_aes128_histogram,
-    new_prio3_aes128_sum,
-};
 use prio::vdaf::{prio3::Prio3InputShare, Client as Prio3Client};
 
 /// This benchmark compares the performance of recursive and iterative FFT.
@@ -185,7 +181,7 @@ pub fn count_vec(c: &mut Criterion) {
 pub fn prio3_client(c: &mut Criterion) {
     let num_shares = 2;
 
-    let prio3 = new_prio3_aes128_count(num_shares).unwrap();
+    let prio3 = Prio3::new_aes128_count(num_shares).unwrap();
     let measurement = 1;
     println!(
         "prio3 count size = {}",
@@ -198,7 +194,7 @@ pub fn prio3_client(c: &mut Criterion) {
     });
 
     let buckets: Vec<u64> = (1..10).collect();
-    let prio3 = new_prio3_aes128_histogram(num_shares, &buckets).unwrap();
+    let prio3 = Prio3::new_aes128_histogram(num_shares, &buckets).unwrap();
     let measurement = 17;
     println!(
         "prio3 histogram ({} buckets) size = {}",
@@ -215,7 +211,7 @@ pub fn prio3_client(c: &mut Criterion) {
     );
 
     let bits = 32;
-    let prio3 = new_prio3_aes128_sum(num_shares, bits).unwrap();
+    let prio3 = Prio3::new_aes128_sum(num_shares, bits).unwrap();
     let measurement = 1337;
     println!(
         "prio3 sum ({} bits) size = {}",
@@ -229,10 +225,7 @@ pub fn prio3_client(c: &mut Criterion) {
     });
 
     let len = 1000;
-    let prio3 = new_prio3_aes128_count_vec::<ParallelSum<F, BlindPolyEval<F>>, PrgAes128, 16>(
-        num_shares, len,
-    )
-    .unwrap();
+    let prio3 = Prio3::new_aes128_count_vec(num_shares, len).unwrap();
     let measurement = vec![0; len];
     println!(
         "prio3 countvec ({} len) size = {}",

--- a/benches/speed_tests.rs
+++ b/benches/speed_tests.rs
@@ -15,15 +15,14 @@ use prio::flp::{
     Type,
 };
 use prio::server::{generate_verification_message, ValidationMemory};
+use prio::vdaf::prg::PrgAes128;
 #[cfg(feature = "multithreaded")]
 use prio::vdaf::prio3::Prio3Aes128CountVecMultithreaded;
-use prio::vdaf::{
-    prio3::{
-        Prio3Aes128Count, Prio3Aes128CountVec, Prio3Aes128Histogram, Prio3Aes128Sum,
-        Prio3InputShare,
-    },
-    Client as Prio3Client,
+use prio::vdaf::prio3::{
+    new_prio3_aes128_count, new_prio3_aes128_count_vec, new_prio3_aes128_histogram,
+    new_prio3_aes128_sum,
 };
+use prio::vdaf::{prio3::Prio3InputShare, Client as Prio3Client};
 
 /// This benchmark compares the performance of recursive and iterative FFT.
 pub fn fft(c: &mut Criterion) {
@@ -186,7 +185,7 @@ pub fn count_vec(c: &mut Criterion) {
 pub fn prio3_client(c: &mut Criterion) {
     let num_shares = 2;
 
-    let prio3 = Prio3Aes128Count::new(num_shares).unwrap();
+    let prio3 = new_prio3_aes128_count(num_shares).unwrap();
     let measurement = 1;
     println!(
         "prio3 count size = {}",
@@ -199,7 +198,7 @@ pub fn prio3_client(c: &mut Criterion) {
     });
 
     let buckets: Vec<u64> = (1..10).collect();
-    let prio3 = Prio3Aes128Histogram::new(num_shares, &buckets).unwrap();
+    let prio3 = new_prio3_aes128_histogram(num_shares, &buckets).unwrap();
     let measurement = 17;
     println!(
         "prio3 histogram ({} buckets) size = {}",
@@ -216,7 +215,7 @@ pub fn prio3_client(c: &mut Criterion) {
     );
 
     let bits = 32;
-    let prio3 = Prio3Aes128Sum::new(num_shares, bits).unwrap();
+    let prio3 = new_prio3_aes128_sum(num_shares, bits).unwrap();
     let measurement = 1337;
     println!(
         "prio3 sum ({} bits) size = {}",
@@ -230,7 +229,10 @@ pub fn prio3_client(c: &mut Criterion) {
     });
 
     let len = 1000;
-    let prio3 = Prio3Aes128CountVec::new(num_shares, len).unwrap();
+    let prio3 = new_prio3_aes128_count_vec::<ParallelSum<F, BlindPolyEval<F>>, PrgAes128, 16>(
+        num_shares, len,
+    )
+    .unwrap();
     let measurement = vec![0; len];
     println!(
         "prio3 countvec ({} len) size = {}",

--- a/src/flp.rs
+++ b/src/flp.rs
@@ -176,7 +176,7 @@ pub trait Type: Sized + Eq + Clone + Debug {
     /// once `input` has been validated.
     fn truncate(&self, input: Vec<Self::Field>) -> Result<Vec<Self::Field>, FlpError>;
 
-    /// The length in field elements of the encoded input returned by [`Self::encode`].
+    /// The length in field elements of the encoded input returned by [`Self::encode_measurement`].
     fn input_len(&self) -> usize;
 
     /// The length in field elements of the proof generated for this type.

--- a/src/vdaf/prio3.rs
+++ b/src/vdaf/prio3.rs
@@ -159,12 +159,12 @@ pub fn new_prio3_aes128_histogram(
 /// ```
 /// use prio::vdaf::{
 ///     Aggregator, Client, Collector, PrepareTransition,
-///     prio3::Prio3Aes128Count,
+///     prio3::new_prio3_aes128_count,
 /// };
 /// use rand::prelude::*;
 ///
 /// let num_shares = 2;
-/// let vdaf = Prio3Aes128Count::new(num_shares).unwrap();
+/// let vdaf = new_prio3_aes128_count(num_shares).unwrap();
 ///
 /// let mut out_shares = vec![vec![]; num_shares.into()];
 /// let mut rng = thread_rng();

--- a/src/vdaf/prio3.rs
+++ b/src/vdaf/prio3.rs
@@ -144,8 +144,8 @@ impl Prio3Aes128Sum {
 pub type Prio3Aes128Histogram = Prio3<Histogram<Field128>, PrgAes128, 16>;
 
 impl Prio3Aes128Histogram {
-    /// Constructs an instance of Prio3Aes128Histogram with the given suite, number of aggregators,
-    /// and desired histogram bucket boundaries.
+    /// Constructs an instance of Prio3Aes128Histogram with the given number of aggregators and
+    /// desired histogram bucket boundaries.
     pub fn new_aes128_histogram(num_aggregators: u8, buckets: &[u64]) -> Result<Self, VdafError> {
         check_num_aggregators(num_aggregators)?;
 

--- a/src/vdaf/prio3.rs
+++ b/src/vdaf/prio3.rs
@@ -14,13 +14,10 @@
 //! a VDAF. The base type, [`Prio3`], supports a wide variety of aggregation functions, some of
 //! which are instantiated here:
 //!
-//! - [`Prio3Aes128Count`] for aggregating a counter, constructed via [`new_prio3_aes128_count`] (*)
-//! - [`Prio3Aes128CountVec`] for aggregating a vector of counters, constructed via
-//!   [`new_prio3_aes128_count_vec`]
-//! - [`Prio3Aes128Sum`] for copmputing the sum of integers, constructed via
-//!   [`new_prio3_aes128_sum`] (*)
-//! - [`Prio3Aes128Histogram`] for estimating a distribution via a histogram, constructed via
-//!   [`new_prio3_aes128_histogram`] (*)
+//! - [`Prio3Aes128Count`] for aggregating a counter (*)
+//! - [`Prio3Aes128CountVec`] for aggregating a vector of counters
+//! - [`Prio3Aes128Sum`] for copmputing the sum of integers (*)
+//! - [`Prio3Aes128Histogram`] for estimating a distribution via a histogram (*)
 //!
 //! Additional types can be constructed from [`Prio3`] as needed.
 //!
@@ -34,7 +31,7 @@ use crate::codec::{CodecError, Decode, Encode, ParameterizedDecode};
 use crate::field::{Field128, Field64, FieldElement};
 #[cfg(feature = "multithreaded")]
 use crate::flp::gadgets::ParallelSumMultithreaded;
-use crate::flp::gadgets::{BlindPolyEval, ParallelSum, ParallelSumGadget};
+use crate::flp::gadgets::{BlindPolyEval, ParallelSum};
 use crate::flp::types::{Count, CountVec, Histogram, Sum};
 use crate::flp::Type;
 use crate::prng::Prng;
@@ -56,21 +53,37 @@ const VERS_PRIO3: &[u8] = b"vdaf-01 prio3";
 /// The count type. Each measurement is an integer in `[0,2)` and the aggregate result is the sum.
 pub type Prio3Aes128Count = Prio3<Count<Field64>, PrgAes128, 16>;
 
-/// Construct an instance of the Prio3Aes128Count VDAF with the given number of aggregators.
-pub fn new_prio3_aes128_count(num_aggregators: u8) -> Result<Prio3Aes128Count, VdafError> {
-    check_num_aggregators(num_aggregators)?;
+impl Prio3Aes128Count {
+    /// Construct an instance of Prio3Aes128Count with the given number of aggregators.
+    pub fn new_aes128_count(num_aggregators: u8) -> Result<Self, VdafError> {
+        check_num_aggregators(num_aggregators)?;
 
-    Ok(Prio3 {
-        num_aggregators,
-        typ: Count::new(),
-        phantom: PhantomData,
-    })
+        Ok(Prio3 {
+            num_aggregators,
+            typ: Count::new(),
+            phantom: PhantomData,
+        })
+    }
 }
 
 /// The count-vector type. Each measurement is a vector of integers in `[0,2)` and the aggregate is
 /// the element-wise sum.
 pub type Prio3Aes128CountVec =
     Prio3<CountVec<Field128, ParallelSum<Field128, BlindPolyEval<Field128>>>, PrgAes128, 16>;
+
+impl Prio3Aes128CountVec {
+    /// Construct an instance of Prio3Aes1238CountVec with the given number of aggregators. `len`
+    /// defines the length of each measurement.
+    pub fn new_aes128_count_vec(num_aggregators: u8, len: usize) -> Result<Self, VdafError> {
+        check_num_aggregators(num_aggregators)?;
+
+        Ok(Prio3 {
+            num_aggregators,
+            typ: CountVec::new(len),
+            phantom: PhantomData,
+        })
+    }
+}
 
 /// Like [`Prio3CountVec`] except this type uses multithreading to improve sharding and
 /// preparation time. Note that the improvement is only noticeable for very large input lengths,
@@ -83,67 +96,67 @@ pub type Prio3Aes128CountVecMultithreaded = Prio3<
     16,
 >;
 
-/// Construct an instance of a CountVec VDAF with the given suite and the given number of
-/// aggregators. `len` defines the length of each measurement.
-pub fn new_prio3_aes128_count_vec<S, P, const L: usize>(
-    num_aggregators: u8,
-    len: usize,
-) -> Result<Prio3<CountVec<Field128, S>, P, L>, VdafError>
-where
-    S: 'static + ParallelSumGadget<Field128, BlindPolyEval<Field128>> + Eq,
-    P: Prg<L>,
-{
-    check_num_aggregators(num_aggregators)?;
+#[cfg(feature = "multithreaded")]
+#[cfg_attr(docsrs, doc(cfg(feature = "multithreaded")))]
+impl Prio3Aes128CountVecMultithreaded {
+    /// Construct an instance of Prio3Aes1238CountVecMultithreaded with the given number of
+    /// aggregators. `len` defines the length of each measurement.
+    pub fn new_aes128_count_vec_multithreaded(
+        num_aggregators: u8,
+        len: usize,
+    ) -> Result<Self, VdafError> {
+        check_num_aggregators(num_aggregators)?;
 
-    Ok(Prio3 {
-        num_aggregators,
-        typ: CountVec::new(len),
-        phantom: PhantomData,
-    })
+        Ok(Prio3 {
+            num_aggregators,
+            typ: CountVec::new(len),
+            phantom: PhantomData,
+        })
+    }
 }
 
 /// The sum type. Each measurement is an integer in `[0,2^bits)` for some `0 < bits < 64` and the
 /// aggregate is the sum.
 pub type Prio3Aes128Sum = Prio3<Sum<Field128>, PrgAes128, 16>;
 
-/// Construct an instance of the Prio3Aes128Sum VDAF with the given number of aggregators and
-/// required bit length. The bit length must not exceed 64.
-pub fn new_prio3_aes128_sum(num_aggregators: u8, bits: u32) -> Result<Prio3Aes128Sum, VdafError> {
-    check_num_aggregators(num_aggregators)?;
+impl Prio3Aes128Sum {
+    /// Construct an instance of Prio3Aes128Sum with the given number of aggregators and required
+    /// bit length. The bit length must not exceed 64.
+    pub fn new_aes128_sum(num_aggregators: u8, bits: u32) -> Result<Self, VdafError> {
+        check_num_aggregators(num_aggregators)?;
 
-    if bits > 64 {
-        return Err(VdafError::Uncategorized(format!(
-            "bit length ({}) exceeds limit for aggregate type (64)",
-            bits
-        )));
+        if bits > 64 {
+            return Err(VdafError::Uncategorized(format!(
+                "bit length ({}) exceeds limit for aggregate type (64)",
+                bits
+            )));
+        }
+
+        Ok(Prio3 {
+            num_aggregators,
+            typ: Sum::new(bits as usize)?,
+            phantom: PhantomData,
+        })
     }
-
-    Ok(Prio3 {
-        num_aggregators,
-        typ: Sum::new(bits as usize)?,
-        phantom: PhantomData,
-    })
 }
-
 /// The histogram type. Each measurement is an unsigned integer and the result is a histogram
 /// representation of the distribution. The bucket boundaries are fixed in advance.
 pub type Prio3Aes128Histogram = Prio3<Histogram<Field128>, PrgAes128, 16>;
 
-/// Constructs an instance of the Prio3Aes128Histogram VDAF with the given number of aggregators and
-/// desired histogram bucket boundaries.
-pub fn new_prio3_aes128_histogram(
-    num_aggregators: u8,
-    buckets: &[u64],
-) -> Result<Prio3Aes128Histogram, VdafError> {
-    check_num_aggregators(num_aggregators)?;
+impl Prio3Aes128Histogram {
+    /// Constructs an instance of Prio3Aes128Histogram with the given suite, number of aggregators,
+    /// and desired histogram bucket boundaries.
+    pub fn new_aes128_histogram(num_aggregators: u8, buckets: &[u64]) -> Result<Self, VdafError> {
+        check_num_aggregators(num_aggregators)?;
 
-    let buckets = buckets.iter().map(|bucket| *bucket as u128).collect();
+        let buckets = buckets.iter().map(|bucket| *bucket as u128).collect();
 
-    Ok(Prio3 {
-        num_aggregators,
-        typ: Histogram::<Field128>::new(buckets)?,
-        phantom: PhantomData,
-    })
+        Ok(Prio3 {
+            num_aggregators,
+            typ: Histogram::<Field128>::new(buckets)?,
+            phantom: PhantomData,
+        })
+    }
 }
 
 /// The base type for Prio3.
@@ -159,12 +172,12 @@ pub fn new_prio3_aes128_histogram(
 /// ```
 /// use prio::vdaf::{
 ///     Aggregator, Client, Collector, PrepareTransition,
-///     prio3::new_prio3_aes128_count,
+///     prio3::Prio3,
 /// };
 /// use rand::prelude::*;
 ///
 /// let num_shares = 2;
-/// let vdaf = new_prio3_aes128_count(num_shares).unwrap();
+/// let vdaf = Prio3::new_aes128_count(num_shares).unwrap();
 ///
 /// let mut out_shares = vec![vec![]; num_shares.into()];
 /// let mut rng = thread_rng();
@@ -907,7 +920,7 @@ mod tests {
 
     #[test]
     fn test_prio3_count() {
-        let prio3 = new_prio3_aes128_count(2).unwrap();
+        let prio3 = Prio3::new_aes128_count(2).unwrap();
 
         assert_eq!(run_vdaf(&prio3, &(), [1, 0, 0, 1, 1]).unwrap(), 3);
 
@@ -926,7 +939,7 @@ mod tests {
 
     #[test]
     fn test_prio3_sum() {
-        let prio3 = new_prio3_aes128_sum(3, 16).unwrap();
+        let prio3 = Prio3::new_aes128_sum(3, 16).unwrap();
 
         assert_eq!(
             run_vdaf(&prio3, &(), [0, (1 << 16) - 1, 0, 1, 1]).unwrap(),
@@ -971,7 +984,7 @@ mod tests {
 
     #[test]
     fn test_prio3_histogram() {
-        let prio3 = new_prio3_aes128_histogram(2, &[0, 10, 20]).unwrap();
+        let prio3 = Prio3::new_aes128_histogram(2, &[0, 10, 20]).unwrap();
 
         assert_eq!(
             run_vdaf(&prio3, &(), [0, 10, 20, 9999]).unwrap(),
@@ -988,7 +1001,7 @@ mod tests {
 
     #[test]
     fn test_prio3_input_share() {
-        let prio3 = new_prio3_aes128_sum(5, 16).unwrap();
+        let prio3 = Prio3::new_aes128_sum(5, 16).unwrap();
         let input_shares = prio3.shard(&1).unwrap();
 
         // Check that seed shares are distinct.

--- a/src/vdaf/prio3_test.rs
+++ b/src/vdaf/prio3_test.rs
@@ -5,15 +5,14 @@ use crate::{
     flp::Type,
     vdaf::{
         prg::Prg,
-        prio3::{
-            Prio3, Prio3Aes128Count, Prio3Aes128Histogram, Prio3Aes128Sum, Prio3InputShare,
-            Prio3PrepareShare,
-        },
+        prio3::{Prio3, Prio3InputShare, Prio3PrepareShare},
         Aggregator, PrepareTransition,
     },
 };
 use serde::{Deserialize, Serialize};
 use std::{convert::TryInto, fmt::Debug};
+
+use super::prio3::{new_prio3_aes128_count, new_prio3_aes128_histogram, new_prio3_aes128_sum};
 
 #[derive(Debug, Deserialize, Serialize)]
 struct TEncoded(#[serde(with = "hex")] Vec<u8>);
@@ -132,7 +131,7 @@ fn check_prep_test_vec<M, T, P, const L: usize>(
 fn test_vec_prio3_count() {
     let t: TPrio3<u64> =
         serde_json::from_str(include_str!("test_vec/01/Prio3Aes128Count.json")).unwrap();
-    let prio3 = Prio3Aes128Count::new(2).unwrap();
+    let prio3 = new_prio3_aes128_count(2).unwrap();
     let verify_key = t.verify_key.as_ref().try_into().unwrap();
 
     for (test_num, p) in t.prep.iter().enumerate() {
@@ -144,7 +143,7 @@ fn test_vec_prio3_count() {
 fn test_vec_prio3_sum() {
     let t: TPrio3<u128> =
         serde_json::from_str(include_str!("test_vec/01/Prio3Aes128Sum.json")).unwrap();
-    let prio3 = Prio3Aes128Sum::new(2, 8).unwrap();
+    let prio3 = new_prio3_aes128_sum(2, 8).unwrap();
     let verify_key = t.verify_key.as_ref().try_into().unwrap();
 
     for (test_num, p) in t.prep.iter().enumerate() {
@@ -156,7 +155,7 @@ fn test_vec_prio3_sum() {
 fn test_vec_prio3_histogram() {
     let t: TPrio3<u128> =
         serde_json::from_str(include_str!("test_vec/01/Prio3Aes128Histogram.json")).unwrap();
-    let prio3 = Prio3Aes128Histogram::new(2, &[1, 10, 100]).unwrap();
+    let prio3 = new_prio3_aes128_histogram(2, &[1, 10, 100]).unwrap();
     let verify_key = t.verify_key.as_ref().try_into().unwrap();
 
     for (test_num, p) in t.prep.iter().enumerate() {

--- a/src/vdaf/prio3_test.rs
+++ b/src/vdaf/prio3_test.rs
@@ -12,8 +12,6 @@ use crate::{
 use serde::{Deserialize, Serialize};
 use std::{convert::TryInto, fmt::Debug};
 
-use super::prio3::{new_prio3_aes128_count, new_prio3_aes128_histogram, new_prio3_aes128_sum};
-
 #[derive(Debug, Deserialize, Serialize)]
 struct TEncoded(#[serde(with = "hex")] Vec<u8>);
 
@@ -131,7 +129,7 @@ fn check_prep_test_vec<M, T, P, const L: usize>(
 fn test_vec_prio3_count() {
     let t: TPrio3<u64> =
         serde_json::from_str(include_str!("test_vec/01/Prio3Aes128Count.json")).unwrap();
-    let prio3 = new_prio3_aes128_count(2).unwrap();
+    let prio3 = Prio3::new_aes128_count(2).unwrap();
     let verify_key = t.verify_key.as_ref().try_into().unwrap();
 
     for (test_num, p) in t.prep.iter().enumerate() {
@@ -143,7 +141,7 @@ fn test_vec_prio3_count() {
 fn test_vec_prio3_sum() {
     let t: TPrio3<u128> =
         serde_json::from_str(include_str!("test_vec/01/Prio3Aes128Sum.json")).unwrap();
-    let prio3 = new_prio3_aes128_sum(2, 8).unwrap();
+    let prio3 = Prio3::new_aes128_sum(2, 8).unwrap();
     let verify_key = t.verify_key.as_ref().try_into().unwrap();
 
     for (test_num, p) in t.prep.iter().enumerate() {
@@ -155,7 +153,7 @@ fn test_vec_prio3_sum() {
 fn test_vec_prio3_histogram() {
     let t: TPrio3<u128> =
         serde_json::from_str(include_str!("test_vec/01/Prio3Aes128Histogram.json")).unwrap();
-    let prio3 = new_prio3_aes128_histogram(2, &[1, 10, 100]).unwrap();
+    let prio3 = Prio3::new_aes128_histogram(2, &[1, 10, 100]).unwrap();
     let verify_key = t.verify_key.as_ref().try_into().unwrap();
 
     for (test_num, p) in t.prep.iter().enumerate() {


### PR DESCRIPTION
Previously, the docs for the constructors would show up on the `Prio3`
type, which was confusing since they were all named `new`. Now, the
constructors are free functions with descriptive names. The module
documentation has been updated to reference these functions to provide
readers a hint as to how to construct the various Prio3 VDAF
instantiations.

Also, fixup the only `cargo doc` warning while I'm touching docs.

Closes #237.