### PR TITLE
Update lockfile to reflect version bump

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -726,7 +726,7 @@ checksum = "ac74c624d6b2d21f425f752262f42188365d7b8ff1aff74c82e45136510a4857"
 
 [[package]]
 name = "prio"
-version = "0.8.0"
+version = "0.8.2"
 dependencies = [
  "aes 0.8.1",
  "aes-gcm",


### PR DESCRIPTION
This updates `Cargo.lock`, as a follow-up to #266.