### PR TITLE
Prio2: Implement serialization of the prep state

### DIFF
--- a/src/vdaf.rs
+++ b/src/vdaf.rs
@@ -53,6 +53,17 @@ pub enum Share<F, const L: usize> {
     Helper(Seed<L>),
 }
 
+impl<F: Clone, const L: usize> Share<F, L> {
+    /// Truncate the Leader's share to the given length. If this is the Helper's share, then this
+    /// method clones the input without modifying it.
+    pub(crate) fn truncated(&self, len: usize) -> Self {
+        match self {
+            Self::Leader(ref data) => Self::Leader(data[..len].to_vec()),
+            Self::Helper(ref seed) => Self::Helper(seed.clone()),
+        }
+    }
+}
+
 /// Parameters needed to decode a [`Share`]
 #[derive(Clone, Debug, PartialEq, Eq)]
 pub(crate) enum ShareDecodingParameter<const L: usize> {


### PR DESCRIPTION
Implements encoding/decoding traits for Prio2 prep state. The Leader
stores its output share; the Helper stores the seed used to generate the
output share.