### PR TITLE
Don't unify "real" and dev dependencies

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,6 +7,7 @@ description = "Implementation of the Prio aggregation system core: https://crypt
 license = "MPL-2.0"
 repository = "https://github.com/divviup/libprio-rs"
 rust-version = "1.58"
+resolver = "2"
 
 [dependencies]
 aes = "0.8.1"
@@ -46,8 +47,7 @@ test-vector = ["rand", "serde_json"]
 multithreaded = ["rayon"]
 
 [workspace]
-members = ["binaries"]
-default-members = ["binaries", "."]
+members = [".", "binaries"]
 
 [[bench]]
 name = "speed_tests"


### PR DESCRIPTION
This commit moves the library and `binaries` targets to `resolver = "2"`
so that `dev-dependencies` don't get pulled in when building non-test
configurations of the `prio` library. Up until now, the crate releases
were enabling feature `test-vector`, unnecessarily including the
`test_vector` module and its dependencies. See [1] for details on
dependency resolution with the new resolver.

[1]: https://github.com/rust-lang/cargo/issues/4866