### PR TITLE
Add prio3 type for sum of bounded-norm fixed-point vectors.

### DIFF
--- a/.github/workflows/ci-build.yml
+++ b/.github/workflows/ci-build.yml
@@ -30,7 +30,7 @@ jobs:
       matrix:
         rust-toolchain: [
           # MSRV from Cargo.toml
-          "1.58",
+          "1.61",
           "stable",
         ]
     runs-on: ubuntu-latest
@@ -65,7 +65,7 @@ jobs:
         ]
         rust-toolchain: [
           # MSRV from Cargo.toml
-          "1.58",
+          "1.61",
           "stable",
         ]
     runs-on: ubuntu-latest

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4,9 +4,9 @@ version = 3
 
 [[package]]
 name = "addr2line"
-version = "0.16.0"
+version = "0.17.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3e61f2b7f93d2c7d2b08263acaa4a363b3e276806c68af6134c44f523bf1aacd"
+checksum = "b9ecd88a8c8378ca913a680cd98f0f13ac67383d35993f86c90a70e3f137816b"
 dependencies = [
  "gimli",
 ]
@@ -97,15 +97,21 @@ dependencies = [
 
 [[package]]
 name = "autocfg"
-version = "1.0.1"
+version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cdb031dd78e28731d87d56cc8ffef4a8f36ca26c38fe2de700543e627f8a464a"
+checksum = "d468802bab17cbc0cc575e9b053f41e72aa36bfa6b7f55e3529ffa43161b97fa"
+
+[[package]]
+name = "az"
+version = "1.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7b7e4c2464d97fe331d41de9d5db0def0a96f4d823b8b32a2efd503578988973"
 
 [[package]]
 name = "backtrace"
-version = "0.3.61"
+version = "0.3.66"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e7a905d892734eea339e896738c14b9afce22b5318f64b951e70bf3844419b01"
+checksum = "cab84319d616cfb654d03394f38ab7e6f0919e181b1b57e1fd15e7fb4077d9a7"
 dependencies = [
  "addr2line",
  "cc",
@@ -124,24 +130,30 @@ checksum = "904dfeac50f3cdaba28fc6f57fdcddb75f49ed61346676a78c4ffe55877802fd"
 
 [[package]]
 name = "bitflags"
-version = "1.2.1"
+version = "1.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cf1de2fe8c75bc145a2f577add951f8134889b4795d47466a54a5c846d691693"
+checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
 
 [[package]]
 name = "block-buffer"
-version = "0.10.2"
+version = "0.10.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0bf7fe51849ea569fd452f37822f606a5cabb684dc918707a0193fd4664ff324"
+checksum = "69cce20737498f97b993470a6e536b8523f0af7892a4f928cceb1ac5e52ebe7e"
 dependencies = [
  "generic-array",
 ]
 
 [[package]]
 name = "bumpalo"
-version = "3.6.1"
+version = "3.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "63396b8a4b9de3f4fdfb320ab6080762242f66a8ef174c49d8e19b674db4cdbe"
+checksum = "c1ad822118d20d2c234f427000d5acc36eabe1e29a348c89b63dd60b13f28e5d"
+
+[[package]]
+name = "bytemuck"
+version = "1.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2f5715e491b5a1598fc2bef5a606847b5dc1d48ea625bd3c02c00de8285591da"
 
 [[package]]
 name = "byteorder"
@@ -157,9 +169,9 @@ checksum = "37b2a672a2cb129a2e41c10b1224bb368f9f37a2b16b612598138befd7b37eb5"
 
 [[package]]
 name = "cc"
-version = "1.0.67"
+version = "1.0.73"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e3c69b077ad434294d3ce9f1f6143a2a4b89a8a2d54ef813d85003a4fd1137fd"
+checksum = "2fff2a6927b3bb87f9595d67196a70493f627687a71d87a0d692242c33f58c11"
 
 [[package]]
 name = "cfg-if"
@@ -191,7 +203,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "213030a2b5a4e0c0892b6652260cf6ccac84827b83a85a534e178e3906c4cf1b"
 dependencies = [
  "ciborium-io",
- "half",
+ "half 1.8.2",
 ]
 
 [[package]]
@@ -230,9 +242,9 @@ dependencies = [
 
 [[package]]
 name = "clap"
-version = "3.2.20"
+version = "3.2.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "23b71c3ce99b7611011217b366d923f1d0a7e07a92bb2dbf1e84508c673ca3bd"
+checksum = "1ed5341b2301a26ab80be5cbdced622e80ed808483c52e45e3310a877d3b37d7"
 dependencies = [
  "bitflags",
  "clap_lex",
@@ -289,9 +301,9 @@ dependencies = [
 
 [[package]]
 name = "cpufeatures"
-version = "0.2.1"
+version = "0.2.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "95059428f66df56b63431fdb4e1947ed2190586af5c5a8a8b71122bdf5a7f469"
+checksum = "28d997bd5e24a5928dd43e46dc529867e207907fe0b239c3477d924f7f2ca320"
 dependencies = [
  "libc",
 ]
@@ -306,7 +318,7 @@ dependencies = [
  "atty",
  "cast",
  "ciborium",
- "clap 3.2.20",
+ "clap 3.2.21",
  "criterion-plot",
  "itertools",
  "lazy_static",
@@ -334,9 +346,9 @@ dependencies = [
 
 [[package]]
 name = "crossbeam-channel"
-version = "0.5.1"
+version = "0.5.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "06ed27e177f16d65f0f0c22a213e17c696ace5dd64b14258b52f9417ccb52db4"
+checksum = "c2dd04ddaf88237dc3b8d8f9a3c1004b506b54b3313403944054d23c0870c521"
 dependencies = [
  "cfg-if",
  "crossbeam-utils",
@@ -344,9 +356,9 @@ dependencies = [
 
 [[package]]
 name = "crossbeam-deque"
-version = "0.8.1"
+version = "0.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6455c0ca19f0d2fbf751b908d5c55c1f5cbc65e03c4225427254b46890bdde1e"
+checksum = "715e8152b692bba2d374b53d4875445368fdf21a94751410af607a5ac677d1fc"
 dependencies = [
  "cfg-if",
  "crossbeam-epoch",
@@ -355,32 +367,39 @@ dependencies = [
 
 [[package]]
 name = "crossbeam-epoch"
-version = "0.9.5"
+version = "0.9.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4ec02e091aa634e2c3ada4a392989e7c3116673ef0ac5b72232439094d73b7fd"
+checksum = "045ebe27666471bb549370b4b0b3e51b07f56325befa4284db65fc89c02511b1"
 dependencies = [
+ "autocfg",
  "cfg-if",
  "crossbeam-utils",
- "lazy_static",
  "memoffset",
+ "once_cell",
  "scopeguard",
 ]
 
 [[package]]
 name = "crossbeam-utils"
-version = "0.8.8"
+version = "0.8.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0bf124c720b7686e3c2663cf54062ab0f68a88af2fb6a030e87e30bf721fcb38"
+checksum = "51887d4adc7b564537b15adcfb307936f8075dfcd5f00dde9a9f1d29383682bc"
 dependencies = [
  "cfg-if",
- "lazy_static",
+ "once_cell",
 ]
 
 [[package]]
-name = "crypto-common"
-version = "0.1.3"
+name = "crunchy"
+version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "57952ca27b5e3606ff4dd79b0020231aaf9d6aa76dc05fd30137538c50bd3ce8"
+checksum = "7a81dae078cea95a014a339291cec439d2f232ebe854a9d672b796c6afafa9b7"
+
+[[package]]
+name = "crypto-common"
+version = "0.1.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1bfb12502f3fc46cca1bb51ac28df9d618d813cdc3d2f25b9fe775a34af26bb3"
 dependencies = [
  "generic-array",
  "typenum",
@@ -426,25 +445,72 @@ dependencies = [
 
 [[package]]
 name = "either"
-version = "1.6.1"
+version = "1.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e78d4f1cc4ae33bbfc157ed5d5a5ef3bc29227303d595861deb238fcec4e9457"
+checksum = "90e5c1c8368803113bf0c9584fc495a58b86dc8a29edbf8fe877d21d9507e797"
 
 [[package]]
 name = "eyre"
-version = "0.6.5"
+version = "0.6.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "221239d1d5ea86bf5d6f91c9d6bc3646ffe471b08ff9b0f91c44f115ac969d2b"
+checksum = "4c2b6b5a29c02cdc822728b7d7b8ae1bab3e3b05d44522770ddd49722eeac7eb"
 dependencies = [
  "indenter",
  "once_cell",
 ]
 
 [[package]]
-name = "generic-array"
-version = "0.14.4"
+name = "fixed"
+version = "1.19.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "501466ecc8a30d1d3b7fc9229b122b2ce8ed6e9d9223f1138d4babb253e51817"
+checksum = "e0371cd413fb63f8ec1b9eb4dff47fa2c88b21abc681771234c84808b9920991"
+dependencies = [
+ "az",
+ "bytemuck",
+ "half 2.1.0",
+ "typenum",
+]
+
+[[package]]
+name = "fixed-macro"
+version = "1.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3f6b2cae66e4989f93364a38a59a12e1830afe3201c7c11e5ea8727534831fbe"
+dependencies = [
+ "fixed",
+ "fixed-macro-impl",
+ "fixed-macro-types",
+]
+
+[[package]]
+name = "fixed-macro-impl"
+version = "1.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "787fa8e0bf88449e84799f4b440a15bd1958c4552a80abc568d5ba9e20a4283e"
+dependencies = [
+ "fixed",
+ "paste",
+ "proc-macro-error",
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "fixed-macro-types"
+version = "1.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "13c7241f3a037641b460153db21d5611c789e7e0504bf52e20a9b4bbe1d7cc00"
+dependencies = [
+ "fixed",
+ "fixed-macro-impl",
+]
+
+[[package]]
+name = "generic-array"
+version = "0.14.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bff49e947297f3312447abdca79f45f4738097cc82b06e72054d2223f601f1b9"
 dependencies = [
  "typenum",
  "version_check",
@@ -473,15 +539,24 @@ dependencies = [
 
 [[package]]
 name = "gimli"
-version = "0.25.0"
+version = "0.26.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f0a01e0497841a3b2db4f8afa483cce65f7e96a3498bd6c541734792aeac8fe7"
+checksum = "22030e2c5a68ec659fde1e949a745124b48e6fa8b045b7ed5bd1fe4ccc5c4e5d"
 
 [[package]]
 name = "half"
-version = "1.7.1"
+version = "1.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "62aca2aba2d62b4a7f5b33f3712cb1b0692779a56fb510499d5c0aa594daeaf3"
+checksum = "eabb4a44450da02c90444cf74558da904edde8fb4e9035a9a6a4e15445af0bd7"
+
+[[package]]
+name = "half"
+version = "2.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ad6a9459c9c30b177b925162351f97e7d967c7ea8bab3b8352805327daf45554"
+dependencies = [
+ "crunchy",
+]
 
 [[package]]
 name = "hashbrown"
@@ -540,9 +615,9 @@ dependencies = [
 
 [[package]]
 name = "inout"
-version = "0.1.2"
+version = "0.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9e1f03d4ab4d5dc9ec2d219f86c15d2a15fc08239d1cd3b2d6a19717c0a2f443"
+checksum = "a0c10553d664a4d0bcff9f4215d0aac67a639cc68ef660840afe309b807bc9f5"
 dependencies = [
  "generic-array",
 ]
@@ -558,15 +633,15 @@ dependencies = [
 
 [[package]]
 name = "itoa"
-version = "1.0.1"
+version = "1.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1aab8fc367588b89dcee83ab0fd66b72b50b72fa1904d7095045ace2b0c81c35"
+checksum = "6c8af84674fe1f223a982c933a0ee1086ac4d4052aa0fb8060c12c6ad838e754"
 
 [[package]]
 name = "js-sys"
-version = "0.3.51"
+version = "0.3.60"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "83bdfbace3a0e81a4253f73b49e960b053e396a11012cbd49b9b74d6a2b67062"
+checksum = "49409df3e3bf0856b916e2ceaca09ee28e6871cf7d9ce97a692cacfdb2a25a47"
 dependencies = [
  "wasm-bindgen",
 ]
@@ -579,42 +654,41 @@ checksum = "e2abad23fbc42b3700f2f279844dc832adb2b2eb069b2df918f455c4e18cc646"
 
 [[package]]
 name = "libc"
-version = "0.2.121"
+version = "0.2.132"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "efaa7b300f3b5fe8eb6bf21ce3895e1751d9665086af2d64b42f19701015ff4f"
+checksum = "8371e4e5341c3a96db127eb2465ac681ced4c433e01dd0e938adbef26ba93ba5"
 
 [[package]]
 name = "log"
-version = "0.4.14"
+version = "0.4.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "51b9bbe6c47d51fc3e1a9b945965946b4c44142ab8792c50835a980d362c2710"
+checksum = "abb12e687cfb44aa40f41fc3978ef76448f9b6038cad6aef4259d3c095a2382e"
 dependencies = [
  "cfg-if",
 ]
 
 [[package]]
 name = "memchr"
-version = "2.4.1"
+version = "2.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "308cc39be01b73d0d18f82a0e7b2a3df85245f84af96fdddc5d202d27e47b86a"
+checksum = "2dffe52ecf27772e601905b7522cb4ef790d2cc203488bbd0e2fe85fcb74566d"
 
 [[package]]
 name = "memoffset"
-version = "0.6.4"
+version = "0.6.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "59accc507f1338036a0477ef61afdae33cde60840f4dfe481319ce3ad116ddf9"
+checksum = "5aa361d4faea93603064a027415f07bd8e1d5c88c9fbf68bf56a285428fd79ce"
 dependencies = [
  "autocfg",
 ]
 
 [[package]]
 name = "miniz_oxide"
-version = "0.4.4"
+version = "0.5.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a92518e98c078586bc6c934028adcca4c92a53d6a958196de835170a01d84e4b"
+checksum = "96590ba8f175222643a85693f33d26e9c8a015f599c216509b1a6894af675d34"
 dependencies = [
  "adler",
- "autocfg",
 ]
 
 [[package]]
@@ -639,9 +713,9 @@ dependencies = [
 
 [[package]]
 name = "num-integer"
-version = "0.1.44"
+version = "0.1.45"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d2cc698a63b549a70bc047073d2949cce27cd1c7b0a4a862d08a8031bc2801db"
+checksum = "225d3389fb3509a24c93f5c29eb6bde2586b98d9f016636dff58d7c6f7569cd9"
 dependencies = [
  "autocfg",
  "num-traits",
@@ -649,18 +723,18 @@ dependencies = [
 
 [[package]]
 name = "num-traits"
-version = "0.2.14"
+version = "0.2.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9a64b1ec5cda2586e284722486d802acf1f7dbdc623e2bfc57e65ca1cd099290"
+checksum = "578ede34cf02f8924ab9447f50c28075b4d3e5b269972345e7e0372b38c6cdcd"
 dependencies = [
  "autocfg",
 ]
 
 [[package]]
 name = "num_cpus"
-version = "1.13.0"
+version = "1.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "05499f3756671c15885fee9034446956fff3f243d6077b91e5767df161f766b3"
+checksum = "19e64526ebdee182341572e50e9ad03965aa510cd94427a4549448f285e957a1"
 dependencies = [
  "hermit-abi",
  "libc",
@@ -668,18 +742,18 @@ dependencies = [
 
 [[package]]
 name = "object"
-version = "0.26.2"
+version = "0.29.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "39f37e50073ccad23b6d09bcb5b263f4e76d3bb6038e4a3c08e52162ffa8abc2"
+checksum = "21158b2c33aa6d4561f1c0a6ea283ca92bc54802a93b263e910746d679a7eb53"
 dependencies = [
  "memchr",
 ]
 
 [[package]]
 name = "once_cell"
-version = "1.7.2"
+version = "1.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "af8b08b04175473088b46763e51ee54da5f9a164bc162f615b91bc179dbf15a3"
+checksum = "2f7254b99e31cad77da24b08ebf628882739a608578bb1bcdfc1f9c21260d7c0"
 
 [[package]]
 name = "oorandom"
@@ -701,21 +775,27 @@ checksum = "9ff7415e9ae3fff1225851df9e0d9e4e5479f947619774677a63572e55e80eff"
 
 [[package]]
 name = "owo-colors"
-version = "3.2.0"
+version = "3.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "20448fd678ec04e6ea15bbe0476874af65e98a01515d667aa49f1434dc44ebf4"
+checksum = "c1b04fb49957986fdce4d6ee7a65027d55d4b6d2265e5848bbb507b58ccfdb6f"
+
+[[package]]
+name = "paste"
+version = "1.0.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b1de2e551fb905ac83f73f7aedf2f0cb4a0da7e35efa24a202a936269f1f18e1"
 
 [[package]]
 name = "pin-project-lite"
-version = "0.2.7"
+version = "0.2.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8d31d11c69a6b52a174b42bdc0c30e5e11670f90788b2c471c31c1d17d449443"
+checksum = "e0a7ae3ac2f1173085d398531c705756c94a4c56843785df85a60c1a0afac116"
 
 [[package]]
 name = "plotters"
-version = "0.3.1"
+version = "0.3.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "32a3fd9ec30b9749ce28cd91f255d569591cdf937fe280c312143e3c4bad6f2a"
+checksum = "2538b639e642295546c50fcd545198c9d64ee2a38620a628724a3b266d5fbf97"
 dependencies = [
  "num-traits",
  "plotters-backend",
@@ -726,15 +806,15 @@ dependencies = [
 
 [[package]]
 name = "plotters-backend"
-version = "0.3.2"
+version = "0.3.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d88417318da0eaf0fdcdb51a0ee6c3bed624333bff8f946733049380be67ac1c"
+checksum = "193228616381fecdc1224c62e96946dfbc73ff4384fba576e052ff8c1bea8142"
 
 [[package]]
 name = "plotters-svg"
-version = "0.3.1"
+version = "0.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "521fa9638fa597e1dc53e9412a4f9cefb01187ee1f7413076f9e6749e2885ba9"
+checksum = "f9a81d2759aae1dae668f783c308bc5c8ebd191ff4184aaa1b37f65a6ae5a56f"
 dependencies = [
  "plotters-backend",
 ]
@@ -753,9 +833,9 @@ dependencies = [
 
 [[package]]
 name = "ppv-lite86"
-version = "0.2.10"
+version = "0.2.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ac74c624d6b2d21f425f752262f42188365d7b8ff1aff74c82e45136510a4857"
+checksum = "eb9f9e6e233e5c4a35559a617bf40a4ec447db2e84c20b55a6f83167b7e57872"
 
 [[package]]
 name = "prio"
@@ -770,6 +850,8 @@ dependencies = [
  "cmac",
  "criterion",
  "ctr 0.9.1",
+ "fixed",
+ "fixed-macro",
  "getrandom",
  "hex",
  "iai",
@@ -823,18 +905,18 @@ dependencies = [
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.36"
+version = "1.0.43"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c7342d5883fbccae1cc37a2353b09c87c9b0f3afd73f5fb9bba687a1f733b029"
+checksum = "0a2ca2c61bc9f3d74d2886294ab7b9853abd9c1ad903a3ac7815c58989bb7bab"
 dependencies = [
- "unicode-xid",
+ "unicode-ident",
 ]
 
 [[package]]
 name = "quote"
-version = "1.0.9"
+version = "1.0.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c3d0b9745dc2debf507c8422de05d7226cc1f0644216dfdfead988f9b1ab32a7"
+checksum = "bbe448f377a7d6961e30f5955f9b8d106c3f5e449d493ee1b125c1d43c2b5179"
 dependencies = [
  "proc-macro2",
 ]
@@ -883,9 +965,9 @@ dependencies = [
 
 [[package]]
 name = "rayon-core"
-version = "1.9.2"
+version = "1.9.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9f51245e1e62e1f1629cbfec37b5793bbabcaeb90f30e94d2ba03564687353e4"
+checksum = "258bcdb5ac6dad48491bb2992db6b7cf74878b0384908af124823d118c99683f"
 dependencies = [
  "crossbeam-channel",
  "crossbeam-deque",
@@ -895,18 +977,18 @@ dependencies = [
 
 [[package]]
 name = "regex"
-version = "1.5.6"
+version = "1.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d83f127d94bdbcda4c8cc2e50f6f84f4b611f69c902699ca385a39c3a75f9ff1"
+checksum = "4c4eb3267174b8c6c2f654116623910a0fef09c4753f8dd83db29c48a0df988b"
 dependencies = [
  "regex-syntax",
 ]
 
 [[package]]
 name = "regex-syntax"
-version = "0.6.26"
+version = "0.6.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "49b3de9ec5dc0a3417da371aab17d729997c15010e7fd24ff707773a33bddb64"
+checksum = "a3f87b73ce11b1619a3c6332f45341e0047173771e8b8b73f87bfeefb7b56244"
 
 [[package]]
 name = "ring"
@@ -931,9 +1013,9 @@ checksum = "7ef03e0a2b150c7a90d01faf6254c9c48a41e95fb2a8c2ac1c6f0d2b9aefc342"
 
 [[package]]
 name = "ryu"
-version = "1.0.5"
+version = "1.0.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "71d301d4193d031abdd79ff7e3dd721168a9572ef3fe51a1517aba235bd8f86e"
+checksum = "4501abdff3ae82a1c1b477a17252eb69cee9e66eb915c1abaa4f44d873df9f09"
 
 [[package]]
 name = "same-file"
@@ -983,9 +1065,9 @@ dependencies = [
 
 [[package]]
 name = "sharded-slab"
-version = "0.1.3"
+version = "0.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "740223c51853f3145fe7c90360d2d4232f2b62e3449489c207eccde818979982"
+checksum = "900fba806f70c630b0a382d0d825e17a0f19fcd059a2ade1ff237bcddf446b31"
 dependencies = [
  "lazy_static",
 ]
@@ -1034,19 +1116,19 @@ dependencies = [
 
 [[package]]
 name = "subtle"
-version = "2.4.0"
+version = "2.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1e81da0851ada1f3e9d4312c704aa4f8806f0f9d69faaf8df2f3464b4a9437c2"
+checksum = "6bdef32e8150c2a081110b42772ffe7d7c9032b606bc226c8260fd97e0976601"
 
 [[package]]
 name = "syn"
-version = "1.0.92"
+version = "1.0.99"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7ff7c592601f11445996a06f8ad0c27f094a58857c2f89e97974ab9235b92c52"
+checksum = "58dbef6ec655055e20b86b15a8cc6d439cca19b667537ac6a1369572d151ab13"
 dependencies = [
  "proc-macro2",
  "quote",
- "unicode-xid",
+ "unicode-ident",
 ]
 
 [[package]]
@@ -1105,9 +1187,9 @@ dependencies = [
 
 [[package]]
 name = "tracing"
-version = "0.1.28"
+version = "0.1.36"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "84f96e095c0c82419687c20ddf5cb3eadb61f4e1405923c9dc8e53a1adacbda8"
+checksum = "2fce9567bd60a67d08a16488756721ba392f24f29006402881e43b19aac64307"
 dependencies = [
  "cfg-if",
  "pin-project-lite",
@@ -1116,11 +1198,12 @@ dependencies = [
 
 [[package]]
 name = "tracing-core"
-version = "0.1.21"
+version = "0.1.29"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1f4ed65637b8390770814083d20756f87bfa2c21bf2f110babdc5438351746e4"
+checksum = "5aeea4303076558a00714b823f9ad67d58a3bbda1df83d8827d21193156e22f7"
 dependencies = [
- "lazy_static",
+ "once_cell",
+ "valuable",
 ]
 
 [[package]]
@@ -1135,9 +1218,9 @@ dependencies = [
 
 [[package]]
 name = "tracing-subscriber"
-version = "0.3.6"
+version = "0.3.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "77be66445c4eeebb934a7340f227bfe7b338173d3f8c00a60a5a58005c9faecf"
+checksum = "60db860322da191b40952ad9affe65ea23e7dd6a5c442c2c42865810c6ab8e6b"
 dependencies = [
  "sharded-slab",
  "thread_local",
@@ -1151,28 +1234,28 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dcf81ac59edc17cc8697ff311e8f5ef2d99fcbd9817b34cec66f90b6c3dfd987"
 
 [[package]]
-name = "unicode-segmentation"
-version = "1.8.0"
+name = "unicode-ident"
+version = "1.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8895849a949e7845e06bd6dc1aa51731a103c42707010a5b591c0038fb73385b"
+checksum = "c4f5b37a154999a8f3f98cc23a628d850e154479cd94decf3414696e12e31aaf"
+
+[[package]]
+name = "unicode-segmentation"
+version = "1.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7e8820f5d777f6224dc4be3632222971ac30164d4a258d595640799554ebfd99"
 
 [[package]]
 name = "unicode-width"
-version = "0.1.8"
+version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9337591893a19b88d8d87f2cec1e73fad5cdfd10e5a6f349f498ad6ea2ffb1e3"
-
-[[package]]
-name = "unicode-xid"
-version = "0.2.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f7fe0bb3479651439c9112f72b6c505038574c9fbb575ed1bf3b797fa39dd564"
+checksum = "3ed742d4ea2bd1176e236172c8429aaf54486e7ac098db29ffe6529e0ce50973"
 
 [[package]]
 name = "universal-hash"
-version = "0.4.0"
+version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8326b2c654932e3e4f9196e69d08fdf7cfd718e1dc6f66b347e6024a0c961402"
+checksum = "9f214e8f697e925001e66ec2c6e37a4ef93f0f78c2eed7814394e10c62025b05"
 dependencies = [
  "generic-array",
  "subtle",
@@ -1185,6 +1268,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a156c684c91ea7d62626509bce3cb4e1d9ed5c4d978f7b4352658f96a4c26b4a"
 
 [[package]]
+name = "valuable"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "830b7e5d4d90034032940e4ace0d9a9a057e7a45cd94e6c007832e39edb82f6d"
+
+[[package]]
 name = "vec_map"
 version = "0.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1192,9 +1281,9 @@ checksum = "f1bddf1187be692e79c5ffeab891132dfb0f236ed36a43c7ed39f1165ee20191"
 
 [[package]]
 name = "version_check"
-version = "0.9.2"
+version = "0.9.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b5a972e5669d67ba988ce3dc826706fb0a8b01471c088cb0b6110b805cc36aed"
+checksum = "49874b5167b65d7193b8aba1567f5c7d93d001cafc34600cee003eda787e483f"
 
 [[package]]
 name = "walkdir"
@@ -1215,9 +1304,9 @@ checksum = "9c8d87e72b64a3b4db28d11ce29237c246188f4f51057d65a7eab63b7987e423"
 
 [[package]]
 name = "wasm-bindgen"
-version = "0.2.74"
+version = "0.2.83"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d54ee1d4ed486f78874278e63e4069fc1ab9f6a18ca492076ffb90c5eb2997fd"
+checksum = "eaf9f5aceeec8be17c128b2e93e031fb8a4d469bb9c4ae2d7dc1888b26887268"
 dependencies = [
  "cfg-if",
  "wasm-bindgen-macro",
@@ -1225,13 +1314,13 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-backend"
-version = "0.2.74"
+version = "0.2.83"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3b33f6a0694ccfea53d94db8b2ed1c3a8a4c86dd936b13b9f0a15ec4a451b900"
+checksum = "4c8ffb332579b0557b52d268b91feab8df3615f265d5270fec2a8c95b17c1142"
 dependencies = [
  "bumpalo",
- "lazy_static",
  "log",
+ "once_cell",
  "proc-macro2",
  "quote",
  "syn",
@@ -1240,9 +1329,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro"
-version = "0.2.74"
+version = "0.2.83"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "088169ca61430fe1e58b8096c24975251700e7b1f6fd91cc9d59b04fb9b18bd4"
+checksum = "052be0f94026e6cbc75cdefc9bae13fd6052cdcaf532fa6c45e7ae33a1e6c810"
 dependencies = [
  "quote",
  "wasm-bindgen-macro-support",
@@ -1250,9 +1339,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro-support"
-version = "0.2.74"
+version = "0.2.83"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "be2241542ff3d9f241f5e2cb6dd09b37efe786df8851c54957683a49f0987a97"
+checksum = "07bc0c051dc5f23e307b13285f9d75df86bfdf816c5721e573dec1f9b8aa193c"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1263,15 +1352,15 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-shared"
-version = "0.2.74"
+version = "0.2.83"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d7cff876b8f18eed75a66cf49b65e7f967cb354a7aa16003fb55dbfd25b44b4f"
+checksum = "1c38c045535d93ec4f0b4defec448e4291638ee608530863b1e2ba115d4fff7f"
 
 [[package]]
 name = "web-sys"
-version = "0.3.51"
+version = "0.3.60"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e828417b379f3df7111d3a2a9e5753706cae29c41f7c4029ee9fd77f3e09e582"
+checksum = "bcda906d8be16e728fd5adc5b729afad4e444e106ab28cd1c7256e54fa61510f"
 dependencies = [
  "js-sys",
  "wasm-bindgen",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,7 +6,7 @@ edition = "2018"
 description = "Implementation of the Prio aggregation system core: https://crypto.stanford.edu/prio/"
 license = "MPL-2.0"
 repository = "https://github.com/divviup/libprio-rs"
-rust-version = "1.58"
+rust-version = "1.61"
 resolver = "2"
 
 [dependencies]
@@ -15,6 +15,7 @@ ctr = { version = "0.9.1", optional = true }
 cmac = { version = "0.7.1", optional = true }
 base64 = "0.13.0"
 byteorder = "1.4.3"
+fixed = "1.19"
 getrandom = { version = "0.2.7", features = ["std"] }
 serde = { version = "1.0", features = ["derive"] }
 static_assertions = "1.1.0"
@@ -34,6 +35,7 @@ ring = { version = "0.16.20", optional = true }
 [dev-dependencies]
 assert_matches = "1.5.0"
 criterion = "0.4"
+fixed-macro = "1.1.1"
 iai = "0.1"
 itertools = "0.10.3"
 modinverse = "0.1.0"

--- a/benches/speed_tests.rs
+++ b/benches/speed_tests.rs
@@ -2,6 +2,7 @@
 
 use criterion::{criterion_group, criterion_main, Criterion};
 
+use fixed_macro::fixed;
 use prio::benchmarked::*;
 #[cfg(feature = "prio2")]
 use prio::client::Client as Prio2Client;
@@ -260,6 +261,48 @@ pub fn prio3_client(c: &mut Criterion) {
                 prio3.shard(&measurement).unwrap();
             })
         });
+    }
+
+    let len = 1000;
+    let prio3 = Prio3::new_aes128_fixedpoint_boundedl2_vec_sum(num_shares, len).unwrap();
+    let fp_num = fixed!(0.0001: I1F15);
+    let measurement = vec![fp_num; len];
+    println!(
+        "prio3 fixedpoint16 boundedl2 vec ({} entries) size = {}",
+        len,
+        prio3_input_share_size(&prio3.shard(&measurement).unwrap().1)
+    );
+    c.bench_function(
+        &format!("prio3 fixedpoint16 boundedl2 vec ({} entries)", len),
+        |b| {
+            b.iter(|| {
+                prio3.shard(&measurement).unwrap();
+            })
+        },
+    );
+
+    #[cfg(feature = "multithreaded")]
+    {
+        let prio3 =
+            Prio3::new_aes128_fixedpoint_boundedl2_vec_sum_multithreaded(num_shares, len).unwrap();
+        let fp_num = fixed!(0.0001: I1F15);
+        let measurement = vec![fp_num; len];
+        println!(
+            "prio3 fixedpoint16 boundedl2 vec multithreaded ({} entries) size = {}",
+            len,
+            prio3_input_share_size(&prio3.shard(&measurement).unwrap().1)
+        );
+        c.bench_function(
+            &format!(
+                "prio3 fixedpoint16 boundedl2 vec multithreaded ({} entries)",
+                len
+            ),
+            |b| {
+                b.iter(|| {
+                    prio3.shard(&measurement).unwrap();
+                })
+            },
+        );
     }
 }
 

--- a/src/codec.rs
+++ b/src/codec.rs
@@ -210,7 +210,7 @@ pub fn encode_u8_items<P, E: ParameterizedEncode<P>>(
     }
 
     let len = bytes.len() - len_offset - 1;
-    assert!(len <= u8::MAX.into());
+    assert!(len <= usize::from(u8::MAX));
     bytes[len_offset] = len as u8;
 }
 
@@ -245,7 +245,7 @@ pub fn encode_u16_items<P, E: ParameterizedEncode<P>>(
     }
 
     let len = bytes.len() - len_offset - 2;
-    assert!(len <= u16::MAX.into());
+    assert!(len <= usize::from(u16::MAX));
     for (offset, byte) in u16::to_be_bytes(len as u16).iter().enumerate() {
         bytes[len_offset + offset] = *byte;
     }

--- a/src/field.rs
+++ b/src/field.rs
@@ -201,6 +201,37 @@ pub trait FieldElement:
 
 /// Methods common to all `FieldElement` implementations that are private to the crate.
 pub(crate) trait FieldElementExt: FieldElement {
+    /// Encode `input` as bitvector of elements of `Self`. Output is written into the `output` slice.
+    /// If `output.len()` is smaller than the number of bits required to respresent `input`,
+    /// an error is returned.
+    ///
+    /// # Arguments
+    ///
+    /// * `input` - The field element to encode
+    /// * `output` - The slice to write the encoded bits into. Least signicant bit comes first
+    fn fill_with_bitvector_representation(
+        input: &Self::Integer,
+        output: &mut [Self],
+    ) -> Result<(), FieldError> {
+        // Create a mutable copy of `input`. In each iteration of the following loop we take the
+        // least significant bit, and shift input to the right by one bit.
+        let mut i = *input;
+
+        let one = Self::Integer::from(Self::one());
+        for bit in output.iter_mut() {
+            let w = Self::from(i & one);
+            *bit = w;
+            i = i >> one;
+        }
+
+        // If `i` is still not zero, this means that it cannot be encoded by `bits` bits.
+        if i != Self::Integer::from(Self::zero()) {
+            return Err(FieldError::InputSizeMismatch);
+        }
+
+        Ok(())
+    }
+
     /// Encode `input` as `bits`-bit vector of elements of `Self` if it's small enough
     /// to be represented with that many bits.
     ///
@@ -212,24 +243,9 @@ pub(crate) trait FieldElementExt: FieldElement {
         input: &Self::Integer,
         bits: usize,
     ) -> Result<Vec<Self>, FieldError> {
-        // Create a mutable copy of `input`. In each iteration of the following loop we take the
-        // least significant bit, and shift input to the right by one bit.
-        let mut i = *input;
-
-        let one = Self::Integer::from(Self::one());
-        let mut encoded = Vec::with_capacity(bits);
-        for _ in 0..bits {
-            let w = Self::from(i & one);
-            encoded.push(w);
-            i = i >> one;
-        }
-
-        // If `i` is still not zero, this means that it cannot be encoded by `bits` bits.
-        if i != Self::Integer::from(Self::zero()) {
-            return Err(FieldError::InputSizeMismatch);
-        }
-
-        Ok(encoded)
+        let mut result = vec![Self::zero(); bits];
+        Self::fill_with_bitvector_representation(input, &mut result)?;
+        Ok(result)
     }
 
     /// Decode the bitvector-represented value `input` into a simple representation as a single
@@ -239,13 +255,16 @@ pub(crate) trait FieldElementExt: FieldElement {
     ///
     /// This function errors if `2^input.len() - 1` does not fit into the field `Self`.
     fn decode_from_bitvector_representation(input: &[Self]) -> Result<Self, FieldError> {
+        let fi_one = Self::Integer::from(Self::one());
+
         if !Self::valid_integer_bitlength(input.len()) {
             return Err(FieldError::ModulusOverflow);
         }
 
         let mut decoded = Self::zero();
         for (l, bit) in input.iter().enumerate() {
-            let w = Self::Integer::try_from(1 << l).map_err(|_| FieldError::IntegerTryFrom)?;
+            let fi_l = Self::Integer::try_from(l).map_err(|_| FieldError::IntegerTryFrom)?;
+            let w = fi_one << fi_l;
             decoded += Self::from(w) * *bit;
         }
         Ok(decoded)
@@ -267,6 +286,9 @@ pub(crate) trait FieldElementExt: FieldElement {
     /// Check if the largest number representable with `bits` bits (i.e. 2^bits - 1) is
     /// representable in this field.
     fn valid_integer_bitlength(bits: usize) -> bool {
+        if bits >= 8 * Self::ENCODED_SIZE {
+            return false;
+        }
         if let Ok(bits_int) = Self::Integer::try_from(bits) {
             if Self::modulus() >> bits_int != Self::Integer::from(Self::zero()) {
                 return true;
@@ -956,5 +978,28 @@ mod tests {
     #[test]
     fn test_field128() {
         field_element_test::<Field128>();
+    }
+
+    #[test]
+    fn test_encode_into_bitvector() {
+        let zero = Field128::zero();
+        let one = Field128::one();
+        let zero_enc = Field128::encode_into_bitvector_representation(&0, 4).unwrap();
+        let one_enc = Field128::encode_into_bitvector_representation(&1, 4).unwrap();
+        let fifteen_enc = Field128::encode_into_bitvector_representation(&15, 4).unwrap();
+        assert_eq!(zero_enc, [zero; 4]);
+        assert_eq!(one_enc, [one, zero, zero, zero]);
+        assert_eq!(fifteen_enc, [one; 4]);
+        Field128::encode_into_bitvector_representation(&16, 4).unwrap_err();
+    }
+
+    #[test]
+    fn test_fill_bitvector() {
+        let zero = Field128::zero();
+        let one = Field128::one();
+        let mut output: Vec<Field128> = vec![zero; 6];
+        Field128::fill_with_bitvector_representation(&9, &mut output[1..5]).unwrap();
+        assert_eq!(output, [zero, one, zero, zero, one, zero]);
+        Field128::fill_with_bitvector_representation(&16, &mut output[1..5]).unwrap_err();
     }
 }

--- a/src/flp.rs
+++ b/src/flp.rs
@@ -255,9 +255,9 @@ pub trait Type: Sized + Eq + Clone + Debug {
                 let inner_arity = inner.arity();
                 if prove_rand_len + inner_arity > prove_rand.len() {
                     return Err(FlpError::Prove(format!(
-                        "short prove randomness: got {}; want {}",
+                        "short prove randomness: got {}; want at least {}",
                         prove_rand.len(),
-                        self.prove_rand_len()
+                        prove_rand_len + inner_arity
                     )));
                 }
 

--- a/src/flp/types.rs
+++ b/src/flp/types.rs
@@ -623,18 +623,11 @@ pub(crate) fn decode_result_vec<F: FieldElement>(
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::field::{random_vector, split_vector, Field64 as TestField};
+    use crate::field::{random_vector, Field64 as TestField};
     use crate::flp::gadgets::ParallelSum;
     #[cfg(feature = "multithreaded")]
     use crate::flp::gadgets::ParallelSumMultithreaded;
-
-    // Number of shares to split input and proofs into in `flp_test`.
-    const NUM_SHARES: usize = 3;
-
-    struct ValidityTestCase<F> {
-        expect_valid: bool,
-        expected_output: Option<Vec<F>>,
-    }
+    use crate::flp::types::test_utils::{flp_validity_test, ValidityTestCase};
 
     #[test]
     fn test_count() {
@@ -662,6 +655,7 @@ mod tests {
             &ValidityTestCase::<TestField> {
                 expect_valid: true,
                 expected_output: Some(vec![one]),
+                num_shares: 3,
             },
         )
         .unwrap();
@@ -672,6 +666,7 @@ mod tests {
             &ValidityTestCase::<TestField> {
                 expect_valid: true,
                 expected_output: Some(vec![zero]),
+                num_shares: 3,
             },
         )
         .unwrap();
@@ -683,6 +678,7 @@ mod tests {
             &ValidityTestCase::<TestField> {
                 expect_valid: false,
                 expected_output: None,
+                num_shares: 3,
             },
         )
         .unwrap();
@@ -718,6 +714,7 @@ mod tests {
             &ValidityTestCase {
                 expect_valid: true,
                 expected_output: Some(vec![TestField::from(1337)]),
+                num_shares: 3,
             },
         )
         .unwrap();
@@ -728,6 +725,7 @@ mod tests {
             &ValidityTestCase::<TestField> {
                 expect_valid: true,
                 expected_output: Some(vec![zero]),
+                num_shares: 3,
             },
         )
         .unwrap();
@@ -738,6 +736,7 @@ mod tests {
             &ValidityTestCase {
                 expect_valid: true,
                 expected_output: Some(vec![one]),
+                num_shares: 3,
             },
         )
         .unwrap();
@@ -748,6 +747,7 @@ mod tests {
             &ValidityTestCase::<TestField> {
                 expect_valid: true,
                 expected_output: Some(vec![TestField::from(237)]),
+                num_shares: 3,
             },
         )
         .unwrap();
@@ -759,6 +759,7 @@ mod tests {
             &ValidityTestCase::<TestField> {
                 expect_valid: false,
                 expected_output: None,
+                num_shares: 3,
             },
         )
         .unwrap();
@@ -769,6 +770,7 @@ mod tests {
             &ValidityTestCase::<TestField> {
                 expect_valid: false,
                 expected_output: None,
+                num_shares: 3,
             },
         )
         .unwrap();
@@ -852,6 +854,7 @@ mod tests {
             &ValidityTestCase::<TestField> {
                 expect_valid: true,
                 expected_output: Some(vec![one, zero, zero]),
+                num_shares: 3,
             },
         )
         .unwrap();
@@ -862,6 +865,7 @@ mod tests {
             &ValidityTestCase::<TestField> {
                 expect_valid: true,
                 expected_output: Some(vec![zero, one, zero]),
+                num_shares: 3,
             },
         )
         .unwrap();
@@ -872,6 +876,7 @@ mod tests {
             &ValidityTestCase::<TestField> {
                 expect_valid: true,
                 expected_output: Some(vec![zero, zero, one]),
+                num_shares: 3,
             },
         )
         .unwrap();
@@ -883,6 +888,7 @@ mod tests {
             &ValidityTestCase::<TestField> {
                 expect_valid: false,
                 expected_output: None,
+                num_shares: 3,
             },
         )
         .unwrap();
@@ -893,6 +899,7 @@ mod tests {
             &ValidityTestCase::<TestField> {
                 expect_valid: false,
                 expected_output: None,
+                num_shares: 3,
             },
         )
         .unwrap();
@@ -903,6 +910,7 @@ mod tests {
             &ValidityTestCase::<TestField> {
                 expect_valid: false,
                 expected_output: None,
+                num_shares: 3,
             },
         )
         .unwrap();
@@ -913,6 +921,7 @@ mod tests {
             &ValidityTestCase::<TestField> {
                 expect_valid: false,
                 expected_output: None,
+                num_shares: 3,
             },
         )
         .unwrap();
@@ -935,6 +944,7 @@ mod tests {
                 &ValidityTestCase::<TestField> {
                     expect_valid: true,
                     expected_output: Some(vec![one; len]),
+                    num_shares: 3,
                 },
             )
             .unwrap();
@@ -948,6 +958,7 @@ mod tests {
             &ValidityTestCase::<TestField> {
                 expect_valid: true,
                 expected_output: Some(vec![one; len]),
+                num_shares: 3,
             },
         )
         .unwrap();
@@ -961,6 +972,7 @@ mod tests {
                 &ValidityTestCase::<TestField> {
                     expect_valid: false,
                     expected_output: None,
+                    num_shares: 3,
                 },
             )
             .unwrap();
@@ -1028,8 +1040,21 @@ mod tests {
         assert_eq!(verifier.len(), typ.verifier_len());
         assert!(typ.decide(&verifier).unwrap());
     }
+}
 
-    fn flp_validity_test<T: Type>(
+#[cfg(test)]
+mod test_utils {
+    use super::*;
+    use crate::field::{random_vector, split_vector};
+
+    pub(crate) struct ValidityTestCase<F> {
+        pub(crate) expect_valid: bool,
+        pub(crate) expected_output: Option<Vec<F>>,
+        // Number of shares to split input and proofs into in `flp_test`.
+        pub(crate) num_shares: usize,
+    }
+
+    pub(crate) fn flp_validity_test<T: Type>(
         typ: &T,
         input: &[T::Field],
         t: &ValidityTestCase<T::Field>,
@@ -1101,24 +1126,24 @@ mod tests {
         }
 
         // Run distributed FLP.
-        let input_shares: Vec<Vec<T::Field>> = split_vector(input, NUM_SHARES)
+        let input_shares: Vec<Vec<T::Field>> = split_vector(input, t.num_shares)
             .unwrap()
             .into_iter()
             .collect();
 
-        let proof_shares: Vec<Vec<T::Field>> = split_vector(&proof, NUM_SHARES)
+        let proof_shares: Vec<Vec<T::Field>> = split_vector(&proof, t.num_shares)
             .unwrap()
             .into_iter()
             .collect();
 
-        let verifier: Vec<T::Field> = (0..NUM_SHARES)
+        let verifier: Vec<T::Field> = (0..t.num_shares)
             .map(|i| {
                 typ.query(
                     &input_shares[i],
                     &proof_shares[i],
                     &query_rand,
                     &joint_rand,
-                    NUM_SHARES,
+                    t.num_shares,
                 )
                 .unwrap()
             })
@@ -1197,3 +1222,5 @@ mod tests {
         Ok(())
     }
 }
+
+pub mod fixedpoint_l2;

--- a/src/flp/types/fixedpoint_l2.rs
+++ b/src/flp/types/fixedpoint_l2.rs
@@ -1,0 +1,786 @@
+// SPDX-License-Identifier: MPL-2.0
+
+//! A [`Type`] for summing vectors of fixed point numbers where the
+//! [L2 norm](https://en.wikipedia.org/wiki/Norm_(mathematics)#Euclidean_norm)
+//! of each vector is bounded by `1`.
+//!
+//! In the following a high level overview over the inner workings of this type
+//! is given and implementation details are discussed. It is not necessary for
+//! using the type, but it should be helpful when trying to understand the
+//! implementation.
+//!
+//! ### Overview
+//!
+//! Clients submit a vector of numbers whose values semantically lie in `[-1,1)`,
+//! together with a norm in the range `[0,1)`. The validation circuit checks that
+//! the norm of the vector is equal to the submitted norm, while the encoding
+//! guarantees that the submitted norm lies in the correct range.
+//!
+//! ### Different number encodings
+//!
+//! Let `n` denote the number of bits of the chosen fixed-point type.
+//! Numbers occur in 5 different representations:
+//! 1. Clients have a vector whose entries are fixed point numbers. Only those
+//!    fixed point types are supported where the numbers lie in the range
+//!    `[-1,1)`.
+//! 2. Because norm computation happens in the validation circuit, it is done
+//!    on entries encoded as field elements. That is, the same vector entries
+//!    are now represented by integers in the range `[0,2^n)`, where `-1` is
+//!    represented by `0` and `+1` by `2^n`.
+//! 3. Because the field is not necessarily exactly of size `2^n`, but might be
+//!    larger, it is not enough to encode a vector entry as in (2.) and submit
+//!    it to the aggregator. Instead, in order to make sure that all submitted
+//!    values are in the correct range, they are bit-encoded. (This is the same
+//!    as what happens in the [`Sum`](crate::flp::types::Sum) type.)
+//!    This means that instead of sending a field element in the range `[0,2^n)`,
+//!    we send `n` field elements representing the bit encoding. The validation
+//!    circuit can verify that all submitted "bits" are indeed either `0` or `1`.
+//! 4. The computed and submitted norms are treated similar to the vector
+//!    entries, but they have a different number of bits, namely `2n-2`.
+//! 5. As the aggregation result is a pointwise sum of the client vectors,
+//!    the numbers no longer (semantically) lie in the range `[-1,1)`, and cannot
+//!    be represented by the same fixed point type as the input. Instead the
+//!    decoding happens directly into a vector of floats.
+//!
+//! ### Fixed point encoding
+//!
+//! Submissions consist of encoded fixed-point numbers in `[-1,1)` represented as
+//! field elements in `[0,2^n)`, where n is the number of bits the fixed-point
+//! representation has. Encoding and decoding is handled by the associated functions
+//! of the [`CompatibleFloat`] trait. Semantically, the following function describes
+//! how a fixed-point value `x` in range `[-1,1)` is converted to a field integer:
+//! ```text
+//! enc : [-1,1) -> [0,2^n)
+//! enc(x) = 2^(n-1) * x + 2^(n-1)
+//! ```
+//! The inverse is:
+//! ```text
+//! dec : [0,2^n) -> [-1,1)
+//! dec(y) = (y - 2^(n-1)) * 2^(1-n)
+//! ```
+//! Note that these functions only make sense when interpreting all occuring
+//! numbers as real numbers. Since our signed fixed-point numbers are encoded as
+//! two's complement integers, the computation that happens in
+//! [`CompatibleFloat::to_field_integer`] is actually simpler.
+//!
+//! ### Norm computation
+//!
+//! The L2 norm of a vector xs of numbers in `[-1,1)` is given by:
+//! ```text
+//! norm(xs) = sqrt(sum_{x in xs} x^2)
+//! ```
+//! Instead of computing the norm, we make two simplifications:
+//! 1. We ignore the square root, which means that we are actually computing
+//!    the square of the norm.
+//! 2. We want our norm computation result to be integral and in the range `[0, 2^(2n-2))`,
+//!    so we can represent it in our field integers. We achieve this by multiplying with `2^(2n-2)`.
+//! This means that what is actually computed in this type is the following:
+//! ```text
+//! our_norm(xs) = 2^(2n-2) * norm(xs)^2
+//! ```
+//!
+//! Explained more visually, `our_norm()` is a composition of three functions:
+//!
+//! ```text
+//!                    map of dec()                    norm()          "mult with 2^(2n-2)"
+//!   vector of [0,2^n)    ->       vector of [-1,1)    ->       [0,1)         ->           [0,2^(2n-2))
+//!                                         ^                      ^
+//!                                         |                      |
+//!                     fractions with denom of 2^(n-1)     fractions with denom of 2^(2n-2)
+//! ```
+//! (Note that the ranges on the LHS and RHS of `"mult with 2^(2n-2)"` are stated
+//! here for vectors with a norm less than `1`.)
+//!
+//! Given a vector `ys` of numbers in the field integer encoding (in `[0,2^n)`),
+//! this gives the following equation:
+//! ```text
+//! our_norm_on_encoded(ys) = our_norm([dec(y) for y in ys])
+//!                         = 2^(2n-2) * sum_{y in ys} ((y - 2^(n-1)) * 2^(1-n))^2
+//!                         = 2^(2n-2)
+//!                           * sum_{y in ys} y^2 - 2*y*2^(n-1) + (2^(n-1))^2
+//!                           * 2^(1-n)^2
+//!                         = sum_{y in ys} y^2 - (2^n)*y + 2^(2n-2)
+//! ```
+//!
+//! Let `d` denote the number of the vector entries. The maximal value the result
+//! of `our_norm_on_encoded()` can take occurs in the case where all entries are
+//! `2^n-1`, in which case `d * 2^(2n-2)` is an upper bound to the result. The
+//! finite field used for encoding must be at least as large as this.
+//! For validating that the norm of the submitted vector lies in the correct
+//! range, consider the following:
+//!  - The result of `norm(xs)` should be in `[0,1)`.
+//!  - Thus, the result of `our_norm(xs)` should be in `[0,2^(2n-2))`.
+//!  - The result of `our_norm_on_encoded(ys)` should be in `[0,2^(2n-2))`.
+//! This means that the valid norms are exactly those representable with `2n-2`
+//! bits.
+//!
+//! ### Differences in the computation because of distribution
+//!
+//! In `decode_result()`, what is decoded are not the submitted entries of a
+//! single client, but the sum of the the entries of all clients. We have to
+//! take this into account, and cannot directly use the `dec()` function from
+//! above. Instead we use:
+//! ```text
+//! dec'(y) = y * 2^(1-n) - c
+//! ```
+//! Here, `c` is the number of clients.
+//!
+//! ### Naming in the implementation
+//!
+//! The following names are used:
+//!  - `self.bits_per_entry` is `n`
+//!  - `self.entries`        is `d`
+//!  - `self.bits_for_norm`  is `2n-2`
+//!
+//! ### Submission layout
+//!
+//! The client submissions contain a share of their vector and the norm
+//! they claim it has.
+//! The submission is a vector of field elements laid out as follows:
+//! ```text
+//! |---- bits_per_entry * entries ----|---- bits_for_norm ----|
+//!  ^                                  ^
+//!  \- the input vector entries        |
+//!                                     \- the encoded norm
+//! ```
+//!
+//! ### Value `1`
+//!
+//! We actually do not allow the submitted norm or vector entries to be
+//! exactly `1`, but rather require them to be strictly less. Supporting `1` would
+//! entail a more fiddly encoding and is not necessary for our usecase.
+//! The largest representable vector entry can be computed by `dec(2^n-1)`.
+//! For example, it is `0.999969482421875` for `n = 16`.
+
+pub mod compatible_float;
+
+use crate::field::{FieldElement, FieldElementExt};
+use crate::flp::gadgets::{BlindPolyEval, ParallelSumGadget, PolyEval};
+use crate::flp::types::fixedpoint_l2::compatible_float::CompatibleFloat;
+use crate::flp::{FlpError, Gadget, Type};
+use crate::polynomial::poly_range_check;
+use fixed::traits::Fixed;
+
+use std::{convert::TryFrom, convert::TryInto, fmt::Debug, marker::PhantomData};
+
+/// The fixed point vector sum data type. Each measurement is a vector of fixed point numbers of
+/// type `T`, and the aggregate result is the float vector of the sum of the measurements.
+///
+/// The validity circuit verifies that the L2 norm of each measurement is bounded by 1.
+///
+/// The [*fixed* crate](https://crates.io/crates/fixed) is used for fixed point numbers, in
+/// particular, exactly the following types are supported:
+/// `FixedI16<U15>`, `FixedI32<U31>` and `FixedI64<U63>`.
+///
+/// Depending on the size of the vector that needs to be transmitted, a corresponding field type has
+/// to be chosen for `F`. For a `n`-bit fixed point type and a `d`-dimensional vector, the field
+/// modulus needs to be larger than `d * 2^(2n-2)` so there are no overflows during norm validity
+/// computation.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct FixedPointBoundedL2VecSum<
+    T: Fixed,
+    F: FieldElement,
+    SPoly: ParallelSumGadget<F, PolyEval<F>> + Clone,
+    SBlindPoly: ParallelSumGadget<F, BlindPolyEval<F>> + Clone,
+> {
+    bits_per_entry: usize,
+    fi_bits_per_entry: F::Integer,
+    entries: usize,
+    bits_for_norm: usize,
+    range_01_checker: Vec<F>,
+    norm_summand_poly: Vec<F>,
+    phantom: PhantomData<(T, SPoly, SBlindPoly)>,
+
+    // range/position constants
+    range_norm_begin: usize,
+    range_norm_end: usize,
+
+    // configuration of parallel sum gadgets
+    gadget0_calls: usize,
+    gadget0_chunk_len: usize,
+    gadget1_calls: usize,
+    gadget1_chunk_len: usize,
+}
+
+impl<T, F, SPoly, SBlindPoly> FixedPointBoundedL2VecSum<T, F, SPoly, SBlindPoly>
+where
+    T: Fixed,
+    F: FieldElement,
+    SPoly: ParallelSumGadget<F, PolyEval<F>> + Clone,
+    SBlindPoly: ParallelSumGadget<F, BlindPolyEval<F>> + Clone,
+    u128: TryFrom<F::Integer>,
+{
+    /// Return a new [`FixedPointBoundedL2VecSum`] type parameter. Each value of this type is a
+    /// fixed point vector with `entries` entries.
+    pub fn new(entries: usize) -> Result<Self, FlpError> {
+        // (0) initialize constants
+        let fi_one = F::Integer::from(F::one());
+        let fi_two = fi_one + fi_one;
+
+        // (I) Check that the fixed type `F` is compatible.
+        //
+        // We only support fixed types that encode values in [-1,1].
+        // These have a single integer bit.
+        if <T as Fixed>::INT_NBITS != 1 {
+            return Err(FlpError::Encode(format!(
+                "Expected fixed point type with one integer bit, but got {}.",
+                <T as Fixed>::INT_NBITS,
+            )));
+        }
+
+        // Compute number of bits of an entry, and check that an entry fits
+        // into the field.
+        let bits_per_entry: usize = (<T as Fixed>::INT_NBITS + <T as Fixed>::FRAC_NBITS)
+            .try_into()
+            .map_err(|_| FlpError::Encode("Could not convert u32 into usize.".to_string()))?;
+        if !F::valid_integer_bitlength(bits_per_entry) {
+            return Err(FlpError::Encode(format!(
+                "fixed point type bit length ({}) too large for field modulus",
+                bits_per_entry,
+            )));
+        }
+        let fi_bits_per_entry: F::Integer = F::valid_integer_try_from(bits_per_entry)
+            .map_err(|_| FlpError::Encode("Could not create FieldInteger from usize even though size check was successful".to_string()))?;
+
+        // (II) Check that the field is large enough for the norm.
+        //
+        // Valid norms encoded as field integers lie in [0,2^(2*bits - 2)).
+        let bits_for_norm = 2 * bits_per_entry - 2;
+        if !F::valid_integer_bitlength(bits_for_norm) {
+            return Err(FlpError::Encode(format!(
+                "maximal norm bit length ({}) too large for field modulus",
+                bits_for_norm,
+            )));
+        }
+
+        // In order to compare the actual norm of the vector with the claimed
+        // norm, the field needs to be able to represent all numbers that can
+        // occur during the computation of the norm of any submitted vector,
+        // even if its norm is not bounded by 1. Because of our encoding, an
+        // upper bound to that value is `entries * 2^(2*bits - 2)` (see docs of
+        // compute_norm_of_entries for details). It has to fit into the field.
+        let err = Err(FlpError::Encode(format!(
+            "number of entries ({}) not compatible with field size",
+            entries,
+        )));
+
+        if let Some(val) = (entries as u128).checked_mul(1 << bits_for_norm) {
+            if let Ok(modulus) = u128::try_from(F::modulus()) {
+                if val >= modulus {
+                    return err;
+                }
+            } else {
+                return err;
+            }
+        } else {
+            return err;
+        }
+
+        // Construct the polynomial that computes a part of the norm for a
+        // single vector entry.
+        //
+        // the linear part is 2^n,
+        // the constant part is 2^(2n-2),
+        // the polynomial is:
+        //   p(y) = 2^(2n-2) + -(2^n) * y + 1 * y^2
+        let linear_part = fi_one << fi_bits_per_entry;
+        let constant_part = fi_one << (fi_bits_per_entry + fi_bits_per_entry - fi_two);
+        let norm_summand_poly = vec![F::from(constant_part), -F::from(linear_part), F::one()];
+
+        // Compute chunk length and number of calls for parallel sum gadgets.
+        let len0 = bits_per_entry * entries + bits_for_norm;
+        let gadget0_chunk_len = std::cmp::max(1, (len0 as f64).sqrt() as usize);
+        let gadget0_calls = (len0 + gadget0_chunk_len - 1) / gadget0_chunk_len;
+
+        let len1 = entries;
+        let gadget1_chunk_len = std::cmp::max(1, (len1 as f64).sqrt() as usize);
+        let gadget1_calls = (len1 + gadget1_chunk_len - 1) / gadget1_chunk_len;
+
+        Ok(Self {
+            bits_per_entry,
+            fi_bits_per_entry,
+            entries,
+            bits_for_norm,
+            range_01_checker: poly_range_check(0, 2),
+            norm_summand_poly,
+            phantom: PhantomData,
+
+            // range constants
+            range_norm_begin: entries * bits_per_entry,
+            range_norm_end: entries * bits_per_entry + bits_for_norm,
+
+            // configuration of parallel sum gadgets
+            gadget0_calls,
+            gadget0_chunk_len,
+            gadget1_calls,
+            gadget1_chunk_len,
+        })
+    }
+}
+
+impl<T, F, SPoly, SBlindPoly> Type for FixedPointBoundedL2VecSum<T, F, SPoly, SBlindPoly>
+where
+    T: Fixed + CompatibleFloat<F>,
+    F: FieldElement,
+    SPoly: ParallelSumGadget<F, PolyEval<F>> + Eq + Clone + 'static,
+    SBlindPoly: ParallelSumGadget<F, BlindPolyEval<F>> + Eq + Clone + 'static,
+{
+    const ID: u32 = 0xFFFF0000;
+    type Measurement = Vec<T>;
+    type AggregateResult = Vec<f64>;
+    type Field = F;
+
+    fn encode_measurement(&self, fp_entries: &Vec<T>) -> Result<Vec<F>, FlpError> {
+        // Convert the fixed-point encoded input values to field integers. We do
+        // this once here because we need them for encoding but also for
+        // computing the norm.
+        let integer_entries = fp_entries.iter().map(|x| x.to_field_integer());
+
+        // (I) Vector entries.
+        // Encode the integer entries bitwise, and write them into the `encoded`
+        // vector.
+        let mut encoded: Vec<F> =
+            vec![F::zero(); self.bits_per_entry * self.entries + self.bits_for_norm];
+        for (l, entry) in integer_entries.clone().enumerate() {
+            F::fill_with_bitvector_representation(
+                &entry,
+                &mut encoded[l * self.bits_per_entry..(l + 1) * self.bits_per_entry],
+            )?;
+        }
+
+        // (II) Vector norm.
+        // Compute the norm of the input vector.
+        let field_entries = integer_entries.map(|x| F::from(x));
+        let norm = compute_norm_of_entries(field_entries, self.fi_bits_per_entry)?;
+        let norm_int = <F as FieldElement>::Integer::from(norm);
+
+        // Write the norm into the `entries` vector.
+        F::fill_with_bitvector_representation(
+            &norm_int,
+            &mut encoded[self.range_norm_begin..self.range_norm_end],
+        )?;
+
+        Ok(encoded)
+    }
+
+    fn decode_result(&self, data: &[F], num_measurements: usize) -> Result<Vec<f64>, FlpError> {
+        if data.len() != self.entries {
+            return Err(FlpError::Decode("unexpected input length".into()));
+        }
+        let num_measurements = match u128::try_from(num_measurements) {
+            Ok(m) => m,
+            Err(_) => {
+                return Err(FlpError::Decode(
+                    "number of clients is too large to fit into u128".into(),
+                ))
+            }
+        };
+        let mut res = Vec::with_capacity(data.len());
+        for d in data {
+            let decoded = <T as CompatibleFloat<F>>::to_float(*d, num_measurements);
+            res.push(decoded);
+        }
+        Ok(res)
+    }
+
+    fn gadget(&self) -> Vec<Box<dyn Gadget<F>>> {
+        // This gadget checks that a field element is zero or one.
+        // It is called for all the "bits" of the encoded entries
+        // and of the encoded norm.
+        let gadget0 = SBlindPoly::new(
+            BlindPolyEval::new(self.range_01_checker.clone(), self.gadget0_calls),
+            self.gadget0_chunk_len,
+        );
+
+        // This gadget computes the square of a field element.
+        // It is called on each entry during norm computation.
+        let gadget1 = SPoly::new(
+            PolyEval::new(self.norm_summand_poly.clone(), self.gadget1_calls),
+            self.gadget1_chunk_len,
+        );
+
+        vec![Box::new(gadget0), Box::new(gadget1)]
+    }
+
+    fn valid(
+        &self,
+        g: &mut Vec<Box<dyn Gadget<F>>>,
+        input: &[F],
+        joint_rand: &[F],
+        num_shares: usize,
+    ) -> Result<F, FlpError> {
+        self.valid_call_check(input, joint_rand)?;
+
+        let f_num_shares = F::from(F::valid_integer_try_from(num_shares)?);
+        let constant_part_multiplier = F::one() / f_num_shares;
+
+        // Ensure that all submitted field elements are either 0 or 1.
+        // This is done for:
+        //  (I) all vector entries (each of them encoded in `self.bits_per_entry`
+        //     field elements)
+        //  (II) the submitted norm (encoded in `self.bits_for_norm` field
+        //    elements)
+        //
+        // Since all input vector entry (field-)bits, as well as the norm bits,
+        // are contiguous, we do the check directly for all bits from 0 to
+        // entries*bits_per_entry + bits_for_norm.
+        //
+        // In order to keep the proof size down, this is done using the
+        // `ParallelSum` gadget. For a similar application see the `CountVec`
+        // type.
+        let range_check = {
+            let mut outp = F::zero();
+            let mut r = joint_rand[0];
+            let mut padded_chunk = vec![F::zero(); 2 * self.gadget0_chunk_len];
+
+            for chunk in input[..self.range_norm_end].chunks(self.gadget0_chunk_len) {
+                let d = chunk.len();
+                // We use the BlindPolyEval gadget, so the chunk needs to have
+                // the i-th input at position 2*i and it's random factor at po-
+                // sition 2*i+1.
+                for i in 0..self.gadget0_chunk_len {
+                    if i < d {
+                        padded_chunk[2 * i] = chunk[i];
+                    } else {
+                        // If the chunk is smaller than the padded_chunk length,
+                        // copy the last element into all remaining slots.
+                        padded_chunk[2 * i] = chunk[d - 1];
+                    }
+                    padded_chunk[2 * i + 1] = r * constant_part_multiplier;
+                    r *= joint_rand[0];
+                }
+
+                outp += g[0].call(&padded_chunk)?;
+            }
+
+            outp
+        };
+
+        // Compute the norm of the entries and ensure that it is the same as the
+        // submitted norm. There are exactly enough bits such that a submitted
+        // norm is always a valid norm (semantically in the range [0,1]). By
+        // comparing submitted with actual, we make sure the actual norm is
+        // valid.
+        //
+        // The function to compute here (see explanatory comment at the top) is
+        //   norm(ys) = sum_{y in ys} y^2 - (2^n)*y + 2^(2n-2)
+        //
+        // This is done by the `ParallelSum` gadget `g[1]`, which evaluates the
+        // inner polynomial on each (decoded) vector entry, and then sums the
+        // results. Note that the gadget is not called on the whole vector at
+        // once, but sequentially on chunks of size `self.gadget1_chunk_len` of
+        // it. The results of these calls are accumulated in the `outp` variable.
+        //
+        // decode the bit-encoded entries into elements in the range [0,2^n):
+        let decoded_entries: Result<Vec<_>, _> = input[0..self.entries * self.bits_per_entry]
+            .chunks(self.bits_per_entry)
+            .map(F::decode_from_bitvector_representation)
+            .collect();
+
+        // run parallel sum gadget on the decoded entries
+        let computed_norm = {
+            let mut outp = F::zero();
+
+            for chunk in decoded_entries?.chunks(self.gadget1_chunk_len) {
+                let d = chunk.len();
+                if d == self.gadget1_chunk_len {
+                    outp += g[1].call(chunk)?;
+                } else {
+                    // If the chunk is smaller than the chunk length, extend
+                    // chunk with zeros.
+                    let mut padded_chunk: Vec<_> = chunk.to_owned();
+                    padded_chunk.resize(self.gadget1_chunk_len, F::zero());
+                    outp += g[1].call(&padded_chunk)?;
+                }
+            }
+
+            outp
+        };
+
+        // The submitted norm is also decoded from its bit-encoding, and
+        // compared with the computed norm.
+        let submitted_norm_enc = &input[self.range_norm_begin..self.range_norm_end];
+        let submitted_norm = F::decode_from_bitvector_representation(submitted_norm_enc)?;
+
+        let norm_check = computed_norm - submitted_norm;
+
+        // Finally, we require both checks to be successful by computing a
+        // random linear combination of them.
+        let out = joint_rand[1] * range_check + (joint_rand[1] * joint_rand[1]) * norm_check;
+        Ok(out)
+    }
+
+    fn truncate(&self, input: Vec<F>) -> Result<Vec<Self::Field>, FlpError> {
+        self.truncate_call_check(&input)?;
+
+        let mut decoded_vector = vec![];
+
+        for i_entry in 0..self.entries {
+            let start = i_entry * self.bits_per_entry;
+            let end = (i_entry + 1) * self.bits_per_entry;
+
+            let decoded = F::decode_from_bitvector_representation(&input[start..end])?;
+            decoded_vector.push(decoded);
+        }
+        Ok(decoded_vector)
+    }
+
+    fn input_len(&self) -> usize {
+        self.bits_per_entry * self.entries + self.bits_for_norm
+    }
+
+    fn proof_len(&self) -> usize {
+        // computed via
+        // `gadget.arity() + gadget.degree()
+        //   * ((1 + gadget.calls()).next_power_of_two() - 1) + 1;`
+        let proof_gadget_0 = (self.gadget0_chunk_len * 2)
+            + 3 * ((1 + self.gadget0_calls).next_power_of_two() - 1)
+            + 1;
+        let proof_gadget_1 =
+            (self.gadget1_chunk_len) + 2 * ((1 + self.gadget1_calls).next_power_of_two() - 1) + 1;
+
+        proof_gadget_0 + proof_gadget_1
+    }
+
+    fn verifier_len(&self) -> usize {
+        self.gadget0_chunk_len * 2 + self.gadget1_chunk_len + 3
+    }
+
+    fn output_len(&self) -> usize {
+        self.entries
+    }
+
+    fn joint_rand_len(&self) -> usize {
+        2
+    }
+
+    fn prove_rand_len(&self) -> usize {
+        self.gadget0_chunk_len * 2 + self.gadget1_chunk_len
+    }
+
+    fn query_rand_len(&self) -> usize {
+        2
+    }
+}
+
+/// Compute the square of the L2 norm of a vector of fixed-point numbers encoded as field elements.
+///
+/// * `entries` - Iterator over the vector entries.
+/// * `bits_per_entry` - Number of bits one entry has.
+fn compute_norm_of_entries<F, Fs>(entries: Fs, fi_bits_per_entry: F::Integer) -> Result<F, FlpError>
+where
+    F: FieldElement,
+    Fs: IntoIterator<Item = F>,
+{
+    let fi_one = F::Integer::from(F::one());
+    let fi_two = fi_one + fi_one;
+
+    // The value that is computed here is:
+    //    sum_{y in entries} 2^(2n-2) + -(2^n) * y + 1 * y^2
+    //
+    // Check out the norm computation bit in the explanatory comment block for
+    // more information.
+    //
+    // Initialize `norm_accumulator`.
+    let mut norm_accumulator = F::zero();
+
+    // constants
+    let linear_part = fi_one << fi_bits_per_entry; // = 2^(2n-2)
+    let constant_part = fi_one << (fi_bits_per_entry + fi_bits_per_entry - fi_two); // = 2^n
+
+    // Add term for a given `entry` to `norm_accumulator`.
+    for entry in entries.into_iter() {
+        let summand = entry * entry + F::from(constant_part) - F::from(linear_part) * (entry);
+        norm_accumulator += summand;
+    }
+    Ok(norm_accumulator)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::field::{random_vector, Field128};
+    use crate::flp::gadgets::ParallelSum;
+    use crate::flp::types::test_utils::{flp_validity_test, ValidityTestCase};
+    use fixed::types::extra::{U127, U14, U63};
+    use fixed::{FixedI128, FixedI16, FixedI64};
+    use fixed_macro::fixed;
+
+    #[test]
+    fn test_bounded_fpvec_sum_parallel() {
+        let fp16_4_inv = fixed!(0.25: I1F15);
+        let fp16_8_inv = fixed!(0.125: I1F15);
+        let fp16_16_inv = fixed!(0.0625: I1F15);
+
+        let fp16_vec = vec![fp16_4_inv, fp16_8_inv, fp16_16_inv];
+
+        // the encoded vector has the following entries:
+        // enc(0.25) =  2^(n-1) * 0.25 + 2^(n-1)     = 40960
+        // enc(0.125) =  2^(n-1) * 0.125 + 2^(n-1)   = 36864
+        // enc(0.0625) =  2^(n-1) * 0.0625 + 2^(n-1) = 34816
+        test_fixed(fp16_vec, vec![40960, 36864, 34816]);
+
+        let fp32_4_inv = fixed!(0.25: I1F31);
+        let fp32_8_inv = fixed!(0.125: I1F31);
+        let fp32_16_inv = fixed!(0.0625: I1F31);
+
+        let fp32_vec = vec![fp32_4_inv, fp32_8_inv, fp32_16_inv];
+        // computed as above but with n=32
+        test_fixed(fp32_vec, vec![2684354560, 2415919104, 2281701376]);
+
+        let fp64_4_inv = fixed!(0.25: I1F63);
+        let fp64_8_inv = fixed!(0.125: I1F63);
+        let fp64_16_inv = fixed!(0.0625: I1F63);
+
+        let fp64_vec = vec![fp64_4_inv, fp64_8_inv, fp64_16_inv];
+        // computed as above but with n=64
+        test_fixed(
+            fp64_vec,
+            vec![
+                11529215046068469760,
+                10376293541461622784,
+                9799832789158199296,
+            ],
+        );
+
+        fn test_fixed<F: Fixed>(fp_vec: Vec<F>, enc_vec: Vec<u128>)
+        where
+            F: CompatibleFloat<Field128>,
+        {
+            let n: usize = (F::INT_NBITS + F::FRAC_NBITS).try_into().unwrap();
+
+            type Ps = ParallelSum<Field128, PolyEval<Field128>>;
+            type Psb = ParallelSum<Field128, BlindPolyEval<Field128>>;
+
+            let vsum: FixedPointBoundedL2VecSum<F, Field128, Ps, Psb> =
+                FixedPointBoundedL2VecSum::new(3).unwrap();
+            let one = Field128::one();
+            // Round trip
+            assert_eq!(
+                vsum.decode_result(
+                    &vsum
+                        .truncate(vsum.encode_measurement(&fp_vec).unwrap())
+                        .unwrap(),
+                    1
+                )
+                .unwrap(),
+                vec!(0.25, 0.125, 0.0625)
+            );
+
+            // encoded norm does not match computed norm
+            let mut input: Vec<Field128> = vsum.encode_measurement(&fp_vec).unwrap();
+            assert_eq!(input[0], Field128::zero());
+            input[0] = one; // it was zero
+            flp_validity_test(
+                &vsum,
+                &input,
+                &ValidityTestCase::<Field128> {
+                    expect_valid: false,
+                    expected_output: Some(vec![
+                        Field128::from(enc_vec[0] + 1), // = enc(0.25) + 2^0
+                        Field128::from(enc_vec[1]),
+                        Field128::from(enc_vec[2]),
+                    ]),
+                    num_shares: 3,
+                },
+            )
+            .unwrap();
+
+            // encoding contains entries that are not zero or one
+            let mut input2: Vec<Field128> = vsum.encode_measurement(&fp_vec).unwrap();
+            input2[0] = one + one;
+            flp_validity_test(
+                &vsum,
+                &input2,
+                &ValidityTestCase::<Field128> {
+                    expect_valid: false,
+                    expected_output: Some(vec![
+                        Field128::from(enc_vec[0] + 2), // = enc(0.25) + 2*2^0
+                        Field128::from(enc_vec[1]),
+                        Field128::from(enc_vec[2]),
+                    ]),
+                    num_shares: 3,
+                },
+            )
+            .unwrap();
+
+            // norm is too big
+            // 2^n - 1, the field element encoded by the all-1 vector
+            let one_enc = Field128::from(((2_u128) << (n - 1)) - 1);
+            flp_validity_test(
+                &vsum,
+                &vec![one; 3 * n + 2 * n - 2], // all vector entries and the norm are all-1-vectors
+                &ValidityTestCase::<Field128> {
+                    expect_valid: false,
+                    expected_output: Some(vec![one_enc; 3]),
+                    num_shares: 3,
+                },
+            )
+            .unwrap();
+
+            // invalid submission length, should be 3n + (2*n - 2) for a
+            // 3-element n-bit vector. 3*n bits for 3 entries, (2*n-2) for norm.
+            let joint_rand = random_vector(vsum.joint_rand_len()).unwrap();
+            vsum.valid(
+                &mut vsum.gadget(),
+                &vec![one; 3 * n + 2 * n - 1],
+                &joint_rand,
+                1,
+            )
+            .unwrap_err();
+
+            // test that the zero vector has correct norm, where zero is encoded as:
+            // enc(0) = 2^(n-1) * 0 + 2^(n-1)
+            let zero_enc = Field128::from((2_u128) << (n - 2));
+            {
+                let entries = vec![zero_enc; 3];
+                let norm = compute_norm_of_entries(entries, vsum.fi_bits_per_entry).unwrap();
+                let expected_norm = Field128::from(0);
+                assert_eq!(norm, expected_norm);
+            }
+
+            // ensure that no overflow occurs with largest possible norm
+            {
+                // the largest possible entries (2^n-1)
+                let entries = vec![one_enc; 3];
+                let norm = compute_norm_of_entries(entries, vsum.fi_bits_per_entry).unwrap();
+                let expected_norm = Field128::from(3 * (1 + (1 << (2 * n - 2)) - (1 << n)));
+                // = 3 * ((2^n-1)^2 - (2^n-1)*2^16 + 2^(2*n-2))
+                assert_eq!(norm, expected_norm);
+
+                // the smallest possible entries (0)
+                let entries = vec![Field128::from(0), Field128::from(0), Field128::from(0)];
+                let norm = compute_norm_of_entries(entries, vsum.fi_bits_per_entry).unwrap();
+                let expected_norm = Field128::from(3 * (1 << (2 * n - 2)));
+                // = 3 * (0^2 - 0*2^n + 2^(2*n-2))
+                assert_eq!(norm, expected_norm);
+            }
+        }
+
+        // invalid initialization
+        // fixed point too large
+        <FixedPointBoundedL2VecSum<
+            FixedI128<U127>,
+            Field128,
+            ParallelSum<Field128, PolyEval<Field128>>,
+            ParallelSum<Field128, BlindPolyEval<Field128>>,
+        >>::new(3)
+        .unwrap_err();
+        // vector too large
+        <FixedPointBoundedL2VecSum<
+            FixedI64<U63>,
+            Field128,
+            ParallelSum<Field128, PolyEval<Field128>>,
+            ParallelSum<Field128, BlindPolyEval<Field128>>,
+        >>::new(30000000000)
+        .unwrap_err();
+        // fixed point type has more than one int bit
+        <FixedPointBoundedL2VecSum<
+            FixedI16<U14>,
+            Field128,
+            ParallelSum<Field128, PolyEval<Field128>>,
+            ParallelSum<Field128, BlindPolyEval<Field128>>,
+        >>::new(3)
+        .unwrap_err();
+    }
+}

--- a/src/flp/types/fixedpoint_l2/compatible_float.rs
+++ b/src/flp/types/fixedpoint_l2/compatible_float.rs
@@ -1,0 +1,93 @@
+// SPDX-License-Identifier: MPL-2.0
+
+//! Implementations of encoding fixed point types as field elements and field elements as floats
+//! for the [`FixedPointBoundedL2VecSum`](crate::flp::types::fixedpoint_l2::FixedPointBoundedL2VecSum) type.
+
+use crate::field::{Field128, FieldElement};
+use fixed::types::extra::{U15, U31, U63};
+use fixed::{FixedI16, FixedI32, FixedI64};
+
+/// Assign a `Float` type to this type and describe how to represent this type as an integer of the
+/// given field, and how to represent a field element as the assigned `Float` type.
+pub trait CompatibleFloat<F: FieldElement> {
+    /// Represent a field element as `Float`, given the number of clients `c`.
+    fn to_float(t: F, c: u128) -> f64;
+
+    /// Represent a value of this type as an integer in the given field.
+    fn to_field_integer(&self) -> <F as FieldElement>::Integer;
+}
+
+impl CompatibleFloat<Field128> for FixedI16<U15> {
+    fn to_float(d: Field128, c: u128) -> f64 {
+        to_float_bits(d, c, 16)
+    }
+
+    fn to_field_integer(&self) -> <Field128 as FieldElement>::Integer {
+        //signed two's complement integer representation
+        let i: i16 = self.to_bits();
+        // reinterpret as unsigned
+        let u = i as u16;
+        // invert the left-most bit to de-two-complement
+        u128::from(u ^ (1 << 15))
+    }
+}
+
+impl CompatibleFloat<Field128> for FixedI32<U31> {
+    fn to_float(d: Field128, c: u128) -> f64 {
+        to_float_bits(d, c, 32)
+    }
+
+    fn to_field_integer(&self) -> <Field128 as FieldElement>::Integer {
+        //signed two's complement integer representation
+        let i: i32 = self.to_bits();
+        // reinterpret as unsigned
+        let u = i as u32;
+        // invert the left-most bit to de-two-complement
+        u128::from(u ^ (1 << 31))
+    }
+}
+
+impl CompatibleFloat<Field128> for FixedI64<U63> {
+    fn to_float(d: Field128, c: u128) -> f64 {
+        to_float_bits(d, c, 64)
+    }
+
+    fn to_field_integer(&self) -> <Field128 as FieldElement>::Integer {
+        //signed two's complement integer representation
+        let i: i64 = self.to_bits();
+        // reinterpret as unsigned
+        let u = i as u64;
+        // invert the left-most bit to de-two-complement
+        u128::from(u ^ (1 << 63))
+    }
+}
+
+/// Return an `f64` representation of the field element `s`, assuming it is the computation result
+/// of a `c`-client fixed point vector summation with `n` fractional bits.
+fn to_float_bits(s: Field128, c: u128, n: i32) -> f64 {
+    // get integer representation of field element
+    let s_int: u128 = <Field128 as FieldElement>::Integer::from(s);
+
+    // to decode a single integer, we'd use the function
+    //   dec(y) = (y - 2^(n-1)) * 2^(1-n) = y * 2^(1-n) - 1
+    // as s is the sum of c encoded vector entries where c is the number of
+    // clients, we have to compute instead
+    //   s * 2^(1-n) - c
+    //
+    // Furthermore, for better numerical stability, we reformulate this as
+    //   = (s - c*2^(n-1)) * 2^(1-n)
+    // where the subtraction of `c` is done on integers and only afterwards
+    // the conversion to floats is done.
+    //
+    // Since the RHS of the substraction may be larger than the LHS
+    // (when the number we are decoding is going to be negative),
+    // yet we are dealing with unsigned 128-bit integers, we manually
+    // check for the resulting sign while ensuring that the subtraction
+    // does not underflow.
+    let (a, b, sign) = match (s_int, c << (n - 1)) {
+        (x, y) if x < y => (y, x, -1.0f64),
+        (x, y) => (x, y, 1.0f64),
+    };
+
+    ((a - b) as f64) * sign * f64::powi(2.0, 1 - n)
+}


### PR DESCRIPTION
As announced in #257, we added a feature for our custom type to compute the sum of fixed point vectors, with a circuit for verifying their L2 norm is bounded by 1. A couple of questions from our side:

- In the [unit tests in prio3.rs](https://github.com/dpsa-project/libprio-rs/blob/835fbb1c28c74b275bc0c133c4a3ef7b37b99151/src/vdaf/prio3.rs#L1090-L1123), we duplicate code from the `Sum` type testing all sorts of invalid inputs for our type. Does that make sense?
- We chose [`verifier_len`](https://github.com/dpsa-project/libprio-rs/blob/835fbb1c28c74b275bc0c133c4a3ef7b37b99151/src/flp/types/fixedpoint_l2.rs#L433-L435) of our type by doing what we were told by [an error message from the `query` function](https://github.com/dpsa-project/libprio-rs/blob/835fbb1c28c74b275bc0c133c4a3ef7b37b99151/src/flp.rs#L461) associated to the `Type` trait, but had difficulties to understand the reason by looking at the [documentation](https://github.com/dpsa-project/libprio-rs/blob/835fbb1c28c74b275bc0c133c4a3ef7b37b99151/src/flp.rs#L189) and the code that produces the error. Did we do it right?
- We refactored the tests in [`types.rs`](https://github.com/dpsa-project/libprio-rs/blob/835fbb1c28c74b275bc0c133c4a3ef7b37b99151/src/flp/types.rs#L1005-L1185) to enable using `ValidityTestCase` and `flp_validity_test` in our file. The two are now `pub(crate)`, but still have the `test` attribute. Is that satisfactory?

Looking forward to your comments! :)

Co-Authored-By: Olivia <ovi@posteo.de>
Co-Authored-By: Maxim Urschumzew <u.maxim@live.de>