### PR TITLE
Rewrite joint rand derivation, CMAC instead of XOR

### DIFF
--- a/src/vdaf/prg.rs
+++ b/src/vdaf/prg.rs
@@ -200,7 +200,7 @@ mod tests {
         let mut prg = P::init(seed.as_ref());
         prg.update(info);
 
-        let mut want: Seed<L> = Seed([0u8; L]);
+        let mut want = Seed([0; L]);
         prg.clone().into_seed_stream().fill(&mut want.0[..]);
         let got = prg.clone().into_seed();
         assert_eq!(got, want);

--- a/src/vdaf/prg.rs
+++ b/src/vdaf/prg.rs
@@ -41,22 +41,6 @@ impl<const L: usize> Seed<L> {
         rand_source(&mut seed)?;
         Ok(Self(seed))
     }
-
-    pub(crate) fn uninitialized() -> Self {
-        Self([0; L])
-    }
-
-    pub(crate) fn xor_accumulate(&mut self, other: &Self) {
-        for i in 0..L {
-            self.0[i] ^= other.0[i]
-        }
-    }
-
-    pub(crate) fn xor(&mut self, left: &Self, right: &Self) {
-        for i in 0..L {
-            self.0[i] = left.0[i] ^ right.0[i]
-        }
-    }
 }
 
 impl<const L: usize> AsRef<[u8; L]> for Seed<L> {
@@ -216,7 +200,7 @@ mod tests {
         let mut prg = P::init(seed.as_ref());
         prg.update(info);
 
-        let mut want: Seed<L> = Seed::uninitialized();
+        let mut want: Seed<L> = Seed([0u8; L]);
         prg.clone().into_seed_stream().fill(&mut want.0[..]);
         let got = prg.clone().into_seed();
         assert_eq!(got, want);

--- a/src/vdaf/prio3.rs
+++ b/src/vdaf/prio3.rs
@@ -364,16 +364,16 @@ where
                 *x -= y;
             }
 
-            helper.joint_rand_param.seed_hint = Vec::with_capacity(num_aggregators as usize - 1);
-            let hint = &mut helper.joint_rand_param.seed_hint;
+            let mut hint = Vec::with_capacity(num_aggregators as usize - 1);
             hint.push(leader_joint_rand_seed_part.clone());
             hint.extend(helper_joint_rand_parts[..j].iter().cloned());
             hint.extend(helper_joint_rand_parts[j + 1..].iter().cloned());
+            helper.joint_rand_param.seed_hint = hint;
         }
 
         let leader_joint_rand_param = if self.typ.joint_rand_len() > 0 {
             Some(JointRandParam {
-                seed_hint: helper_joint_rand_parts.clone(),
+                seed_hint: helper_joint_rand_parts,
                 blind: leader_blind,
             })
         } else {

--- a/src/vdaf/prio3.rs
+++ b/src/vdaf/prio3.rs
@@ -994,6 +994,12 @@ mod tests {
         run_vdaf_prepare(&prio3, &verify_key, &(), nonce, public_share, input_shares).unwrap();
 
         test_prepare_state_serialization(&prio3, &1).unwrap();
+
+        let prio3_extra_helper = Prio3::new_aes128_count(3).unwrap();
+        assert_eq!(
+            run_vdaf(&prio3_extra_helper, &(), [1, 0, 0, 1, 1]).unwrap(),
+            3,
+        );
     }
 
     #[test]


### PR DESCRIPTION
This implements a change from draft-irtf-cfrg-vdaf-03, updating the joint randomness derivation to combine contributions from each share in a nonlinear manner.

This depends on #286, #287, #288, and #289.