### PR TITLE
dependabot: update deps in release/0.8

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,3 +4,9 @@ updates:
     directory: "/"
     schedule:
       interval: "weekly"
+
+  - package-ecosystem: "cargo"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    target-branch: release/0.8


### PR DESCRIPTION
Adds an entry to `.github/dependabot.yml` instructing the bot to keep branch `release/0.8` up to date, as well as the default branch (`main`).