### PR TITLE
Add feature flag to hide PRG.

### DIFF
--- a/.github/workflows/ci-build.yml
+++ b/.github/workflows/ci-build.yml
@@ -17,13 +17,13 @@ jobs:
         features: [
           "--all-features",
           "--features=default",
-          "--features=test-vector",
+          "--features=test-util",
           "--features=multithreaded",
-          "--features=test-vector,multithreaded",
+          "--features=test-util,multithreaded",
           "--features=prio2",
-          "--features=prio2,test-vector",
+          "--features=prio2,test-util",
           "--features=prio2,multithreaded",
-          "--features=prio2,test-vector,multithreaded",
+          "--features=prio2,test-util,multithreaded",
         ]
     runs-on: ubuntu-latest
     steps:

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,9 +10,9 @@ rust-version = "1.58"
 resolver = "2"
 
 [dependencies]
-aes = "0.8.1"
-ctr = "0.9.1"
-cmac = "0.7.1"
+aes = { version = "0.8.1", optional = true }
+ctr = { version = "0.9.1", optional = true }
+cmac = { version = "0.7.1", optional = true }
 base64 = "0.13.0"
 byteorder = "1.4.3"
 getrandom = { version = "0.2.7", features = ["std"] }
@@ -20,7 +20,7 @@ serde = { version = "1.0", features = ["derive"] }
 static_assertions = "1.1.0"
 thiserror = "1.0"
 
-# dependencies required if feature "test-vector" is enabled
+# dependencies required if feature "test-util" is enabled
 rand = { version = "0.8", optional = true }
 serde_json = { version = "1.0", optional = true }
 
@@ -41,13 +41,14 @@ serde_json = "1.0"
 hex = { version = "0.4.3" , features = ["serde"] }
 # Enable test_vector module for test targets
 # https://github.com/rust-lang/cargo/issues/2911#issuecomment-749580481
-prio = { path = ".", features = ["test-vector"] }
+prio = { path = ".", features = ["test-util"] }
 
 [features]
-default = []
-test-vector = ["rand", "serde_json"]
+default = ["crypto-dependencies"]
+test-util = ["rand", "serde_json"]
 multithreaded = ["rayon"]
 prio2 = ["aes-gcm", "ring"]
+crypto-dependencies = ["aes", "ctr", "cmac"]
 
 [workspace]
 members = [".", "binaries"]

--- a/binaries/Cargo.toml
+++ b/binaries/Cargo.toml
@@ -8,7 +8,7 @@ repository = "https://github.com/divviup/libprio-rs"
 
 [dependencies]
 base64 = "0.13.0"
-prio = { path = "..", features = ["test-vector", "prio2"] }
+prio = { path = "..", features = ["test-util", "prio2"] }
 color-eyre = { version = "^0.6" }
 serde_json = { version = "1.0" }
 structopt = { version = "0.3.26" }

--- a/src/field.rs
+++ b/src/field.rs
@@ -6,10 +6,11 @@
 //! Each field has an associated parameter called the "generator" that generates a multiplicative
 //! subgroup of order `2^n` for some `n`.
 
