### PR TITLE
Add algorithm IDs and update PRG seed derivation

### DIFF
--- a/src/flp.rs
+++ b/src/flp.rs
@@ -110,6 +110,9 @@ pub enum FlpError {
 /// as a vector of field elements and how validity of the encoded measurement is determined.
 /// Validity is determined via an arithmetic circuit evaluated over the encoded measurement.
 pub trait Type: Sized + Eq + Clone + Debug {
+    /// The Prio3 VDAF identifier corresponding to this type.
+    const ID: u32;
+
     /// The type of raw measurement to be encoded.
     type Measurement: Clone + Debug;
 
@@ -798,6 +801,7 @@ mod tests {
     }
 
     impl<F: FieldElement> Type for TestType<F> {
+        const ID: u32 = 0xFFFF3002;
         type Measurement = F::Integer;
         type AggregateResult = F::Integer;
         type Field = F;
@@ -932,6 +936,7 @@ mod tests {
     }
 
     impl<F: FieldElement> Type for Issue254Type<F> {
+        const ID: u32 = 0xFFFF3003;
         type Measurement = F::Integer;
         type AggregateResult = F::Integer;
         type Field = F;

--- a/src/flp.rs
+++ b/src/flp.rs
@@ -801,7 +801,7 @@ mod tests {
     }
 
     impl<F: FieldElement> Type for TestType<F> {
-        const ID: u32 = 0xFFFF3002;
+        const ID: u32 = 0xFFFF0000;
         type Measurement = F::Integer;
         type AggregateResult = F::Integer;
         type Field = F;
@@ -936,7 +936,7 @@ mod tests {
     }
 
     impl<F: FieldElement> Type for Issue254Type<F> {
-        const ID: u32 = 0xFFFF3003;
+        const ID: u32 = 0xFFFF0000;
         type Measurement = F::Integer;
         type AggregateResult = F::Integer;
         type Field = F;

--- a/src/flp/types.rs
+++ b/src/flp/types.rs
@@ -222,7 +222,7 @@ impl<F: FieldElement> Average<F> {
 }
 
 impl<F: FieldElement> Type for Average<F> {
-    const ID: u32 = 0xFFFF3000;
+    const ID: u32 = 0xFFFF0000;
     type Measurement = F::Integer;
     type AggregateResult = f64;
     type Field = F;
@@ -472,7 +472,7 @@ where
     F: FieldElement,
     S: ParallelSumGadget<F, BlindPolyEval<F>> + Eq + 'static,
 {
-    const ID: u32 = 0xFFFF3001;
+    const ID: u32 = 0xFFFF0000;
     type Measurement = Vec<F::Integer>;
     type AggregateResult = Vec<F::Integer>;
     type Field = F;

--- a/src/flp/types.rs
+++ b/src/flp/types.rs
@@ -32,6 +32,7 @@ impl<F: FieldElement> Default for Count<F> {
 }
 
 impl<F: FieldElement> Type for Count<F> {
+    const ID: u32 = 0x00000000;
     type Measurement = F::Integer;
     type AggregateResult = F::Integer;
     type Field = F;
@@ -128,6 +129,7 @@ impl<F: FieldElement> Sum<F> {
 }
 
 impl<F: FieldElement> Type for Sum<F> {
+    const ID: u32 = 0x00000001;
     type Measurement = F::Integer;
     type AggregateResult = F::Integer;
     type Field = F;
@@ -220,6 +222,7 @@ impl<F: FieldElement> Average<F> {
 }
 
 impl<F: FieldElement> Type for Average<F> {
+    const ID: u32 = 0xFFFF3000;
     type Measurement = F::Integer;
     type AggregateResult = f64;
     type Field = F;
@@ -327,6 +330,7 @@ impl<F: FieldElement> Histogram<F> {
 }
 
 impl<F: FieldElement> Type for Histogram<F> {
+    const ID: u32 = 0x00000002;
     type Measurement = F::Integer;
     type AggregateResult = Vec<F::Integer>;
     type Field = F;
@@ -468,6 +472,7 @@ where
     F: FieldElement,
     S: ParallelSumGadget<F, BlindPolyEval<F>> + Eq + 'static,
 {
+    const ID: u32 = 0xFFFF3001;
     type Measurement = Vec<F::Integer>;
     type AggregateResult = Vec<F::Integer>;
     type Field = F;

--- a/src/vdaf.rs
+++ b/src/vdaf.rs
@@ -15,9 +15,11 @@ use std::convert::TryFrom;
 use std::fmt::Debug;
 use std::io::Cursor;
 
-/// Domain-separation tag used to bind the VDAF operations to the document version. This will be
-/// revised with each draft with breaking changes.
-pub(crate) const VERSION: &[u8] = b"vdaf-03";
+/// A component of the domain-separation tag, used to bind the VDAF operations to the document
+/// version. This will be revised with each draft with breaking changes.
+const VERSION: &[u8] = b"vdaf-03";
+/// Length of the domain-separation tag, including document version and algorithm ID.
+const DST_LEN: usize = VERSION.len() + 4;
 
 /// Errors emitted by this module.
 #[derive(Debug, thiserror::Error)]

--- a/src/vdaf.rs
+++ b/src/vdaf.rs
@@ -15,6 +15,10 @@ use std::convert::TryFrom;
 use std::fmt::Debug;
 use std::io::Cursor;
 
+/// Domain-separation tag used to bind the VDAF operations to the document version. This will be
+/// revised with each draft with breaking changes.
+pub(crate) const VERSION: &[u8] = b"vdaf-03";
+
 /// Errors emitted by this module.
 #[derive(Debug, thiserror::Error)]
 pub enum VdafError {
@@ -120,6 +124,9 @@ pub trait Vdaf: Clone + Debug
 where
     for<'a> &'a Self::AggregateShare: Into<Vec<u8>>,
 {
+    /// Algorithm identifier for this VDAF.
+    const ID: u32;
+
     /// The type of Client measurement to be aggregated.
     type Measurement: Clone + Debug;
 

--- a/src/vdaf/poplar1.rs
+++ b/src/vdaf/poplar1.rs
@@ -341,7 +341,7 @@ where
 {
     // TODO: This currently uses a codepoint reserved for testing purposes. Replace it with
     // 0x00001000 once the implementation is updated to match draft-irtf-cfrg-vdaf-03.
-    const ID: u32 = 0xFFFF2000;
+    const ID: u32 = 0xFFFF0000;
     type Measurement = IdpfInput;
     type AggregateResult = BTreeMap<IdpfInput, u64>;
     type AggregationParam = BTreeSet<IdpfInput>;

--- a/src/vdaf/poplar1.rs
+++ b/src/vdaf/poplar1.rs
@@ -339,6 +339,9 @@ where
     I: Idpf<2, 2>,
     P: Prg<L>,
 {
+    // TODO: This currently uses a codepoint reserved for testing purposes. Replace it with
+    // 0x00001000 once the implementation is updated to match draft-irtf-cfrg-vdaf-03.
+    const ID: u32 = 0xFFFF2000;
     type Measurement = IdpfInput;
     type AggregateResult = BTreeMap<IdpfInput, u64>;
     type AggregationParam = BTreeSet<IdpfInput>;

--- a/src/vdaf/prio2.rs
+++ b/src/vdaf/prio2.rs
@@ -91,7 +91,7 @@ impl Prio2 {
 }
 
 impl Vdaf for Prio2 {
-    const ID: u32 = 0xFFFF1000;
+    const ID: u32 = 0xFFFF0000;
     type Measurement = Vec<u32>;
     type AggregateResult = Vec<u32>;
     type AggregationParam = ();

--- a/src/vdaf/prio2.rs
+++ b/src/vdaf/prio2.rs
@@ -91,6 +91,7 @@ impl Prio2 {
 }
 
 impl Vdaf for Prio2 {
+    const ID: u32 = 0xFFFF1000;
     type Measurement = Vec<u32>;
     type AggregateResult = Vec<u32>;
     type AggregationParam = ();


### PR DESCRIPTION
draft-irtf-cfrg-vdaf-03 introduces algorithm identifiers for each VDAF, to provide domain separation between uses of Prio3 with different circuits. Various PRG derivations are updated to incorporate this algorithm identifier, in addition to the document version. I arbitrarily assigned some identifiers from the "reserved for private use" range for VDAF instances that are for test purposes only or are not standardized.

This depends on #286, #287, and #288.