### PR TITLE
Add public share to VDAF API

### DIFF
--- a/benches/speed_tests.rs
+++ b/benches/speed_tests.rs
@@ -187,7 +187,7 @@ pub fn prio3_client(c: &mut Criterion) {
     let measurement = 1;
     println!(
         "prio3 count size = {}",
-        prio3_input_share_size(&prio3.shard(&measurement).unwrap())
+        prio3_input_share_size(&prio3.shard(&measurement).unwrap().1)
     );
     c.bench_function("prio3 count", |b| {
         b.iter(|| {
@@ -201,7 +201,7 @@ pub fn prio3_client(c: &mut Criterion) {
     println!(
         "prio3 histogram ({} buckets) size = {}",
         buckets.len() + 1,
-        prio3_input_share_size(&prio3.shard(&measurement).unwrap())
+        prio3_input_share_size(&prio3.shard(&measurement).unwrap().1)
     );
     c.bench_function(
         &format!("prio3 histogram ({} buckets)", buckets.len() + 1),
@@ -218,7 +218,7 @@ pub fn prio3_client(c: &mut Criterion) {
     println!(
         "prio3 sum ({} bits) size = {}",
         bits,
-        prio3_input_share_size(&prio3.shard(&measurement).unwrap())
+        prio3_input_share_size(&prio3.shard(&measurement).unwrap().1)
     );
     c.bench_function(&format!("prio3 sum ({} bits)", bits), |b| {
         b.iter(|| {
@@ -232,7 +232,7 @@ pub fn prio3_client(c: &mut Criterion) {
     println!(
         "prio3 countvec ({} len) size = {}",
         len,
-        prio3_input_share_size(&prio3.shard(&measurement).unwrap())
+        prio3_input_share_size(&prio3.shard(&measurement).unwrap().1)
     );
     c.bench_function(&format!("prio3 countvec ({} len)", len), |b| {
         b.iter(|| {
@@ -247,7 +247,7 @@ pub fn prio3_client(c: &mut Criterion) {
         println!(
             "prio3 countvec multithreaded ({} len) size = {}",
             len,
-            prio3_input_share_size(&prio3.shard(&measurement).unwrap())
+            prio3_input_share_size(&prio3.shard(&measurement).unwrap().1)
         );
         c.bench_function(&format!("prio3 parallel countvec ({} len)", len), |b| {
             b.iter(|| {

--- a/src/vdaf/poplar1.rs
+++ b/src/vdaf/poplar1.rs
@@ -342,6 +342,7 @@ where
     type Measurement = IdpfInput;
     type AggregateResult = BTreeMap<IdpfInput, u64>;
     type AggregationParam = BTreeSet<IdpfInput>;
+    type PublicShare = (); // TODO: Replace this when the IDPF from [BBCGGI21] is implemented.
     type InputShare = Poplar1InputShare<I, L>;
     type OutputShare = OutputShare<I::Field>;
     type AggregateShare = AggregateShare<I::Field>;
@@ -357,7 +358,7 @@ where
     P: Prg<L>,
 {
     #[allow(clippy::many_single_char_names)]
-    fn shard(&self, input: &IdpfInput) -> Result<Vec<Poplar1InputShare<I, L>>, VdafError> {
+    fn shard(&self, input: &IdpfInput) -> Result<((), Vec<Poplar1InputShare<I, L>>), VdafError> {
         let idpf_values: Vec<[I::Field; 2]> = Prng::new()?
             .take(input.level + 1)
             .map(|k| [I::Field::one(), k])
@@ -396,18 +397,21 @@ where
         // Generate IDPF shares of the data and authentication vectors.
         let idpf_shares = I::gen(input, idpf_values)?;
 
-        Ok(vec![
-            Poplar1InputShare {
-                idpf: idpf_shares[0].clone(),
-                sketch_start_seed: leader_sketch_start_seed,
-                sketch_next: Share::Leader(leader_sketch_next),
-            },
-            Poplar1InputShare {
-                idpf: idpf_shares[1].clone(),
-                sketch_start_seed: helper_sketch_start_seed,
-                sketch_next: Share::Helper(helper_sketch_next_seed),
-            },
-        ])
+        Ok((
+            (),
+            vec![
+                Poplar1InputShare {
+                    idpf: idpf_shares[0].clone(),
+                    sketch_start_seed: leader_sketch_start_seed,
+                    sketch_next: Share::Leader(leader_sketch_next),
+                },
+                Poplar1InputShare {
+                    idpf: idpf_shares[1].clone(),
+                    sketch_start_seed: helper_sketch_start_seed,
+                    sketch_next: Share::Helper(helper_sketch_next_seed),
+                },
+            ],
+        ))
     }
 }
 
@@ -447,6 +451,7 @@ where
         agg_id: usize,
         agg_param: &BTreeSet<IdpfInput>,
         nonce: &[u8],
+        _public_share: &Self::PublicShare,
         input_share: &Self::InputShare,
     ) -> Result<
         (
@@ -867,13 +872,21 @@ mod tests {
         let mut agg_param = BTreeSet::new();
         agg_param.insert(IdpfInput::new(&[0b0000_0111], 6).unwrap());
         agg_param.insert(IdpfInput::new(&[0b0000_1000], 7).unwrap());
-        let input_shares = vdaf.shard(&input[0]).unwrap();
-        run_vdaf_prepare(&vdaf, &verify_key, &agg_param, nonce, input_shares).unwrap_err();
+        let (public_share, input_shares) = vdaf.shard(&input[0]).unwrap();
+        run_vdaf_prepare(
+            &vdaf,
+            &verify_key,
+            &agg_param,
+            nonce,
+            public_share,
+            input_shares,
+        )
+        .unwrap_err();
 
         // Try evaluating the VDAF with malformed inputs.
         //
         // This IDPF key pair evaluates to 1 everywhere, which is illegal.
-        let mut input_shares = vdaf.shard(&input[0]).unwrap();
+        let (public_share, mut input_shares) = vdaf.shard(&input[0]).unwrap();
         for (i, x) in input_shares[0].idpf.data0.iter_mut().enumerate() {
             if i != input[0].index {
                 *x += Field128::one();
@@ -881,16 +894,32 @@ mod tests {
         }
         let mut agg_param = BTreeSet::new();
         agg_param.insert(IdpfInput::new(&[0b0000_0111], 8).unwrap());
-        run_vdaf_prepare(&vdaf, &verify_key, &agg_param, nonce, input_shares).unwrap_err();
+        run_vdaf_prepare(
+            &vdaf,
+            &verify_key,
+            &agg_param,
+            nonce,
+            public_share,
+            input_shares,
+        )
+        .unwrap_err();
 
         // This IDPF key pair has a garbled authentication vector.
-        let mut input_shares = vdaf.shard(&input[0]).unwrap();
+        let (public_share, mut input_shares) = vdaf.shard(&input[0]).unwrap();
         for x in input_shares[0].idpf.data1.iter_mut() {
             *x = Field128::zero();
         }
         let mut agg_param = BTreeSet::new();
         agg_param.insert(IdpfInput::new(&[0b0000_0111], 8).unwrap());
-        run_vdaf_prepare(&vdaf, &verify_key, &agg_param, nonce, input_shares).unwrap_err();
+        run_vdaf_prepare(
+            &vdaf,
+            &verify_key,
+            &agg_param,
+            nonce,
+            public_share,
+            input_shares,
+        )
+        .unwrap_err();
     }
 
     fn check_btree(btree: &BTreeMap<IdpfInput, u64>, counts: &[u64]) {

--- a/src/vdaf/prio2.rs
+++ b/src/vdaf/prio2.rs
@@ -94,6 +94,7 @@ impl Vdaf for Prio2 {
     type Measurement = Vec<u32>;
     type AggregateResult = Vec<u32>;
     type AggregationParam = ();
+    type PublicShare = ();
     type InputShare = Share<FieldPrio2, 32>;
     type OutputShare = OutputShare<FieldPrio2>;
     type AggregateShare = AggregateShare<FieldPrio2>;
@@ -105,7 +106,7 @@ impl Vdaf for Prio2 {
 }
 
 impl Client for Prio2 {
-    fn shard(&self, measurement: &Vec<u32>) -> Result<Vec<Share<FieldPrio2, 32>>, VdafError> {
+    fn shard(&self, measurement: &Vec<u32>) -> Result<((), Vec<Share<FieldPrio2, 32>>), VdafError> {
         if measurement.len() != self.input_len {
             return Err(VdafError::Uncategorized("incorrect input length".into()));
         }
@@ -126,7 +127,10 @@ impl Client for Prio2 {
             *s1 -= d;
         }
 
-        Ok(vec![Share::Leader(leader_data), Share::Helper(helper_seed)])
+        Ok((
+            (),
+            vec![Share::Leader(leader_data), Share::Helper(helper_seed)],
+        ))
     }
 }
 
@@ -191,6 +195,7 @@ impl Aggregator<32> for Prio2 {
         agg_id: usize,
         _agg_param: &(),
         nonce: &[u8],
+        _public_share: &Self::PublicShare,
         input_share: &Share<FieldPrio2, 32>,
     ) -> Result<(Prio2PrepareState, Prio2PrepareShare), VdafError> {
         let is_leader = role_try_from(agg_id)?;
@@ -361,7 +366,7 @@ mod tests {
         let verify_key = rng.gen();
         let mut nonce = [0; 16];
         rng.fill(&mut nonce);
-        run_vdaf_prepare(&prio2, &verify_key, &(), &nonce, input_shares).unwrap();
+        run_vdaf_prepare(&prio2, &verify_key, &(), &nonce, (), input_shares).unwrap();
     }
 
     #[test]
@@ -373,7 +378,7 @@ mod tests {
 
         let data = vec![0, 0, 1, 1, 0];
         let prio2 = Prio2::new(data.len()).unwrap();
-        let input_shares = prio2.shard(&data).unwrap();
+        let (_public_share, input_shares) = prio2.shard(&data).unwrap();
 
         let encrypted_input_share1 =
             encrypt_share(&input_shares[0].get_encoded(), &pub_key1).unwrap();
@@ -405,10 +410,10 @@ mod tests {
         thread_rng().fill(&mut verify_key[..]);
         let data = vec![0, 0, 1, 1, 0];
         let prio2 = Prio2::new(data.len()).unwrap();
-        let input_shares = prio2.shard(&data).unwrap();
+        let (public_share, input_shares) = prio2.shard(&data).unwrap();
         for (agg_id, input_share) in input_shares.iter().enumerate() {
             let (want, _msg) = prio2
-                .prepare_init(&verify_key, agg_id, &(), &[], input_share)
+                .prepare_init(&verify_key, agg_id, &(), &[], &public_share, input_share)
                 .unwrap();
             let got =
                 Prio2PrepareState::get_decoded_with_param(&(&prio2, agg_id), &want.get_encoded())

--- a/src/vdaf/prio3_test.rs
+++ b/src/vdaf/prio3_test.rs
@@ -85,7 +85,7 @@ fn check_prep_test_vec<M, T, P, const L: usize>(
     let mut prep_shares = Vec::new();
     for (agg_id, input_share) in input_shares.iter().enumerate() {
         let (state, prep_share) = prio3
-            .prepare_init(verify_key, agg_id, &(), &t.nonce, input_share)
+            .prepare_init(verify_key, agg_id, &(), &t.nonce, &(), input_share)
             .unwrap_or_else(|e| err!(test_num, e, "prep state init"));
         states.push(state);
         prep_shares.push(prep_share);


### PR DESCRIPTION
This updates the VDAF API to include a public share along with per-aggregator input shares. A new associated type, `PublicShare`, is added to the `Vdaf` trait, and the signatures of `Client::shard()` and `Aggregator::prepare_init()` are updated to plumb the public share through. The public share will be required to implement Poplar1 as specified in drafts 02 and 03, but it is not used yet in the codebase. (The Poplar paper's IDPF requires a public share, but ToyIdpf does not)

This depends on #286.