### PR TITLE
Fix clippy lint

### DIFF
--- a/src/vdaf/prg.rs
+++ b/src/vdaf/prg.rs
@@ -53,7 +53,7 @@ impl<const L: usize> PartialEq for Seed<L> {
     fn eq(&self, other: &Self) -> bool {
         // Do constant-time compare.
         let mut r = 0;
-        for (x, y) in (&self.0[..]).iter().zip(&other.0[..]) {
+        for (x, y) in self.0[..].iter().zip(&other.0[..]) {
             r |= x ^ y;
         }
         r == 0


### PR DESCRIPTION
This fixes a clippy lint that newly appears with the Rust 1.64 toolchain.