### PR TITLE
Configure dependabot for release/0.10

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -21,3 +21,15 @@ updates:
     schedule:
       interval: "weekly"
     target-branch: release/0.8
+
+  - package-ecosystem: "cargo"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    target-branch: release/0.10
+
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    target-branch: release/0.10


### PR DESCRIPTION
Ahead of branching for the 0.10 crate series, configure dependabot to keep dependencies on that branch up to date.