### PR TITLE
Fix cargo doc warning for Prio3Aes128CountVecMultithreaded.

### DIFF
--- a/.github/workflows/ci-build.yml
+++ b/.github/workflows/ci-build.yml
@@ -18,6 +18,10 @@ jobs:
       run: cargo fmt --message-format human -- --check
     - name: Clippy
       run: cargo clippy --workspace --all-targets -- -D warnings
+    - name: Docs
+      run: cargo doc --all-features
+      env:
+        RUSTDOCFLAGS: -Dwarnings
     - name: Build (default features)
       run: cargo build --verbose --workspace
     - name: Build (all features)

--- a/src/vdaf/prio3.rs
+++ b/src/vdaf/prio3.rs
@@ -85,7 +85,7 @@ impl Prio3Aes128CountVec {
     }
 }
 
-/// Like [`Prio3CountVec`] except this type uses multithreading to improve sharding and
+/// Like [`Prio3Aes128CountVec`] except this type uses multithreading to improve sharding and
 /// preparation time. Note that the improvement is only noticeable for very large input lengths,
 /// e.g., 201 and up. (Your system's mileage may vary.)
 #[cfg(feature = "multithreaded")]


### PR DESCRIPTION
The warning only occurs under `--all-features`.

Also, augment CI with a check that fails if `cargo doc` would produce any warnings.