### PR TITLE
Add unexported trait `FieldElementExt`

### DIFF
--- a/src/flp/types.rs
+++ b/src/flp/types.rs
@@ -2,7 +2,7 @@
 
 //! A collection of [`Type`](crate::flp::Type) implementations.
 
-use crate::field::FieldElement;
+use crate::field::{FieldElement, FieldElementExt};
 use crate::flp::gadgets::{BlindPolyEval, Mul, ParallelSumGadget, PolyEval};
 use crate::flp::{FlpError, Gadget, Type};
 use crate::polynomial::poly_range_check;
@@ -98,7 +98,8 @@ impl<F: FieldElement> Type for Count<F> {
     }
 }
 
-/// This sum type. Each measurement is a integer in `[0, 2^bits)` and the aggregate is the sum of the measurements.
+/// This sum type. Each measurement is a integer in `[0, 2^bits)` and the aggregate is the sum of
+/// the measurements.
 ///
 /// The validity circuit is based on the SIMD circuit construction of [[BBCG+19], Theorem 5.3].
 ///
@@ -593,7 +594,8 @@ pub(crate) fn call_gadget_on_vec_entries<F: FieldElement>(
     Ok(range_check)
 }
 
-/// Given a vector `data` of field elements which should contain exactly one entry, return the integer representation of that entry.
+/// Given a vector `data` of field elements which should contain exactly one entry, return the
+/// integer representation of that entry.
 pub(crate) fn decode_result<F: FieldElement>(data: &[F]) -> Result<F::Integer, FlpError> {
     if data.len() != 1 {
         return Err(FlpError::Decode("unexpected input length".into()));
@@ -601,7 +603,8 @@ pub(crate) fn decode_result<F: FieldElement>(data: &[F]) -> Result<F::Integer, F
     Ok(F::Integer::from(data[0]))
 }
 
-/// Given a vector `data` of field elements, return a vector containing the corresponding integer representations, if the number of entries matches `expected_len`.
+/// Given a vector `data` of field elements, return a vector containing the corresponding integer
+/// representations, if the number of entries matches `expected_len`.
 pub(crate) fn decode_result_vec<F: FieldElement>(
     data: &[F],
     expected_len: usize,

--- a/src/vdaf/prio3.rs
+++ b/src/vdaf/prio3.rs
@@ -146,13 +146,13 @@ impl Prio3Aes128Histogram {
     }
 }
 
-/// The average type. Each measurement is an integer in `[0,2^bits)` for some `0 < bits < 64` and the
-/// aggregate is the arithmetic average.
+/// The average type. Each measurement is an integer in `[0,2^bits)` for some `0 < bits < 64` and
+/// the aggregate is the arithmetic average.
 pub type Prio3Aes128Average = Prio3<Average<Field128>, PrgAes128, 16>;
 
 impl Prio3Aes128Average {
-    /// Construct an instance of Prio3Aes128Average with the given number of aggregators and required
-    /// bit length. The bit length must not exceed 64.
+    /// Construct an instance of Prio3Aes128Average with the given number of aggregators and
+    /// required bit length. The bit length must not exceed 64.
     pub fn new_aes128_average(num_aggregators: u8, bits: u32) -> Result<Self, VdafError> {
         check_num_aggregators(num_aggregators)?;
 


### PR DESCRIPTION
PR #258 added a few utility methods to trait `FieldElement` for encoding
and decoding integers into bit vectors of field elements. @cjpatton
pointed out that these aren't needed in the public API, so this commit
adds `pub(crate) trait FieldElementExt` so that we can provide these
mthods to all `FieldElement`s without increasing the crate's API
surface.

This commit also cleans up some long comment lines and applies rustfmt.