### PR TITLE
Update various URLs with divviup GH org

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,7 +5,7 @@ authors = ["Josh Aas <jaas@kflag.net>", "Tim Geoghegan <timg@letsencrypt.org>", 
 edition = "2018"
 description = "Implementation of the Prio aggregation system core: https://crypto.stanford.edu/prio/"
 license = "MPL-2.0"
-repository = "https://github.com/abetterinternet/libprio-rs"
+repository = "https://github.com/divviup/libprio-rs"
 rust-version = "1.58"
 
 [dependencies]

--- a/README.md
+++ b/README.md
@@ -2,8 +2,8 @@
 [![Build Status]][actions] [![Latest Version]][crates.io] [![Docs badge]][docs.rs]
 
 
-[Build Status]: https://github.com/abetterinternet/libprio-rs/workflows/ci-build/badge.svg
-[actions]: https://github.com/abetterinternet/libprio-rs/actions?query=branch%3Amain
+[Build Status]: https://github.com/divviup/libprio-rs/workflows/ci-build/badge.svg
+[actions]: https://github.com/divviup/libprio-rs/actions?query=branch%3Amain
 [Latest Version]: https://img.shields.io/crates/v/prio.svg
 [crates.io]: https://crates.io/crates/prio
 [Docs badge]: https://img.shields.io/badge/docs.rs-rustdoc-green
@@ -29,6 +29,6 @@ also forthcoming. Prio3 should not yet be used in production applications.
 
 [enpa]: https://www.abetterinternet.org/post/prio-services-for-covid-en/
 [enpa-whitepaper]: https://covid19-static.cdn-apple.com/applications/covid19/current/static/contact-tracing/pdf/ENPA_White_Paper.pdf
-[prio-server]: https://github.com/abetterinternet/prio-server
+[prio-server]: https://github.com/divviup/prio-server
 [vdaf]: https://datatracker.ietf.org/doc/draft-irtf-cfrg-vdaf/
 [dap]: https://datatracker.ietf.org/doc/draft-ietf-ppm-dap/

--- a/binaries/Cargo.toml
+++ b/binaries/Cargo.toml
@@ -4,7 +4,7 @@ version = "0.5.0"
 edition = "2018"
 description = "Prio utilities"
 license = "MPL-2.0"
-repository = "https://github.com/abetterinternet/libprio-rs"
+repository = "https://github.com/divviup/libprio-rs"
 
 [dependencies]
 base64 = "0.13.0"

--- a/binaries/README.md
+++ b/binaries/README.md
@@ -47,5 +47,5 @@ Where the contents of `/path/to/base64/server-1/private/key` and
 
 [enpa-whitepaper]: https://covid19-static.cdn-apple.com/applications/covid19/current/static/contact-tracing/pdf/ENPA_White_Paper.pdf
 [dap]: https://datatracker.ietf.org/doc/draft-ietf-ppm-dap/
-[prio-server]: https://github.com/abetterinternet/prio-server
+[prio-server]: https://github.com/divviup/prio-server
 [libprio-cc]: https://github.com/google/libprio-cc

--- a/documentation/releases.md
+++ b/documentation/releases.md
@@ -9,5 +9,5 @@ release and publish:
 
 Publishing the release will automatically publish the updated [`prio` crate][crate].
 
-[releases]: https://github.com/abetterinternet/libprio-rs/releases/new
+[releases]: https://github.com/divviup/libprio-rs/releases/new
 [crate]: https://crates.io/crates/prio


### PR DESCRIPTION
This repository was moved from `abetterinternet` to `divviup` some time
ago. This commit updates URLs in a few READMEs and `Cargo.toml`s to
point to the new location.