+#[cfg(feature = "crypto-dependencies")]
+use crate::prng::{Prng, PrngError};
 use crate::{
     codec::{CodecError, Decode, Encode},
     fp::{FP128, FP32, FP64, FP96},
-    prng::{Prng, PrngError},
 };
 use serde::{
     de::{DeserializeOwned, Visitor},
@@ -635,6 +636,7 @@ pub(crate) fn merge_vector<F: FieldElement>(
 }
 
 /// Outputs an additive secret sharing of the input.
+#[cfg(feature = "crypto-dependencies")]
 pub(crate) fn split_vector<F: FieldElement>(
     inp: &[F],
     num_shares: usize,
@@ -658,6 +660,7 @@ pub(crate) fn split_vector<F: FieldElement>(
 }
 
 /// Generate a vector of uniform random field elements.
+#[cfg(feature = "crypto-dependencies")]
 pub fn random_vector<F: FieldElement>(len: usize) -> Result<Vec<F>, PrngError> {
     Ok(Prng::new()?.take(len).collect())
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -26,7 +26,7 @@ mod polynomial;
 mod prng;
 // Module test_vector depends on crate `rand` so we make it an optional feature
 // to spare most clients the extra dependency.
-#[cfg(all(any(feature = "test-vector", test), feature = "prio2"))]
+#[cfg(all(any(feature = "test-util", test), feature = "prio2"))]
 pub mod test_vector;
 #[cfg(feature = "prio2")]
 pub mod util;

--- a/src/prng.rs
+++ b/src/prng.rs
@@ -6,8 +6,10 @@
 //! NOTE: The public API for this module is a work in progress.
 
 use crate::field::{FieldElement, FieldError};
-use crate::vdaf::prg::{SeedStream, SeedStreamAes128};
-
+use crate::vdaf::prg::SeedStream;
+#[cfg(feature = "crypto-dependencies")]
+use crate::vdaf::prg::SeedStreamAes128;
+#[cfg(feature = "crypto-dependencies")]
 use getrandom::getrandom;
 
 use std::marker::PhantomData;
@@ -33,6 +35,7 @@ pub(crate) struct Prng<F, S> {
     output_written: usize,
 }
 
+#[cfg(feature = "crypto-dependencies")]
 impl<F: FieldElement> Prng<F, SeedStreamAes128> {
     /// Create a [`Prng`] from a seed for Prio 2. The first 16 bytes of the seed and the last 16
     /// bytes of the seed are used, respectively, for the key and initialization vector for AES128

--- a/src/vdaf.rs
+++ b/src/vdaf.rs
@@ -522,6 +522,7 @@ mod tests {
     }
 }
 
+#[cfg(feature = "crypto-dependencies")]
 pub mod poplar1;
 pub mod prg;
 #[cfg(feature = "prio2")]

--- a/src/vdaf/prg.rs
+++ b/src/vdaf/prg.rs
@@ -5,14 +5,19 @@
 //! [draft-irtf-cfrg-vdaf-01]: https://datatracker.ietf.org/doc/draft-irtf-cfrg-vdaf/01/
 
 use crate::vdaf::{CodecError, Decode, Encode};
+#[cfg(feature = "crypto-dependencies")]
 use aes::{
     cipher::{KeyIvInit, StreamCipher},
     Aes128,
 };
+#[cfg(feature = "crypto-dependencies")]
 use cmac::{Cmac, Mac};
+#[cfg(feature = "crypto-dependencies")]
 use ctr::Ctr64BE;
+#[cfg(feature = "crypto-dependencies")]
+use std::fmt::Formatter;
 use std::{
-    fmt::{Debug, Formatter},
+    fmt::Debug,
     io::{Cursor, Read},
 };
 
@@ -128,8 +133,10 @@ pub trait Prg<const L: usize>: Clone + Debug {
 ///
 /// [draft-irtf-cfrg-vdaf-01]: https://datatracker.ietf.org/doc/draft-irtf-cfrg-vdaf/01/
 #[derive(Clone, Debug)]
+#[cfg(feature = "crypto-dependencies")]
 pub struct PrgAes128(Cmac<Aes128>);
 
+#[cfg(feature = "crypto-dependencies")]
 impl Prg<16> for PrgAes128 {
     type SeedStream = SeedStreamAes128;
 
@@ -148,14 +155,17 @@ impl Prg<16> for PrgAes128 {
 }
 
 /// The key stream produced by AES128 in CTR-mode.
+#[cfg(feature = "crypto-dependencies")]
 pub struct SeedStreamAes128(Ctr64BE<Aes128>);
 
+#[cfg(feature = "crypto-dependencies")]
 impl SeedStreamAes128 {
     pub(crate) fn new(key: &[u8], iv: &[u8]) -> Self {
         SeedStreamAes128(Ctr64BE::<Aes128>::new(key.into(), iv.into()))
     }
 }
 
+#[cfg(feature = "crypto-dependencies")]
 impl SeedStream for SeedStreamAes128 {
     fn fill(&mut self, buf: &mut [u8]) {
         buf.fill(0);
@@ -163,6 +173,7 @@ impl SeedStream for SeedStreamAes128 {
     }
 }
 
+#[cfg(feature = "crypto-dependencies")]
 impl Debug for SeedStreamAes128 {
     fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
         // Ctr64BE<Aes128> does not implement Debug, but [`ctr::CtrCore`][1] does, and we get that


### PR DESCRIPTION
The motivation for this PR is to remove the dependencies on the crates aes, ctr and cmac so a user of the crate can rely on an existing crypto library. This should be dable by implementing analogues of `PrgAes128` and `SeedStreamAes128` and constructing, e.g. `Prio3Aes128Count = Prio3<Count<Field64>, PrgAes128Alt, 16>;`

This would fix the remainder of #241.