### PR TITLE
Preparations for VDAF draft 03 breaking changes

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -726,7 +726,7 @@ checksum = "ac74c624d6b2d21f425f752262f42188365d7b8ff1aff74c82e45136510a4857"
 
 [[package]]
 name = "prio"
-version = "0.8.3"
+version = "0.9.0"
 dependencies = [
  "aes 0.8.1",
  "aes-gcm",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "prio"
-version = "0.8.3"
+version = "0.9.0"
 authors = ["Josh Aas <jaas@kflag.net>", "Tim Geoghegan <timg@letsencrypt.org>", "Christopher Patton <cpatton@cloudflare.com", "Karl Tarbe <tarbe@apple.com>"]
 edition = "2018"
 description = "Implementation of the Prio aggregation system core: https://crypto.stanford.edu/prio/"

--- a/src/flp.rs
+++ b/src/flp.rs
@@ -1,12 +1,13 @@
 // SPDX-License-Identifier: MPL-2.0
 
 //! Implementation of the generic Fully Linear Proof (FLP) system specified in
-//! [[draft-irtf-cfrg-vdaf-01]]. This is the main building block of [`Prio3`](crate::vdaf::prio3).
+//! [[draft-irtf-cfrg-vdaf-03]]. This is the main building block of [`Prio3`](crate::vdaf::prio3).
 //!
 //! The FLP is derived for any implementation of the [`Type`] trait. Such an implementation
 //! specifies a validity circuit that defines the set of valid measurements, as well as the finite
 //! field in which the validity circuit is evaluated. It also determines how raw measurements are
-//! encoded as inputs to the validity circuit.
+//! encoded as inputs to the validity circuit, and how aggregates are decoded from sums of
+//! measurements.
 //!
 //! # Overview
 //!
@@ -43,7 +44,7 @@
 //! assert!(count.decide(&verifier).unwrap());
 //! ```
 //!
-//! [draft-irtf-cfrg-vdaf-01]: https://datatracker.ietf.org/doc/draft-irtf-cfrg-vdaf/01/
+//! [draft-irtf-cfrg-vdaf-03]: https://datatracker.ietf.org/doc/draft-irtf-cfrg-vdaf/03/
 
 use crate::fft::{discrete_fourier_transform, discrete_fourier_transform_inv_finish, FftError};
 use crate::field::{FieldElement, FieldError};

--- a/src/vdaf.rs
+++ b/src/vdaf.rs
@@ -1,9 +1,9 @@
 // SPDX-License-Identifier: MPL-2.0
 
 //! Verifiable Distributed Aggregation Functions (VDAFs) as described in
-//! [[draft-irtf-cfrg-vdaf-01]].
+//! [[draft-irtf-cfrg-vdaf-03]].
 //!
-//! [draft-irtf-cfrg-vdaf-01]: https://datatracker.ietf.org/doc/draft-irtf-cfrg-vdaf/01/
+//! [draft-irtf-cfrg-vdaf-03]: https://datatracker.ietf.org/doc/draft-irtf-cfrg-vdaf/03/
 
 use crate::codec::{CodecError, Decode, Encode, ParameterizedDecode};
 use crate::field::{FieldElement, FieldError};

--- a/src/vdaf/poplar1.rs
+++ b/src/vdaf/poplar1.rs
@@ -2,7 +2,7 @@
 
 //! **(NOTE: This module is experimental. Applications should not use it yet.)** This module
 //! partially implements the core component of the Poplar protocol [[BBCG+21]]. Named for the
-//! Poplar1 [[draft-irtf-cfrg-vdaf-01]], the specification of this VDAF is under active
+//! Poplar1 section of [[draft-irtf-cfrg-vdaf-03]], the specification of this VDAF is under active
 //! development. Thus this code should be regarded as experimental and not compliant with any
 //! existing speciication.
 //!
@@ -16,7 +16,7 @@
 //! merely intended as a proof-of-concept.
 //!
 //! [BBCG+21]: https://eprint.iacr.org/2021/017
-//! [draft-irtf-cfrg-vdaf-01]: https://datatracker.ietf.org/doc/draft-irtf-cfrg-vdaf/01/
+//! [draft-irtf-cfrg-vdaf-03]: https://datatracker.ietf.org/doc/draft-irtf-cfrg-vdaf/03/
 
 use std::cmp::Ordering;
 use std::collections::{BTreeMap, BTreeSet};
@@ -320,7 +320,7 @@ impl<I, P, const L: usize> Poplar1<I, P, L> {
     /// deriving pseudorandom sequences of field elements, and a input length in bits, corresponding
     /// to `BITS` as defined in the [VDAF specification][1].
     ///
-    /// [1]: https://datatracker.ietf.org/doc/draft-irtf-cfrg-vdaf/01/
+    /// [1]: https://datatracker.ietf.org/doc/draft-irtf-cfrg-vdaf/03/
     pub fn new(bits: usize) -> Self {
         Self {
             input_length: bits,

--- a/src/vdaf/prg.rs
+++ b/src/vdaf/prg.rs
@@ -1,8 +1,8 @@
 // SPDX-License-Identifier: MPL-2.0
 
-//! Implementations of PRGs specified in [[draft-irtf-cfrg-vdaf-01]].
+//! Implementations of PRGs specified in [[draft-irtf-cfrg-vdaf-03]].
 //!
-//! [draft-irtf-cfrg-vdaf-01]: https://datatracker.ietf.org/doc/draft-irtf-cfrg-vdaf/01/
+//! [draft-irtf-cfrg-vdaf-03]: https://datatracker.ietf.org/doc/draft-irtf-cfrg-vdaf/03/
 
 use crate::vdaf::{CodecError, Decode, Encode};
 #[cfg(feature = "crypto-dependencies")]
@@ -96,9 +96,9 @@ pub trait SeedStream {
     fn fill(&mut self, buf: &mut [u8]);
 }
 
-/// A pseudorandom generator (PRG) with the interface specified in [[draft-irtf-cfrg-vdaf-01]].
+/// A pseudorandom generator (PRG) with the interface specified in [[draft-irtf-cfrg-vdaf-03]].
 ///
-/// [draft-irtf-cfrg-vdaf-01]: https://datatracker.ietf.org/doc/draft-irtf-cfrg-vdaf/01/
+/// [draft-irtf-cfrg-vdaf-03]: https://datatracker.ietf.org/doc/draft-irtf-cfrg-vdaf/03/
 pub trait Prg<const L: usize>: Clone + Debug {
     /// The type of stream produced by this PRG.
     type SeedStream: SeedStream;
@@ -129,9 +129,9 @@ pub trait Prg<const L: usize>: Clone + Debug {
     }
 }
 
-/// The PRG based on AES128 as specified in [[draft-irtf-cfrg-vdaf-01]].
+/// The PRG based on AES128 as specified in [[draft-irtf-cfrg-vdaf-03]].
 ///
-/// [draft-irtf-cfrg-vdaf-01]: https://datatracker.ietf.org/doc/draft-irtf-cfrg-vdaf/01/
+/// [draft-irtf-cfrg-vdaf-03]: https://datatracker.ietf.org/doc/draft-irtf-cfrg-vdaf/03/
 #[derive(Clone, Debug)]
 #[cfg(feature = "crypto-dependencies")]
 pub struct PrgAes128(Cmac<Aes128>);

--- a/src/vdaf/prio3.rs
+++ b/src/vdaf/prio3.rs
@@ -54,7 +54,7 @@ use std::marker::PhantomData;
 
 // Domain-separation tag used to bind the VDAF operations to the document version. This will be
 // reved with each draft with breaking changes.
-const VERS_PRIO3: &[u8] = b"vdaf-01 prio3";
+const VERS_PRIO3: &[u8] = b"vdaf-03 prio3";
 
 /// The count type. Each measurement is an integer in `[0,2)` and the aggregate result is the sum.
 #[cfg(feature = "crypto-dependencies")]

--- a/src/vdaf/prio3.rs
+++ b/src/vdaf/prio3.rs
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: MPL-2.0
 
-//! Implementation of the Prio3 VDAF [[draft-irtf-cfrg-vdaf-01]].
+//! Implementation of the Prio3 VDAF [[draft-irtf-cfrg-vdaf-03]].
 //!
 //! **WARNING:** Neither this code nor the cryptographic construction it implements has undergone
 //! significant security analysis. Use at your own risk.
@@ -10,7 +10,7 @@
 //! 2019 [[BBCG+19]], that lead to substantial improvements in terms of run time and communication
 //! cost.
 //!
-//! Prio3 is a transformation of a Fully Linear Proof (FLP) system [[draft-irtf-cfrg-vdaf-01]] into
+//! Prio3 is a transformation of a Fully Linear Proof (FLP) system [[draft-irtf-cfrg-vdaf-03]] into
 //! a VDAF. The base type, [`Prio3`], supports a wide variety of aggregation functions, some of
 //! which are instantiated here:
 //!
@@ -21,11 +21,11 @@
 //!
 //! Additional types can be constructed from [`Prio3`] as needed.
 //!
-//! (*) denotes that the type is specified in [[draft-irtf-cfrg-vdaf-01]].
+//! (*) denotes that the type is specified in [[draft-irtf-cfrg-vdaf-03]].
 //!
 //! [BBCG+19]: https://ia.cr/2019/188
 //! [CGB17]: https://crypto.stanford.edu/prio/
-//! [draft-irtf-cfrg-vdaf-01]: https://datatracker.ietf.org/doc/draft-irtf-cfrg-vdaf/01/
+//! [draft-irtf-cfrg-vdaf-03]: https://datatracker.ietf.org/doc/draft-irtf-cfrg-vdaf/03/
 
 #[cfg(feature = "crypto-dependencies")]
 use super::prg::PrgAes128;
@@ -237,7 +237,7 @@ impl Prio3Aes128Average {
 /// assert_eq!(agg_res, 3);
 /// ```
 ///
-/// [draft-irtf-cfrg-vdaf-01]: https://datatracker.ietf.org/doc/draft-irtf-cfrg-vdaf/01/
+/// [draft-irtf-cfrg-vdaf-03]: https://datatracker.ietf.org/doc/draft-irtf-cfrg-vdaf/03/
 #[derive(Clone, Debug)]
 pub struct Prio3<T, P, const L: usize>
 where

--- a/src/vdaf/prio3_test.rs
+++ b/src/vdaf/prio3_test.rs
@@ -126,6 +126,7 @@ fn check_prep_test_vec<M, T, P, const L: usize>(
 }
 
 #[test]
+#[ignore] // awaiting new test vectors
 fn test_vec_prio3_count() {
     let t: TPrio3<u64> =
         serde_json::from_str(include_str!("test_vec/01/Prio3Aes128Count.json")).unwrap();
@@ -138,6 +139,7 @@ fn test_vec_prio3_count() {
 }
 
 #[test]
+#[ignore] // awaiting new test vectors
 fn test_vec_prio3_sum() {
     let t: TPrio3<u128> =
         serde_json::from_str(include_str!("test_vec/01/Prio3Aes128Sum.json")).unwrap();
@@ -150,6 +152,7 @@ fn test_vec_prio3_sum() {
 }
 
 #[test]
+#[ignore] // awaiting new test vectors
 fn test_vec_prio3_histogram() {
     let t: TPrio3<u128> =
         serde_json::from_str(include_str!("test_vec/01/Prio3Aes128Histogram.json")).unwrap();


### PR DESCRIPTION
This makes the following housekeeping changes, in preparation for supporting VDAF draft 03.

- Bump the crate's version from 0.8.3 to 0.9.0.
- Update the document version used in Prio3 PRG derivation.
- Ignore test vector tests, as they would otherwise be broken by the above version number change.
- Update comments and documentation with references to the VDAF document.