### PR TITLE
Use more explicit types than `()` in vdaf impls

### DIFF
--- a/src/vdaf/poplar1.rs
+++ b/src/vdaf/poplar1.rs
@@ -361,7 +361,10 @@ where
     P: Prg<L>,
 {
     #[allow(clippy::many_single_char_names)]
-    fn shard(&self, input: &IdpfInput) -> Result<((), Vec<Poplar1InputShare<I, L>>), VdafError> {
+    fn shard(
+        &self,
+        input: &IdpfInput,
+    ) -> Result<(Self::PublicShare, Vec<Poplar1InputShare<I, L>>), VdafError> {
         let idpf_values: Vec<[I::Field; 2]> = Prng::new()?
             .take(input.level + 1)
             .map(|k| [I::Field::one(), k])

--- a/src/vdaf/prio2.rs
+++ b/src/vdaf/prio2.rs
@@ -107,7 +107,10 @@ impl Vdaf for Prio2 {
 }
 
 impl Client for Prio2 {
-    fn shard(&self, measurement: &Vec<u32>) -> Result<((), Vec<Share<FieldPrio2, 32>>), VdafError> {
+    fn shard(
+        &self,
+        measurement: &Vec<u32>,
+    ) -> Result<(Self::PublicShare, Vec<Share<FieldPrio2, 32>>), VdafError> {
         if measurement.len() != self.input_len {
             return Err(VdafError::Uncategorized("incorrect input length".into()));
         }
@@ -194,7 +197,7 @@ impl Aggregator<32> for Prio2 {
         &self,
         agg_key: &[u8; 32],
         agg_id: usize,
-        _agg_param: &(),
+        _agg_param: &Self::AggregationParam,
         nonce: &[u8],
         _public_share: &Self::PublicShare,
         input_share: &Share<FieldPrio2, 32>,
@@ -252,7 +255,7 @@ impl Aggregator<32> for Prio2 {
 
     fn aggregate<M: IntoIterator<Item = OutputShare<FieldPrio2>>>(
         &self,
-        _agg_param: &(),
+        _agg_param: &Self::AggregationParam,
         out_shares: M,
     ) -> Result<AggregateShare<FieldPrio2>, VdafError> {
         let mut agg_share = AggregateShare(vec![FieldPrio2::zero(); self.input_len]);
@@ -267,7 +270,7 @@ impl Aggregator<32> for Prio2 {
 impl Collector for Prio2 {
     fn unshard<M: IntoIterator<Item = AggregateShare<FieldPrio2>>>(
         &self,
-        _agg_param: &(),
+        _agg_param: &Self::AggregationParam,
         agg_shares: M,
         _num_measurements: usize,
     ) -> Result<Vec<u32>, VdafError> {

--- a/src/vdaf/prio3.rs
+++ b/src/vdaf/prio3.rs
@@ -703,7 +703,7 @@ where
     fn shard(
         &self,
         measurement: &T::Measurement,
-    ) -> Result<((), Vec<Prio3InputShare<T::Field, L>>), VdafError> {
+    ) -> Result<(Self::PublicShare, Vec<Prio3InputShare<T::Field, L>>), VdafError> {
         self.shard_with_rand_source(measurement, getrandom::getrandom)
             .map(|input_shares| ((), input_shares))
     }
@@ -780,9 +780,9 @@ where
         &self,
         verify_key: &[u8; L],
         agg_id: usize,
-        _agg_param: &(),
+        _agg_param: &Self::AggregationParam,
         nonce: &[u8],
-        _public_share: &(),
+        _public_share: &Self::PublicShare,
         msg: &Prio3InputShare<T::Field, L>,
     ) -> Result<
         (
@@ -999,7 +999,7 @@ where
     /// Combines aggregate shares into the aggregate result.
     fn unshard<It: IntoIterator<Item = AggregateShare<T::Field>>>(
         &self,
-        _agg_param: &(),
+        _agg_param: &Self::AggregationParam,
         agg_shares: It,
         num_measurements: usize,
     ) -> Result<T::AggregateResult, VdafError> {


### PR DESCRIPTION
A number of function signatures in implementations of the `Vdaf` family of traits were using `()` as the type for their public shares or aggregation parameters. We now use `Self::PublicShare` or `Self::AggregationParam` as appropriate to make signatures and docs more clear.