### PR TITLE
Optimization: use fold in ParallelSumMultithreaded

### DIFF
--- a/src/flp/types.rs
+++ b/src/flp/types.rs
@@ -993,9 +993,29 @@ mod tests {
     }
 
     #[test]
-    fn count_vec_long() {
+    fn count_vec_serial_long() {
         let typ: CountVec<TestField, ParallelSum<TestField, BlindPolyEval<TestField>>> =
             CountVec::new(1000);
+        let input = typ.encode_measurement(&vec![0; 1000]).unwrap();
+        assert_eq!(input.len(), typ.input_len());
+        let joint_rand = random_vector(typ.joint_rand_len()).unwrap();
+        let prove_rand = random_vector(typ.prove_rand_len()).unwrap();
+        let query_rand = random_vector(typ.query_rand_len()).unwrap();
+        let proof = typ.prove(&input, &prove_rand, &joint_rand).unwrap();
+        let verifier = typ
+            .query(&input, &proof, &query_rand, &joint_rand, 1)
+            .unwrap();
+        assert_eq!(verifier.len(), typ.verifier_len());
+        assert!(typ.decide(&verifier).unwrap());
+    }
+
+    #[test]
+    #[cfg(feature = "multithreaded")]
+    fn count_vec_parallel_long() {
+        let typ: CountVec<
+            TestField,
+            ParallelSumMultithreaded<TestField, BlindPolyEval<TestField>>,
+        > = CountVec::new(1000);
         let input = typ.encode_measurement(&vec![0; 1000]).unwrap();
         assert_eq!(input.len(), typ.input_len());
         let joint_rand = random_vector(typ.joint_rand_len()).unwrap();

--- a/src/vdaf/prio3.rs
+++ b/src/vdaf/prio3.rs
@@ -1055,6 +1055,39 @@ mod tests {
     }
 
     #[test]
+    fn test_prio3_countvec() {
+        let prio3 = Prio3::new_aes128_count_vec(2, 20).unwrap();
+        assert_eq!(
+            run_vdaf(
+                &prio3,
+                &(),
+                [vec![
+                    0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 1, 0, 0, 1, 0, 1, 1, 1, 0, 1,
+                ]]
+            )
+            .unwrap(),
+            vec![0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 1, 0, 0, 1, 0, 1, 1, 1, 0, 1,]
+        );
+    }
+
+    #[test]
+    #[cfg(feature = "multithreaded")]
+    fn test_prio3_countvec_multithreaded() {
+        let prio3 = Prio3::new_aes128_count_vec_multithreaded(2, 20).unwrap();
+        assert_eq!(
+            run_vdaf(
+                &prio3,
+                &(),
+                [vec![
+                    0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 1, 0, 0, 1, 0, 1, 1, 1, 0, 1,
+                ]]
+            )
+            .unwrap(),
+            vec![0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 1, 0, 0, 1, 0, 1, 1, 1, 0, 1,]
+        );
+    }
+
+    #[test]
     fn test_prio3_histogram() {
         let prio3 = Prio3::new_aes128_histogram(2, &[0, 10, 20]).unwrap();
 


### PR DESCRIPTION
This rewrites the parallel processing core of `ParallelSumMultithreaded` to use `ParallelIterator::fold()`, so that buffers can be reused between subsequent operations, and allocation can be taken out of the inner loop.

I got the following benchmark results:

```
prio3 parallel countvec (1000 len)                                                                             
                        time:   [1.8427 ms 1.9360 ms 2.0303 ms]
                        change: [-13.301% -7.7941% -2.0182%] (p = 0.01 < 0.05)
                        Performance has improved.
```