### PR TITLE
codec: Export `decode_items()`

### DIFF
--- a/src/codec.rs
+++ b/src/codec.rs
@@ -304,7 +304,7 @@ pub fn decode_u24_items<P, D: ParameterizedDecode<P>>(
 }
 
 /// Decode the next `length` bytes from `bytes` into as many instances of `D` as possible.
-fn decode_items<P, D: ParameterizedDecode<P>>(
+pub fn decode_items<P, D: ParameterizedDecode<P>>(
     length: usize,
     decoding_parameter: &P,
     bytes: &mut Cursor<&[u8]>,


### PR DESCRIPTION
I'm reworking message serialization a bit ahead of upgrading Daphne to DAP-02, and I found this method to be useful. Let me know if you'd also like me to upstream my code.