### PR TITLE
Make integer-to-GF(p) element conversion fallible

### DIFF
--- a/examples/sum.rs
+++ b/examples/sum.rs
@@ -4,6 +4,7 @@ use prio::client::*;
 use prio::encrypt::*;
 use prio::field::*;
 use prio::server::*;
+use std::convert::TryFrom;
 
 fn main() {
     let priv_key1 = PrivateKey::from_base64(
@@ -30,7 +31,7 @@ fn main() {
 
     let data1 = data1_u32
         .iter()
-        .map(|x| Field32::from(*x))
+        .map(|x| Field32::try_from(*x).unwrap())
         .collect::<Vec<Field32>>();
 
     let data2_u32 = [0, 0, 1, 0, 0, 0, 0, 0];
@@ -38,12 +39,12 @@ fn main() {
 
     let data2 = data2_u32
         .iter()
-        .map(|x| Field32::from(*x))
+        .map(|x| Field32::try_from(*x).unwrap())
         .collect::<Vec<Field32>>();
 
     let (share1_1, share1_2) = client1.encode_simple(&data1).unwrap();
     let (share2_1, share2_2) = client2.encode_simple(&data2).unwrap();
-    let eval_at = Field32::from(12313);
+    let eval_at = Field32::try_from(12313).unwrap();
 
     let mut server1 = Server::new(dim, true, priv_key1).unwrap();
     let mut server2 = Server::new(dim, false, priv_key2).unwrap();

--- a/src/client.rs
+++ b/src/client.rs
@@ -257,7 +257,7 @@ fn test_encode() {
     let data_u32 = [0u32, 1, 0, 1, 1, 0, 0, 0, 1];
     let data = data_u32
         .iter()
-        .map(|x| Field32::from(*x))
+        .map(|x| Field32::try_from(*x).unwrap())
         .collect::<Vec<Field32>>();
     let encoded_shares = encode_simple(&data, pub_key1, pub_key2);
     assert!(encoded_shares.is_ok());

--- a/src/fft.rs
+++ b/src/fft.rs
@@ -80,7 +80,9 @@ pub(crate) fn discrete_fourier_transform_inv<F: FieldElement>(
     inp: &[F],
     size: usize,
 ) -> Result<(), FftError> {
-    let size_inv = F::from(F::Integer::try_from(size).unwrap()).inv();
+    let size_inv = F::try_from(F::Integer::try_from(size).map_err(|_| FftError::SizeTooLarge)?)
+        .map_err(|_| FftError::SizeTooLarge)?
+        .inv();
     discrete_fourier_transform(outp, inp, size)?;
     discrete_fourier_transform_inv_finish(outp, size, size_inv);
     Ok(())

--- a/src/field.rs
+++ b/src/field.rs
@@ -219,7 +219,7 @@ pub(crate) trait FieldElementExt: FieldElement {
         let one = Self::Integer::from(Self::one());
         let mut encoded = Vec::with_capacity(bits);
         for _ in 0..bits {
-            let w = Self::try_from(i & one).unwrap();
+            let w = Self::try_from(i & one)?;
             encoded.push(w);
             i = i >> one;
         }

--- a/src/flp.rs
+++ b/src/flp.rs
@@ -304,7 +304,8 @@ pub trait Type: Sized + Eq + Clone + Debug {
             // evaluation of the gadget.
             let m = wire_poly_len(gadget.calls());
             let m_inv =
-                Self::Field::from(<Self::Field as FieldElement>::Integer::try_from(m).unwrap())
+                Self::Field::try_from(<Self::Field as FieldElement>::Integer::try_from(m).unwrap())
+                    .unwrap()
                     .inv();
             let mut f = vec![vec![Self::Field::zero(); m]; gadget.arity()];
             for wire in 0..gadget.arity() {
@@ -446,7 +447,8 @@ pub trait Type: Sized + Eq + Clone + Debug {
             // polynomial at query randomness `r`.
             let m = (1 + gadget.calls()).next_power_of_two();
             let m_inv =
-                Self::Field::from(<Self::Field as FieldElement>::Integer::try_from(m).unwrap())
+                Self::Field::try_from(<Self::Field as FieldElement>::Integer::try_from(m).unwrap())
+                    .unwrap()
                     .inv();
             let mut f = vec![Self::Field::zero(); m];
             for wire in 0..gadget.arity() {
@@ -877,8 +879,10 @@ mod tests {
 
         fn encode_measurement(&self, measurement: &F::Integer) -> Result<Vec<F>, FlpError> {
             Ok(vec![
-                F::from(*measurement),
-                F::from(*measurement).pow(F::Integer::try_from(3).unwrap()),
+                F::try_from(*measurement).unwrap(),
+                F::try_from(*measurement)
+                    .unwrap()
+                    .pow(F::Integer::try_from(3).unwrap()),
             ])
         }
 
@@ -1012,7 +1016,7 @@ mod tests {
         }
 
         fn encode_measurement(&self, measurement: &F::Integer) -> Result<Vec<F>, FlpError> {
-            Ok(vec![F::from(*measurement)])
+            Ok(vec![F::try_from(*measurement).unwrap()])
         }
 
         fn truncate(&self, input: Vec<F>) -> Result<Vec<F>, FlpError> {

--- a/src/flp.rs
+++ b/src/flp.rs
@@ -303,10 +303,11 @@ pub trait Type: Sized + Eq + Clone + Debug {
             // Interpolate the wire polynomials `f[0], ..., f[g_arity-1]` from the input wires of each
             // evaluation of the gadget.
             let m = wire_poly_len(gadget.calls());
-            let m_inv =
-                Self::Field::try_from(<Self::Field as FieldElement>::Integer::try_from(m).unwrap())
-                    .unwrap()
-                    .inv();
+            let m_inv = Self::Field::try_from(
+                <Self::Field as FieldElement>::Integer::try_from(m)
+                    .map_err(|_| FieldError::IntegerTryFrom)?,
+            )?
+            .inv();
             let mut f = vec![vec![Self::Field::zero(); m]; gadget.arity()];
             for wire in 0..gadget.arity() {
                 discrete_fourier_transform(&mut f[wire], &gadget.f_vals[wire], m)?;
@@ -446,10 +447,11 @@ pub trait Type: Sized + Eq + Clone + Debug {
             // Reconstruct the wire polynomials `f[0], ..., f[g_arity-1]` and evaluate each wire
             // polynomial at query randomness `r`.
             let m = (1 + gadget.calls()).next_power_of_two();
-            let m_inv =
-                Self::Field::try_from(<Self::Field as FieldElement>::Integer::try_from(m).unwrap())
-                    .unwrap()
-                    .inv();
+            let m_inv = Self::Field::try_from(
+                <Self::Field as FieldElement>::Integer::try_from(m)
+                    .map_err(|_| FieldError::IntegerTryFrom)?,
+            )?
+            .inv();
             let mut f = vec![Self::Field::zero(); m];
             for wire in 0..gadget.arity() {
                 discrete_fourier_transform(&mut f, &gadget.f_vals[wire], m)?;

--- a/src/flp/gadgets.rs
+++ b/src/flp/gadgets.rs
@@ -35,7 +35,7 @@ impl<F: FieldElement> Mul<F> {
     /// called by the validity circuit.
     pub fn new(num_calls: usize) -> Self {
         let n = gadget_poly_fft_mem_len(2, num_calls);
-        let n_inv = F::from(F::Integer::try_from(n).unwrap()).inv();
+        let n_inv = F::try_from(F::Integer::try_from(n).unwrap()).unwrap().inv();
         Self {
             n,
             n_inv,
@@ -123,7 +123,7 @@ impl<F: FieldElement> PolyEval<F> {
     /// this gadget is called by the validity circuit.
     pub fn new(poly: Vec<F>, num_calls: usize) -> Self {
         let n = gadget_poly_fft_mem_len(poly_deg(&poly), num_calls);
-        let n_inv = F::from(F::Integer::try_from(n).unwrap()).inv();
+        let n_inv = F::try_from(F::Integer::try_from(n).unwrap()).unwrap().inv();
         Self {
             poly,
             n,
@@ -234,7 +234,7 @@ impl<F: FieldElement> BlindPolyEval<F> {
     /// Returns a `BlindPolyEval` gadget for polynomial `poly`.
     pub fn new(poly: Vec<F>, num_calls: usize) -> Self {
         let n = gadget_poly_fft_mem_len(poly_deg(&poly) + 1, num_calls);
-        let n_inv = F::from(F::Integer::try_from(n).unwrap()).inv();
+        let n_inv = F::try_from(F::Integer::try_from(n).unwrap()).unwrap().inv();
         Self {
             poly,
             n,

--- a/src/flp/gadgets.rs
+++ b/src/flp/gadgets.rs
@@ -35,6 +35,9 @@ impl<F: FieldElement> Mul<F> {
     /// called by the validity circuit.
     pub fn new(num_calls: usize) -> Self {
         let n = gadget_poly_fft_mem_len(2, num_calls);
+        // `n` scales approximately linearly with `num_calls`, so `n` should be much less than the
+        // field's prime modulus in all practical cases. Thus, it is okay to unwrap both results
+        // here.
         let n_inv = F::try_from(F::Integer::try_from(n).unwrap()).unwrap().inv();
         Self {
             n,
@@ -123,6 +126,9 @@ impl<F: FieldElement> PolyEval<F> {
     /// this gadget is called by the validity circuit.
     pub fn new(poly: Vec<F>, num_calls: usize) -> Self {
         let n = gadget_poly_fft_mem_len(poly_deg(&poly), num_calls);
+        // `n` scales approximately linearly with `num_calls`, so `n` should be much less than the
+        // field's prime modulus in all practical cases. Thus, it is okay to unwrap both results
+        // here.
         let n_inv = F::try_from(F::Integer::try_from(n).unwrap()).unwrap().inv();
         Self {
             poly,
@@ -234,6 +240,9 @@ impl<F: FieldElement> BlindPolyEval<F> {
     /// Returns a `BlindPolyEval` gadget for polynomial `poly`.
     pub fn new(poly: Vec<F>, num_calls: usize) -> Self {
         let n = gadget_poly_fft_mem_len(poly_deg(&poly) + 1, num_calls);
+        // `n` scales approximately linearly with `num_calls`, so `n` should be much less than the
+        // field's prime modulus in all practical cases. Thus, it is okay to unwrap both results
+        // here.
         let n_inv = F::try_from(F::Integer::try_from(n).unwrap()).unwrap().inv();
         Self {
             poly,

--- a/src/polynomial.rs
+++ b/src/polynomial.rs
@@ -146,6 +146,8 @@ fn fft_interpolate_raw<F: FieldElement>(
         &mut mem.fft_roots_sub,
     );
     if invert {
+        // `n_points` should be far less than the field's prime modulus in all pracitcal cases, so
+        // it is safe to unwrap these results.
         let n_inverse = F::try_from(F::Integer::try_from(n_points).unwrap())
             .unwrap()
             .inv();
@@ -223,6 +225,9 @@ pub(crate) fn poly_range_check<F: FieldElement>(start: usize, end: usize) -> Vec
     let mut p = vec![F::one()];
     let mut q = [F::zero(), F::one()];
     for i in start..end {
+        // `end` should be less than the field's prime modulus, otherwise it doesn't make sense to
+        // check if a field element is in this range. For now, we will unwrap and panic if `end` is
+        // too large.
         q[0] = -F::try_from(F::Integer::try_from(i).unwrap()).unwrap();
         p = poly_mul(&p, &q);
     }

--- a/src/prng.rs
+++ b/src/prng.rs
@@ -115,7 +115,7 @@ mod tests {
         field::{Field96, FieldPrio2},
         vdaf::prg::{Prg, PrgAes128, Seed},
     };
-    use std::convert::TryInto;
+    use std::convert::{TryFrom, TryInto};
 
     #[test]
     fn secret_sharing_interop() {
@@ -201,7 +201,7 @@ mod tests {
             b"",
         );
         let mut prng = Prng::<Field96, _>::from_seed_stream(seed_stream);
-        let expected = Field96::from(39729620190871453347343769187);
+        let expected = Field96::try_from(39729620190871453347343769187).unwrap();
         let actual = prng.nth(145).unwrap();
         assert_eq!(actual, expected);
     }

--- a/src/server.rs
+++ b/src/server.rs
@@ -285,6 +285,7 @@ mod tests {
         util::{self, unpack_proof_mut},
     };
     use serde_json;
+    use std::convert::TryFrom;
 
     #[test]
     fn test_validation() {
@@ -295,9 +296,12 @@ mod tests {
             2567182742, 3542857140, 124017604, 4201373647, 431621210, 1618555683, 267689149,
         ];
 
-        let mut proof: Vec<Field32> = proof_u32.iter().map(|x| Field32::from(*x)).collect();
+        let mut proof: Vec<Field32> = proof_u32
+            .iter()
+            .map(|x| Field32::try_from(*x).unwrap())
+            .collect();
         let share2 = util::tests::secret_share(&mut proof);
-        let eval_at = Field32::from(12313);
+        let eval_at = Field32::try_from(12313).unwrap();
 
         let mut validation_mem = ValidationMemory::new(dim);
 
@@ -317,9 +321,12 @@ mod tests {
             2567182742, 3542857140, 124017604, 4201373647, 431621210, 1618555683, 267689149,
         ];
 
-        let mut proof: Vec<Field32> = proof_u32.iter().map(|x| Field32::from(*x)).collect();
+        let mut proof: Vec<Field32> = proof_u32
+            .iter()
+            .map(|x| Field32::try_from(*x).unwrap())
+            .collect();
         let share2 = util::tests::secret_share(&mut proof);
-        let eval_at = Field32::from(12313);
+        let eval_at = Field32::try_from(12313).unwrap();
 
         let mut validation_mem = ValidationMemory::new(dim);
 
@@ -363,7 +370,7 @@ mod tests {
         let mut data = vec![FieldPrio2::zero(); dim];
 
         if let Tweak::WrongInput = tweak {
-            data[0] = FieldPrio2::from(2);
+            data[0] = FieldPrio2::try_from(2).unwrap();
         }
 
         let (share1_original, share2) = client.encode_simple(&data).unwrap();
@@ -372,7 +379,7 @@ mod tests {
         let mut share1_field = FieldPrio2::byte_slice_into_vec(&decrypted_share1).unwrap();
         let unpacked_share1 = unpack_proof_mut(&mut share1_field, dim).unwrap();
 
-        let one = FieldPrio2::from(1);
+        let one = FieldPrio2::one();
 
         match tweak {
             Tweak::DataPartOfShare => unpacked_share1.data[0] += one,

--- a/src/test_vector.rs
+++ b/src/test_vector.rs
@@ -12,7 +12,7 @@ use crate::{
 };
 use rand::Rng;
 use serde::{Deserialize, Serialize};
-use std::fmt::Debug;
+use std::{convert::TryFrom, fmt::Debug};
 
 /// Errors propagated by functions in this module.
 #[derive(Debug, thiserror::Error)]
@@ -110,7 +110,7 @@ impl Priov2TestVector {
         for _ in 0..number_of_clients {
             // Generate a random vector of booleans
             let data: Vec<FieldPrio2> = (0..dimension)
-                .map(|_| FieldPrio2::from(rng.gen_range(0..2)))
+                .map(|_| FieldPrio2::try_from(rng.gen_range(0..2)).unwrap())
                 .collect();
 
             // Update reference sum

--- a/src/vdaf/prio2.rs
+++ b/src/vdaf/prio2.rs
@@ -112,7 +112,7 @@ impl Client for Prio2 {
         }
         let mut input: Vec<FieldPrio2> = Vec::with_capacity(measurement.len());
         for int in measurement {
-            input.push((*int).into());
+            input.push((*int).try_into()?);
         }
 
         let mut mem = v2_client::ClientMemory::new(self.input_len)?;
@@ -349,7 +349,7 @@ mod tests {
 
         let data: Vec<FieldPrio2> = [0, 0, 1, 1, 0]
             .iter()
-            .map(|x| FieldPrio2::from(*x))
+            .map(|x| FieldPrio2::try_from(*x).unwrap())
             .collect();
         let (encrypted_input_share1, encrypted_input_share2) =
             encode_simple(&data, pub_key1, pub_key2).unwrap();


### PR DESCRIPTION
draft-irtf-cfrg-vdaf-02 says that construction of a field element from an integer should fail if the integer is greater than or equal to the field's modulus. Previously, `try_from_bytes()`, `byte_slice_into_vec()`, and related methods checked for this already. This change applies the same check to the conversion from individual integers to field elements, changing it from a `From` implementation to a `TryFrom` implementation.

Outside of tests, this conversion chiefly shows up when the number of aggregators appears inside a circuit.

This depends on #286 and #287.