### PR TITLE
Run CI using both MSRV and stable Rust toolchains

### DIFF
--- a/.github/workflows/ci-build.yml
+++ b/.github/workflows/ci-build.yml
@@ -11,26 +11,38 @@ env:
   RUSTFLAGS: "-D warnings"
 
 jobs:
-  lint:
-    runs-on: ubuntu-latest
-    steps:
-    - uses: actions/checkout@v2
-    - name: Lint
-      run: cargo fmt --message-format human -- --check
-
   docs:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v2
+    - name: Install Rust toolchain
+      uses: actions-rs/toolchain@v1
+      with:
+        toolchain: stable
+        default: true
     - name: Docs
       run: cargo doc --all-features
       env:
         RUSTDOCFLAGS: -Dwarnings
 
   build-binaries:
+    strategy:
+      matrix:
+        rust-toolchain: [
+          # MSRV from Cargo.toml
+          "1.58",
+          "stable",
+        ]
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v2
+    - name: Install Rust toolchain
+      uses: actions-rs/toolchain@v1
+      with:
+        toolchain: ${{ matrix.rust-toolchain }}
+        profile: minimal
+        override: true
+        components: clippy
     - name: Build
       run: cargo build --verbose --package prio-binaries
     - name: Clippy
@@ -51,9 +63,23 @@ jobs:
           "--features=prio2,multithreaded",
           "--features=prio2,test-util,multithreaded",
         ]
+        rust-toolchain: [
+          # MSRV from Cargo.toml
+          "1.58",
+          "stable",
+        ]
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v2
+    - name: Install Rust toolchain
+      uses: actions-rs/toolchain@v1
+      with:
+        toolchain: ${{ matrix.rust-toolchain }}
+        profile: minimal
+        override: true
+        components: clippy, rustfmt
+    - name: Lint
+      run: cargo fmt --message-format human -- --check
     - name: Clippy
       run: cargo clippy --workspace --all-targets ${{ matrix.features }}
     - name: Build crate

--- a/.github/workflows/publish-crate.yml
+++ b/.github/workflows/publish-crate.yml
@@ -9,6 +9,11 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v2
+    - name: Install Rust toolchain
+      uses: actions-rs/toolchain@v1
+      with:
+        toolchain: stable
+        override: true
     - run: cargo publish
       env:
         CARGO_REGISTRY_TOKEN: ${{ secrets.LE_AUTOMATON_CRATES_IO_API_TOKEN }}

--- a/src/vdaf/poplar1.rs
+++ b/src/vdaf/poplar1.rs
@@ -440,6 +440,7 @@ where
     type PrepareShare = Poplar1PrepareMessage<I::Field>;
     type PrepareMessage = Poplar1PrepareMessage<I::Field>;
 
+    #[allow(clippy::type_complexity)]
     fn prepare_init(
         &self,
         verify_key: &[u8; L],

--- a/src/vdaf/prio3.rs
+++ b/src/vdaf/prio3.rs
@@ -663,6 +663,7 @@ where
 
     /// Begins the Prep process with the other aggregators. The result of this process is
     /// the aggregator's output share.
+    #[allow(clippy::type_complexity)]
     fn prepare_init(
         &self,
         verify_key: &[u8; L],


### PR DESCRIPTION
We specify a minimum supported Rust version of 1.58 in `Cargo.toml`, but
were not guaranteeing that crate `prio` actually can build with that
toolchain, instead using whatever the Github Actions Ubuntu runner
happens to have. We now use a matrix to run tests and builds with both
the explicit MSRV, and whatever the current stable toolchain is.

Resolves #284