### PR TITLE
AggregateShare: switch to TryFrom<Vec<u8>>, Into<Vec<u8>>.

### DIFF
--- a/src/vdaf.rs
+++ b/src/vdaf.rs
@@ -122,10 +122,7 @@ impl<F: FieldElement, const L: usize> Encode for Share<F, L> {
 // TODO(brandon): once GATs are stabilized [https://github.com/rust-lang/rust/issues/44265],
 // state the "&AggregateShare must implement Into<Vec<u8>>" constraint in terms of a where clause
 // on the associated type instead of a where clause on the trait.
-pub trait Vdaf: Clone + Debug
-where
-    for<'a> &'a Self::AggregateShare: Into<Vec<u8>>,
-{
+pub trait Vdaf: Clone + Debug {
     /// Algorithm identifier for this VDAF.
     const ID: u32;
 
@@ -149,7 +146,9 @@ where
     type OutputShare: Clone + Debug;
 
     /// An Aggregator's share of the aggregate result.
-    type AggregateShare: Aggregatable<OutputShare = Self::OutputShare> + for<'a> TryFrom<&'a [u8]>;
+    type AggregateShare: Aggregatable<OutputShare = Self::OutputShare>
+        + TryFrom<Vec<u8>>
+        + Into<Vec<u8>>;
 
     /// The number of Aggregators. The Client generates as many input shares as there are
     /// Aggregators.
@@ -157,10 +156,7 @@ where
 }
 
 /// The Client's role in the execution of a VDAF.
-pub trait Client: Vdaf
-where
-    for<'a> &'a Self::AggregateShare: Into<Vec<u8>>,
-{
+pub trait Client: Vdaf {
     /// Shards a measurement into a public share and a sequence of input shares, one for each
     /// Aggregator.
     fn shard(
@@ -170,10 +166,7 @@ where
 }
 
 /// The Aggregator's role in the execution of a VDAF.
-pub trait Aggregator<const L: usize>: Vdaf
-where
-    for<'a> &'a Self::AggregateShare: Into<Vec<u8>>,
-{
+pub trait Aggregator<const L: usize>: Vdaf {
     /// State of the Aggregator during the Prepare process.
     type PrepareState: Clone + Debug;
 
@@ -230,10 +223,7 @@ where
 }
 
 /// The Collector's role in the execution of a VDAF.
-pub trait Collector: Vdaf
-where
-    for<'a> &'a Self::AggregateShare: Into<Vec<u8>>,
-{
+pub trait Collector: Vdaf {
     /// Combines aggregate shares into the aggregate result.
     fn unshard<M: IntoIterator<Item = Self::AggregateShare>>(
         &self,
@@ -245,10 +235,7 @@ where
 
 /// A state transition of an Aggregator during the Prepare process.
 #[derive(Debug)]
-pub enum PrepareTransition<V: Aggregator<L>, const L: usize>
-where
-    for<'a> &'a V::AggregateShare: Into<Vec<u8>>,
-{
+pub enum PrepareTransition<V: Aggregator<L>, const L: usize> {
     /// Continue processing.
     Continue(V::PrepareState, V::PrepareShare),
 
@@ -279,23 +266,23 @@ impl<F> AsRef<[F]> for OutputShare<F> {
     }
 }
 
-impl<F> From<Vec<F>> for OutputShare<F> {
+impl<F: FieldElement> From<Vec<F>> for OutputShare<F> {
     fn from(other: Vec<F>) -> Self {
         Self(other)
     }
 }
 
-impl<F: FieldElement> TryFrom<&[u8]> for OutputShare<F> {
-    type Error = FieldError;
-
-    fn try_from(bytes: &[u8]) -> Result<Self, Self::Error> {
-        fieldvec_try_from_bytes(bytes)
+impl<F: FieldElement> From<OutputShare<F>> for Vec<u8> {
+    fn from(output_share: OutputShare<F>) -> Self {
+        fieldvec_to_vec(&output_share.0)
     }
 }
 
-impl<F: FieldElement> From<&OutputShare<F>> for Vec<u8> {
-    fn from(output_share: &OutputShare<F>) -> Self {
-        fieldvec_to_vec(&output_share.0)
+impl<F: FieldElement> TryFrom<Vec<u8>> for OutputShare<F> {
+    type Error = FieldError;
+
+    fn try_from(bytes: Vec<u8>) -> Result<Self, Self::Error> {
+        fieldvec_try_from_bytes(&bytes)
     }
 }
 
@@ -305,19 +292,19 @@ impl<F: FieldElement> From<&OutputShare<F>> for Vec<u8> {
 #[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
 pub struct AggregateShare<F>(Vec<F>);
 
-impl<F> AsRef<[F]> for AggregateShare<F> {
+impl<F: FieldElement> AsRef<[F]> for AggregateShare<F> {
     fn as_ref(&self) -> &[F] {
         &self.0
     }
 }
 
-impl<F> From<OutputShare<F>> for AggregateShare<F> {
+impl<F: FieldElement> From<OutputShare<F>> for AggregateShare<F> {
     fn from(other: OutputShare<F>) -> Self {
         Self(other.0)
     }
 }
 
-impl<F> From<Vec<F>> for AggregateShare<F> {
+impl<F: FieldElement> From<Vec<F>> for AggregateShare<F> {
     fn from(other: Vec<F>) -> Self {
         Self(other)
     }
@@ -355,16 +342,16 @@ impl<F: FieldElement> AggregateShare<F> {
     }
 }
 
-impl<F: FieldElement> TryFrom<&[u8]> for AggregateShare<F> {
+impl<F: FieldElement> TryFrom<Vec<u8>> for AggregateShare<F> {
     type Error = FieldError;
 
-    fn try_from(bytes: &[u8]) -> Result<Self, Self::Error> {
-        fieldvec_try_from_bytes(bytes)
+    fn try_from(bytes: Vec<u8>) -> Result<Self, Self::Error> {
+        fieldvec_try_from_bytes(&bytes)
     }
 }
 
-impl<F: FieldElement> From<&AggregateShare<F>> for Vec<u8> {
-    fn from(aggregate_share: &AggregateShare<F>) -> Self {
+impl<F: FieldElement> From<AggregateShare<F>> for Vec<u8> {
+    fn from(aggregate_share: AggregateShare<F>) -> Self {
         fieldvec_to_vec(&aggregate_share.0)
     }
 }
@@ -393,7 +380,6 @@ pub(crate) fn run_vdaf<V, M, const L: usize>(
 ) -> Result<V::AggregateResult, VdafError>
 where
     V: Client + Aggregator<L> + Collector,
-    for<'a> &'a V::AggregateShare: Into<Vec<u8>>,
     M: IntoIterator<Item = V::Measurement>,
 {
     use rand::prelude::*;
@@ -445,7 +431,6 @@ pub(crate) fn run_vdaf_prepare<V, M, const L: usize>(
 ) -> Result<Vec<V::OutputShare>, VdafError>
 where
     V: Client + Aggregator<L> + Collector,
-    for<'a> &'a V::AggregateShare: Into<Vec<u8>>,
     M: IntoIterator<Item = V::InputShare>,
 {
     let input_shares = input_shares
@@ -524,17 +509,16 @@ mod tests {
     fn fieldvec_roundtrip_test<F, T>()
     where
         F: FieldElement,
-        for<'a> T: Debug + PartialEq + From<Vec<F>> + TryFrom<&'a [u8]>,
-        for<'a> <T as TryFrom<&'a [u8]>>::Error: Debug,
-        for<'a> Vec<u8>: From<&'a T>,
+        T: Clone + Debug + PartialEq + From<Vec<F>> + TryFrom<Vec<u8>> + Into<Vec<u8>>,
+        <T as TryFrom<Vec<u8>>>::Error: Debug,
     {
         // Generate a value based on an arbitrary vector of field elements.
         let g = F::generator();
         let want_value = T::from(iterate(F::one(), |&v| g * v).take(10).collect());
 
         // Round-trip the value through a byte-vector.
-        let buf: Vec<u8> = (&want_value).into();
-        let got_value = T::try_from(&buf).unwrap();
+        let buf: Vec<u8> = want_value.clone().into();
+        let got_value = T::try_from(buf).unwrap();
 
         assert_eq!(want_value, got_value);
     }

--- a/src/vdaf.rs
+++ b/src/vdaf.rs
@@ -119,9 +119,6 @@ impl<F: FieldElement, const L: usize> Encode for Share<F, L> {
 /// The base trait for VDAF schemes. This trait is inherited by traits [`Client`], [`Aggregator`],
 /// and [`Collector`], which define the roles of the various parties involved in the execution of
 /// the VDAF.
-// TODO(brandon): once GATs are stabilized [https://github.com/rust-lang/rust/issues/44265],
-// state the "&AggregateShare must implement Into<Vec<u8>>" constraint in terms of a where clause
-// on the associated type instead of a where clause on the trait.
 pub trait Vdaf: Clone + Debug {
     /// Algorithm identifier for this VDAF.
     const ID: u32;

--- a/src/vdaf.rs
+++ b/src/vdaf.rs
@@ -263,8 +263,7 @@ impl<F> AsRef<[F]> for OutputShare<F> {
     }
 }
 
-// XXX: drop FieldElement requirement?
-impl<F: FieldElement> From<Vec<F>> for OutputShare<F> {
+impl<F> From<Vec<F>> for OutputShare<F> {
     fn from(other: Vec<F>) -> Self {
         Self(other)
     }
@@ -302,8 +301,7 @@ impl<F: FieldElement> From<OutputShare<F>> for AggregateShare<F> {
     }
 }
 
-// XXX: drop FieldElement requirement?
-impl<F: FieldElement> From<Vec<F>> for AggregateShare<F> {
+impl<F> From<Vec<F>> for AggregateShare<F> {
     fn from(other: Vec<F>) -> Self {
         Self(other)
     }


### PR DESCRIPTION
Previously, these were written in terms of transformations to and from references to sequences of bytes. While From & Into can be used in that way, this doesn't fit with their normal usage, which is to consume some type and transform it into another type (in this case, consume the aggregate share and turn it into an owned vector of its serialization, or vice versa). More practically, specifying things in terms of references required specifying a "where" clause which effectively became infectious, needing to be copied to every place the Vdaf trait was referenced.

**This is a breaking change, do not merge until a breaking change window.**