### PR TITLE
CI: build benchmarks with all features, yet another clippy fix.

### DIFF
--- a/.github/workflows/ci-build.yml
+++ b/.github/workflows/ci-build.yml
@@ -17,7 +17,7 @@ jobs:
     - name: Lint
       run: cargo fmt --message-format human -- --check
     - name: Clippy
-      run: cargo clippy --workspace --all-targets -- -D warnings
+      run: cargo clippy --workspace --all-targets --all-features -- -D warnings
     - name: Build (default features)
       run: cargo build --verbose --workspace
     - name: Build (all features)
@@ -26,5 +26,7 @@ jobs:
       run: cargo test --verbose
     - name: Run tests (all features)
       run: cargo test --verbose --all-features
-    - name: Build benchmarks
+    - name: Build benchmarks (default features)
       run: cargo bench --no-run
+    - name: Build benchmarks (all features)
+      run: cargo bench --no-run --all-features

--- a/src/flp/gadgets.rs
+++ b/src/flp/gadgets.rs
@@ -618,9 +618,9 @@ mod tests {
             vec![TestField::zero(); (degree * (1 + num_calls)).next_power_of_two()];
         let mut poly_inp = vec![vec![TestField::zero(); 1 + num_calls]; arity];
         let mut prng: Prng<TestField, _> = Prng::new().unwrap();
-        for i in 0..arity {
-            for j in 0..num_calls {
-                poly_inp[i][j] = prng.get();
+        for inp in poly_inp.iter_mut() {
+            for val in inp.iter_mut().take(num_calls) {
+                *val = prng.get();
             }
         }
         g.call_poly(&mut poly_outp, &poly_inp).unwrap();


### PR DESCRIPTION
Previously, benchmarks were built with default features only, which
would allow even compilation errors in multithreaded code to pass CI.

Also, run clippy against `--all-features`, and fixup one last clippy
error that this discovered.