### PR TITLE
Add num_measurements argument to unshard() and decode_result().

### DIFF
--- a/src/vdaf.rs
+++ b/src/vdaf.rs
@@ -222,6 +222,7 @@ where
         &self,
         agg_param: &Self::AggregationParam,
         agg_shares: M,
+        num_measurements: usize,
     ) -> Result<Self::AggregateResult, VdafError>;
 }
 
@@ -387,7 +388,9 @@ where
     let nonce = b"this is a nonce";
 
     let mut agg_shares: Vec<Option<V::AggregateShare>> = vec![None; vdaf.num_aggregators()];
+    let mut num_measurements: usize = 0;
     for measurement in measurements.into_iter() {
+        num_measurements += 1;
         let input_shares = vdaf.shard(&measurement)?;
         let out_shares = run_vdaf_prepare(vdaf, &verify_key, agg_param, nonce, input_shares)?;
         for (out_share, agg_share) in out_shares.into_iter().zip(agg_shares.iter_mut()) {
@@ -402,6 +405,7 @@ where
     let res = vdaf.unshard(
         agg_param,
         agg_shares.into_iter().map(|option| option.unwrap()),
+        num_measurements,
     )?;
     Ok(res)
 }

--- a/src/vdaf/poplar1.rs
+++ b/src/vdaf/poplar1.rs
@@ -689,6 +689,7 @@ where
         &self,
         agg_param: &BTreeSet<IdpfInput>,
         agg_shares: M,
+        _num_measurements: usize,
     ) -> Result<BTreeMap<IdpfInput, u64>, VdafError> {
         let mut agg_data = AggregateShare(vec![I::Field::zero(); agg_param.len()]);
         for agg_share in agg_shares.into_iter() {

--- a/src/vdaf/prio2.rs
+++ b/src/vdaf/prio2.rs
@@ -263,6 +263,7 @@ impl Collector for Prio2 {
         &self,
         _agg_param: &(),
         agg_shares: M,
+        _num_measurements: usize,
     ) -> Result<Vec<u32>, VdafError> {
         let mut agg = AggregateShare(vec![FieldPrio2::zero(); self.input_len]);
         for agg_share in agg_shares.into_iter() {


### PR DESCRIPTION
I implemented here what @divergentdave suggested in #256.

Currently this is only the `num_measurements` parameter being passed to the `decode_result()` function of prio3 types via `Collector::unshard()`.

Is there something else to be done? For example add an average type like was done in cfrg/draft-irtf-cfrg-vdaf#95?