### PR TITLE
Clippy

### DIFF
--- a/.github/workflows/ci-build.yml
+++ b/.github/workflows/ci-build.yml
@@ -17,7 +17,7 @@ jobs:
     - name: Lint
       run: cargo fmt --message-format human -- --check
     - name: Clippy
-      run: cargo clippy --all-targets -- -D warnings
+      run: cargo clippy --workspace --all-targets -- -D warnings
     - name: Build (default features)
       run: cargo build --verbose --workspace
     - name: Build (all features)

--- a/.github/workflows/ci-build.yml
+++ b/.github/workflows/ci-build.yml
@@ -16,6 +16,8 @@ jobs:
     - uses: actions/checkout@v2
     - name: Lint
       run: cargo fmt --message-format human -- --check
+    - name: Clippy
+      run: cargo clippy --all-targets -- -D warnings
     - name: Build (default features)
       run: cargo build --verbose --workspace
     - name: Build (all features)
@@ -26,5 +28,3 @@ jobs:
       run: cargo test --verbose --all-features
     - name: Build benchmarks
       run: cargo bench --no-run
-    - name: clippy
-      run: cargo clippy --workspace -- -D warnings

--- a/src/vdaf.rs
+++ b/src/vdaf.rs
@@ -433,7 +433,7 @@ where
         for state in states.iter_mut() {
             match vdaf.prepare_step(
                 state.clone(),
-                V::PrepareMessage::get_decoded_with_param(&state, &inbound)
+                V::PrepareMessage::get_decoded_with_param(state, &inbound)
                     .expect("failed to decode prep message"),
             )? {
                 PrepareTransition::Continue(new_state, msg) => {

--- a/src/vdaf/prio3.rs
+++ b/src/vdaf/prio3.rs
@@ -1024,7 +1024,7 @@ mod tests {
         thread_rng().fill(&mut verify_key[..]);
         let input_shares = prio3.shard(measurement)?;
         for (agg_id, input_share) in input_shares.iter().enumerate() {
-            let (want, _msg) = prio3.prepare_init(&verify_key, agg_id, &(), &[], &input_share)?;
+            let (want, _msg) = prio3.prepare_init(&verify_key, agg_id, &(), &[], input_share)?;
             let got =
                 Prio3PrepareState::get_decoded_with_param(&(prio3, agg_id), &want.get_encoded())
                     .expect("failed to decode prepare step");


### PR DESCRIPTION
* Fix the existing Clippy complaints (both minor, in test code).
* Update Clippy invocation in CI build to catch Clippy complaints in test code.
* Invoke Clippy sooner during a CI build, to catch Clippy complaints before the relatively-expensive build & test steps.