### PR TITLE
0.8.x: Revert breaking change to Collector::unshard()

### DIFF
--- a/src/flp.rs
+++ b/src/flp.rs
@@ -125,11 +125,7 @@ pub trait Type: Sized + Eq + Clone + Debug {
     ) -> Result<Vec<Self::Field>, FlpError>;
 
     /// Decode an aggregate result.
-    fn decode_result(
-        &self,
-        data: &[Self::Field],
-        num_measurements: usize,
-    ) -> Result<Self::AggregateResult, FlpError>;
+    fn decode_result(&self, data: &[Self::Field]) -> Result<Self::AggregateResult, FlpError>;
 
     /// Returns the sequence of gadgets associated with the validity circuit.
     ///
@@ -885,11 +881,7 @@ mod tests {
             Ok(input)
         }
 
-        fn decode_result(
-            &self,
-            _data: &[F],
-            _num_measurements: usize,
-        ) -> Result<F::Integer, FlpError> {
+        fn decode_result(&self, _data: &[F]) -> Result<F::Integer, FlpError> {
             panic!("not implemented");
         }
     }
@@ -1018,11 +1010,7 @@ mod tests {
             Ok(input)
         }
 
-        fn decode_result(
-            &self,
-            _data: &[F],
-            _num_measurements: usize,
-        ) -> Result<F::Integer, FlpError> {
+        fn decode_result(&self, _data: &[F]) -> Result<F::Integer, FlpError> {
             panic!("not implemented");
         }
     }

--- a/src/vdaf.rs
+++ b/src/vdaf.rs
@@ -222,7 +222,6 @@ where
         &self,
         agg_param: &Self::AggregationParam,
         agg_shares: M,
-        num_measurements: usize,
     ) -> Result<Self::AggregateResult, VdafError>;
 }
 
@@ -388,9 +387,7 @@ where
     let nonce = b"this is a nonce";
 
     let mut agg_shares: Vec<Option<V::AggregateShare>> = vec![None; vdaf.num_aggregators()];
-    let mut num_measurements: usize = 0;
     for measurement in measurements.into_iter() {
-        num_measurements += 1;
         let input_shares = vdaf.shard(&measurement)?;
         let out_shares = run_vdaf_prepare(vdaf, &verify_key, agg_param, nonce, input_shares)?;
         for (out_share, agg_share) in out_shares.into_iter().zip(agg_shares.iter_mut()) {
@@ -405,7 +402,6 @@ where
     let res = vdaf.unshard(
         agg_param,
         agg_shares.into_iter().map(|option| option.unwrap()),
-        num_measurements,
     )?;
     Ok(res)
 }

--- a/src/vdaf/poplar1.rs
+++ b/src/vdaf/poplar1.rs
@@ -690,7 +690,6 @@ where
         &self,
         agg_param: &BTreeSet<IdpfInput>,
         agg_shares: M,
-        _num_measurements: usize,
     ) -> Result<BTreeMap<IdpfInput, u64>, VdafError> {
         let mut agg_data = AggregateShare(vec![I::Field::zero(); agg_param.len()]);
         for agg_share in agg_shares.into_iter() {

--- a/src/vdaf/prio2.rs
+++ b/src/vdaf/prio2.rs
@@ -263,7 +263,6 @@ impl Collector for Prio2 {
         &self,
         _agg_param: &(),
         agg_shares: M,
-        _num_measurements: usize,
     ) -> Result<Vec<u32>, VdafError> {
         let mut agg = AggregateShare(vec![FieldPrio2::zero(); self.input_len]);
         for agg_share in agg_shares.into_iter() {


### PR DESCRIPTION
This is a pull request against the branch for the 0.8.x release series, to roll back a breaking change to the Collector trait. As of version 0.8.2, `Collector::unshard()` took only two parameters, the aggregation parameter and the aggregate shares. Versions 0.8.3 and 0.8.4 added an additional argument, `num_measurements`. This undoes that change, and removes the `Prio3Aes128Average` VDAF that depended on it.