### PR TITLE
Require codec traits on OutputShare/AggregateShare

### DIFF
--- a/src/field.rs
+++ b/src/field.rs
@@ -167,9 +167,7 @@ pub trait FieldElement:
     /// impossible.
     fn slice_into_byte_vec(values: &[Self]) -> Vec<u8> {
         let mut vec = Vec::with_capacity(values.len() * Self::ENCODED_SIZE);
-        for elem in values {
-            vec.append(&mut (*elem).into());
-        }
+        encode_fieldvec(values, &mut vec);
         vec
     }
 

--- a/src/field.rs
+++ b/src/field.rs
@@ -784,10 +784,12 @@ pub(crate) fn decode_fieldvec<F: FieldElement>(
     input: &mut Cursor<&[u8]>,
 ) -> Result<Vec<F>, CodecError> {
     let mut vec = Vec::with_capacity(count);
-    let mut buffer = vec![0; count * F::ENCODED_SIZE];
-    input.read_exact(&mut buffer)?;
-    for chunk in buffer.chunks(F::ENCODED_SIZE) {
-        vec.push(F::try_from(chunk).map_err(|e| CodecError::Other(Box::new(e)))?);
+    let mut buffer = [0u8; 64];
+    for _ in 0..count {
+        input.read_exact(&mut buffer[..F::ENCODED_SIZE])?;
+        vec.push(
+            F::try_from(&buffer[..F::ENCODED_SIZE]).map_err(|e| CodecError::Other(Box::new(e)))?,
+        );
     }
     Ok(vec)
 }

--- a/src/field.rs
+++ b/src/field.rs
@@ -727,7 +727,6 @@ make_field!(
 /// # Errors
 ///
 /// Fails if the two vectors do not have the same length.
-#[cfg(any(test, feature = "prio2"))]
 pub(crate) fn merge_vector<F: FieldElement>(
     accumulator: &mut [F],
     other_vector: &[F],
@@ -793,20 +792,6 @@ pub(crate) fn decode_fieldvec<F: FieldElement>(
         vec.push(F::try_from(chunk).map_err(|e| CodecError::Other(Box::new(e)))?);
     }
     Ok(vec)
-}
-
-/// `add_fieldvec` adds one vector of field elements to another elementwise, in-place, and returns an
-/// error if the vectors have different lengths.
-pub(crate) fn add_fieldvec<F: FieldElement>(left: &mut [F], right: &[F]) -> Result<(), FieldError> {
-    if left.len() != right.len() {
-        return Err(FieldError::InputSizeMismatch);
-    }
-
-    for (x, y) in left.iter_mut().zip(right.iter()) {
-        *x += *y;
-    }
-
-    Ok(())
 }
 
 #[cfg(test)]

--- a/src/field.rs
+++ b/src/field.rs
@@ -785,6 +785,10 @@ pub(crate) fn decode_fieldvec<F: FieldElement>(
 ) -> Result<Vec<F>, CodecError> {
     let mut vec = Vec::with_capacity(count);
     let mut buffer = [0u8; 64];
+    assert!(
+        buffer.len() >= F::ENCODED_SIZE,
+        "field is too big for buffer"
+    );
     for _ in 0..count {
         input.read_exact(&mut buffer[..F::ENCODED_SIZE])?;
         vec.push(

--- a/src/vdaf.rs
+++ b/src/vdaf.rs
@@ -304,7 +304,7 @@ impl<F: FieldElement> Aggregatable for AggregateShare<F> {
     }
 
     fn accumulate(&mut self, output_share: &Self::OutputShare) -> Result<(), VdafError> {
-        // For poplar1, prio2, and prio3, no conversion is needed between output shares and
+        // For Poplar1, Prio2, and Prio3, no conversion is needed between output shares and
         // aggregate shares.
         self.sum(output_share.as_ref())
     }

--- a/src/vdaf.rs
+++ b/src/vdaf.rs
@@ -7,7 +7,7 @@
 
 use crate::{
     codec::{CodecError, Decode, Encode, ParameterizedDecode},
-    field::{add_fieldvec, encode_fieldvec, FieldElement, FieldError},
+    field::{encode_fieldvec, merge_vector, FieldElement, FieldError},
     flp::FlpError,
     prng::PrngError,
     vdaf::prg::Seed,
@@ -312,7 +312,7 @@ impl<F: FieldElement> Aggregatable for AggregateShare<F> {
 
 impl<F: FieldElement> AggregateShare<F> {
     fn sum(&mut self, other: &[F]) -> Result<(), VdafError> {
-        add_fieldvec(&mut self.0, other).map_err(Into::into)
+        merge_vector(&mut self.0, other).map_err(Into::into)
     }
 }
 

--- a/src/vdaf/poplar1.rs
+++ b/src/vdaf/poplar1.rs
@@ -35,11 +35,11 @@ use crate::fp::log2;
 use crate::prng::Prng;
 use crate::vdaf::prg::{Prg, Seed};
 use crate::vdaf::{
-    Aggregatable, Aggregator, Client, Collector, PrepareTransition, Share, ShareDecodingParameter,
-    Vdaf, VdafError,
+    Aggregator, Client, Collector, PrepareTransition, Share, ShareDecodingParameter, Vdaf,
+    VdafError,
 };
 
-use super::{add_fieldvec, decode_fieldvec, encode_fieldvec};
+use super::{decode_fieldvec, Aggregatable, AggregateShare, OutputShare};
 
 /// An input for an IDPF ([`Idpf`]).
 ///
@@ -349,8 +349,8 @@ where
     type AggregationParam = BTreeSet<IdpfInput>;
     type PublicShare = (); // TODO: Replace this when the IDPF from [BBCGGI21] is implemented.
     type InputShare = Poplar1InputShare<I, L>;
-    type OutputShare = Poplar1OutputShare<I::Field>;
-    type AggregateShare = Poplar1AggregateShare<I::Field>;
+    type OutputShare = OutputShare<I::Field>;
+    type AggregateShare = AggregateShare<I::Field>;
 
     fn num_aggregators(&self) -> usize {
         2
@@ -528,7 +528,7 @@ where
         Ok((
             Poplar1PrepareState {
                 sketch: SketchState::RoundOne,
-                output_share: Poplar1OutputShare(output_share),
+                output_share: OutputShare(output_share),
                 d,
                 e,
                 x,
@@ -622,12 +622,12 @@ where
         }
     }
 
-    fn aggregate<M: IntoIterator<Item = Poplar1OutputShare<I::Field>>>(
+    fn aggregate<M: IntoIterator<Item = OutputShare<I::Field>>>(
         &self,
         agg_param: &BTreeSet<IdpfInput>,
         output_shares: M,
-    ) -> Result<Poplar1AggregateShare<I::Field>, VdafError> {
-        let mut agg_share = Poplar1AggregateShare(vec![I::Field::zero(); agg_param.len()]);
+    ) -> Result<AggregateShare<I::Field>, VdafError> {
+        let mut agg_share = AggregateShare(vec![I::Field::zero(); agg_param.len()]);
         for output_share in output_shares.into_iter() {
             agg_share.accumulate(&output_share)?;
         }
@@ -676,7 +676,7 @@ pub struct Poplar1PrepareState<F> {
     sketch: SketchState,
 
     /// The output share.
-    output_share: Poplar1OutputShare<F>,
+    output_share: OutputShare<F>,
 
     /// Aggregator's share of $A = -2a + k$.
     d: F,
@@ -699,13 +699,13 @@ where
     I: Idpf<2, 2>,
     P: Prg<L>,
 {
-    fn unshard<M: IntoIterator<Item = Poplar1AggregateShare<I::Field>>>(
+    fn unshard<M: IntoIterator<Item = AggregateShare<I::Field>>>(
         &self,
         agg_param: &BTreeSet<IdpfInput>,
         agg_shares: M,
         _num_measurements: usize,
     ) -> Result<BTreeMap<IdpfInput, u64>, VdafError> {
-        let mut agg_data = Poplar1AggregateShare(vec![I::Field::zero(); agg_param.len()]);
+        let mut agg_data = AggregateShare(vec![I::Field::zero(); agg_param.len()]);
         for agg_share in agg_shares.into_iter() {
             agg_data.merge(&agg_share)?;
         }
@@ -722,27 +722,8 @@ where
     }
 }
 
-/// A Poplar1 output share comprised of a vector of field elements.
-#[derive(Debug, Clone)]
-pub struct Poplar1OutputShare<F>(Vec<F>);
-
-impl<F> AsRef<[F]> for Poplar1OutputShare<F> {
-    fn as_ref(&self) -> &[F] {
-        &self.0
-    }
-}
-
-impl<F> Encode for Poplar1OutputShare<F>
-where
-    F: FieldElement,
-{
-    fn encode(&self, bytes: &mut Vec<u8>) {
-        encode_fieldvec(self, bytes)
-    }
-}
-
 impl<'a, F, I, P, const L: usize>
-    ParameterizedDecode<(&'a Poplar1<I, P, L>, &'a BTreeSet<IdpfInput>)> for Poplar1OutputShare<F>
+    ParameterizedDecode<(&'a Poplar1<I, P, L>, &'a BTreeSet<IdpfInput>)> for OutputShare<F>
 where
     F: FieldElement,
     P: Prg<L>,
@@ -751,38 +732,12 @@ where
         (_, agg_param): &(&'a Poplar1<I, P, L>, &'a BTreeSet<IdpfInput>),
         bytes: &mut Cursor<&[u8]>,
     ) -> Result<Self, CodecError> {
-        decode_fieldvec(agg_param.len(), bytes).map(Poplar1OutputShare)
-    }
-}
-
-/// A Poplar1 aggregate share comprised of a vector of field elements.
-#[derive(Debug, Clone)]
-pub struct Poplar1AggregateShare<F>(Vec<F>);
-
-impl<F> AsRef<[F]> for Poplar1AggregateShare<F> {
-    fn as_ref(&self) -> &[F] {
-        &self.0
-    }
-}
-
-impl<F> From<Poplar1OutputShare<F>> for Poplar1AggregateShare<F> {
-    fn from(other: Poplar1OutputShare<F>) -> Self {
-        Self(other.0)
-    }
-}
-
-impl<F> Encode for Poplar1AggregateShare<F>
-where
-    F: FieldElement,
-{
-    fn encode(&self, bytes: &mut Vec<u8>) {
-        encode_fieldvec(self, bytes)
+        decode_fieldvec(agg_param.len(), bytes).map(OutputShare)
     }
 }
 
 impl<'a, F, I, P, const L: usize>
-    ParameterizedDecode<(&'a Poplar1<I, P, L>, &'a BTreeSet<IdpfInput>)>
-    for Poplar1AggregateShare<F>
+    ParameterizedDecode<(&'a Poplar1<I, P, L>, &'a BTreeSet<IdpfInput>)> for AggregateShare<F>
 where
     F: FieldElement,
     P: Prg<L>,
@@ -791,23 +746,7 @@ where
         (_, agg_param): &(&'a Poplar1<I, P, L>, &'a BTreeSet<IdpfInput>),
         bytes: &mut Cursor<&[u8]>,
     ) -> Result<Self, CodecError> {
-        decode_fieldvec(agg_param.len(), bytes).map(Poplar1AggregateShare)
-    }
-}
-
-impl<F> Aggregatable for Poplar1AggregateShare<F>
-where
-    F: FieldElement,
-{
-    type OutputShare = Poplar1OutputShare<F>;
-
-    fn merge(&mut self, agg_share: &Self) -> Result<(), VdafError> {
-        add_fieldvec(&mut self.0, agg_share.as_ref())
-    }
-
-    fn accumulate(&mut self, output_share: &Self::OutputShare) -> Result<(), VdafError> {
-        // For poplar1, no conversion is needed between output shares and aggregation shares.
-        add_fieldvec(&mut self.0, output_share.as_ref())
+        decode_fieldvec(agg_param.len(), bytes).map(AggregateShare)
     }
 }
 
@@ -1035,7 +974,7 @@ mod tests {
         fieldvec_roundtrip_test::<
             Field128,
             Poplar1<ToyIdpf<Field128>, PrgAes128, 16>,
-            Poplar1OutputShare<Field128>,
+            OutputShare<Field128>,
         >(&vdaf, &agg_param, 3);
     }
 
@@ -1051,7 +990,7 @@ mod tests {
         fieldvec_roundtrip_test::<
             Field128,
             Poplar1<ToyIdpf<Field128>, PrgAes128, 16>,
-            Poplar1AggregateShare<Field128>,
+            AggregateShare<Field128>,
         >(&vdaf, &agg_param, 3);
     }
 }

--- a/src/vdaf/poplar1.rs
+++ b/src/vdaf/poplar1.rs
@@ -730,7 +730,7 @@ where
         (_, agg_param): &(&'a Poplar1<I, P, L>, &'a BTreeSet<IdpfInput>),
         bytes: &mut Cursor<&[u8]>,
     ) -> Result<Self, CodecError> {
-        decode_fieldvec(agg_param.len(), bytes).map(OutputShare)
+        decode_fieldvec(agg_param.len(), bytes).map(Self)
     }
 }
 
@@ -744,7 +744,7 @@ where
         (_, agg_param): &(&'a Poplar1<I, P, L>, &'a BTreeSet<IdpfInput>),
         bytes: &mut Cursor<&[u8]>,
     ) -> Result<Self, CodecError> {
-        decode_fieldvec(agg_param.len(), bytes).map(AggregateShare)
+        decode_fieldvec(agg_param.len(), bytes).map(Self)
     }
 }
 

--- a/src/vdaf/poplar1.rs
+++ b/src/vdaf/poplar1.rs
@@ -30,16 +30,14 @@ use crate::codec::{
     decode_u16_items, decode_u24_items, encode_u16_items, encode_u24_items, CodecError, Decode,
     Encode, ParameterizedDecode,
 };
-use crate::field::{split_vector, FieldElement};
+use crate::field::{decode_fieldvec, split_vector, FieldElement};
 use crate::fp::log2;
 use crate::prng::Prng;
 use crate::vdaf::prg::{Prg, Seed};
 use crate::vdaf::{
-    Aggregator, Client, Collector, PrepareTransition, Share, ShareDecodingParameter, Vdaf,
-    VdafError,
+    Aggregatable, AggregateShare, Aggregator, Client, Collector, OutputShare, PrepareTransition,
+    Share, ShareDecodingParameter, Vdaf, VdafError,
 };
-
-use super::{decode_fieldvec, Aggregatable, AggregateShare, OutputShare};
 
 /// An input for an IDPF ([`Idpf`]).
 ///

--- a/src/vdaf/prio2.rs
+++ b/src/vdaf/prio2.rs
@@ -308,7 +308,7 @@ where
         (prio2, _): &(&'a Prio2, &'a ()),
         bytes: &mut Cursor<&[u8]>,
     ) -> Result<Self, CodecError> {
-        decode_fieldvec(prio2.input_len, bytes).map(OutputShare)
+        decode_fieldvec(prio2.input_len, bytes).map(Self)
     }
 }
 
@@ -320,7 +320,7 @@ where
         (prio2, _): &(&'a Prio2, &'a ()),
         bytes: &mut Cursor<&[u8]>,
     ) -> Result<Self, CodecError> {
-        decode_fieldvec(prio2.input_len, bytes).map(AggregateShare)
+        decode_fieldvec(prio2.input_len, bytes).map(Self)
     }
 }
 

--- a/src/vdaf/prio2.rs
+++ b/src/vdaf/prio2.rs
@@ -7,13 +7,13 @@ use super::{AggregateShare, OutputShare};
 use crate::{
     client as v2_client,
     codec::{CodecError, Decode, Encode, ParameterizedDecode},
-    field::{FieldElement, FieldPrio2},
+    field::{decode_fieldvec, FieldElement, FieldPrio2},
     prng::Prng,
     server as v2_server,
     util::proof_length,
     vdaf::{
-        decode_fieldvec, prg::Seed, Aggregatable, Aggregator, Client, Collector, PrepareTransition,
-        Share, ShareDecodingParameter, Vdaf, VdafError,
+        prg::Seed, Aggregatable, Aggregator, Client, Collector, PrepareTransition, Share,
+        ShareDecodingParameter, Vdaf, VdafError,
     },
 };
 use ring::hmac;

--- a/src/vdaf/prio2.rs
+++ b/src/vdaf/prio2.rs
@@ -3,6 +3,7 @@
 //! Port of the ENPA Prio system to a VDAF. It is backwards compatible with
 //! [`Client`](crate::client::Client) and [`Server`](crate::server::Server).
 
+use super::{AggregateShare, OutputShare};
 use crate::{
     client as v2_client,
     codec::{CodecError, Decode, Encode, ParameterizedDecode},
@@ -11,8 +12,8 @@ use crate::{
     server as v2_server,
     util::proof_length,
     vdaf::{
-        decode_fieldvec, encode_fieldvec, prg::Seed, Aggregatable, Aggregator, Client, Collector,
-        PrepareTransition, Share, ShareDecodingParameter, Vdaf, VdafError,
+        decode_fieldvec, prg::Seed, Aggregatable, Aggregator, Client, Collector, PrepareTransition,
+        Share, ShareDecodingParameter, Vdaf, VdafError,
     },
 };
 use ring::hmac;
@@ -20,8 +21,6 @@ use std::{
     convert::{TryFrom, TryInto},
     io::Cursor,
 };
-
-use super::add_fieldvec;
 
 /// The Prio2 VDAF. It supports the same measurement type as
 /// [`Prio3Aes128CountVec`](crate::vdaf::prio3::Prio3Aes128CountVec) but uses the proof system
@@ -99,8 +98,8 @@ impl Vdaf for Prio2 {
     type AggregationParam = ();
     type PublicShare = ();
     type InputShare = Share<FieldPrio2, 32>;
-    type OutputShare = Prio2OutputShare<FieldPrio2>;
-    type AggregateShare = Prio2AggregateShare<FieldPrio2>;
+    type OutputShare = OutputShare<FieldPrio2>;
+    type AggregateShare = AggregateShare<FieldPrio2>;
 
     fn num_aggregators(&self) -> usize {
         // Prio2 can easily be extended to support more than two Aggregators.
@@ -252,15 +251,15 @@ impl Aggregator<32> for Prio2 {
                 prng.take(self.input_len).collect()
             }
         };
-        Ok(PrepareTransition::Finish(Prio2OutputShare::from(data)))
+        Ok(PrepareTransition::Finish(OutputShare::from(data)))
     }
 
-    fn aggregate<M: IntoIterator<Item = Prio2OutputShare<FieldPrio2>>>(
+    fn aggregate<M: IntoIterator<Item = OutputShare<FieldPrio2>>>(
         &self,
         _agg_param: &Self::AggregationParam,
         out_shares: M,
-    ) -> Result<Prio2AggregateShare<FieldPrio2>, VdafError> {
-        let mut agg_share = Prio2AggregateShare(vec![FieldPrio2::zero(); self.input_len]);
+    ) -> Result<AggregateShare<FieldPrio2>, VdafError> {
+        let mut agg_share = AggregateShare(vec![FieldPrio2::zero(); self.input_len]);
         for out_share in out_shares.into_iter() {
             agg_share.accumulate(&out_share)?;
         }
@@ -270,13 +269,13 @@ impl Aggregator<32> for Prio2 {
 }
 
 impl Collector for Prio2 {
-    fn unshard<M: IntoIterator<Item = Prio2AggregateShare<FieldPrio2>>>(
+    fn unshard<M: IntoIterator<Item = AggregateShare<FieldPrio2>>>(
         &self,
         _agg_param: &Self::AggregationParam,
         agg_shares: M,
         _num_measurements: usize,
     ) -> Result<Vec<u32>, VdafError> {
-        let mut agg = Prio2AggregateShare(vec![FieldPrio2::zero(); self.input_len]);
+        let mut agg = AggregateShare(vec![FieldPrio2::zero(); self.input_len]);
         for agg_share in agg_shares.into_iter() {
             agg.merge(&agg_share)?;
         }
@@ -301,32 +300,7 @@ impl<'a> ParameterizedDecode<(&'a Prio2, usize)> for Share<FieldPrio2, 32> {
     }
 }
 
-/// A Prio2 output share comprised of a vector of field elements.
-#[derive(Debug, Clone)]
-pub struct Prio2OutputShare<F>(Vec<F>);
-
-impl<F> AsRef<[F]> for Prio2OutputShare<F> {
-    fn as_ref(&self) -> &[F] {
-        &self.0
-    }
-}
-
-impl<F> From<Vec<F>> for Prio2OutputShare<F> {
-    fn from(vec: Vec<F>) -> Self {
-        Prio2OutputShare(vec)
-    }
-}
-
-impl<F> Encode for Prio2OutputShare<F>
-where
-    F: FieldElement,
-{
-    fn encode(&self, bytes: &mut Vec<u8>) {
-        encode_fieldvec(self, bytes)
-    }
-}
-
-impl<'a, F> ParameterizedDecode<(&'a Prio2, &'a ())> for Prio2OutputShare<F>
+impl<'a, F> ParameterizedDecode<(&'a Prio2, &'a ())> for OutputShare<F>
 where
     F: FieldElement,
 {
@@ -334,36 +308,11 @@ where
         (prio2, _): &(&'a Prio2, &'a ()),
         bytes: &mut Cursor<&[u8]>,
     ) -> Result<Self, CodecError> {
-        decode_fieldvec(prio2.input_len, bytes).map(Prio2OutputShare)
+        decode_fieldvec(prio2.input_len, bytes).map(OutputShare)
     }
 }
 
-/// A Prio2 aggregate share comprised of a vector of field elements.
-#[derive(Debug, Clone)]
-pub struct Prio2AggregateShare<F>(Vec<F>);
-
-impl<F> AsRef<[F]> for Prio2AggregateShare<F> {
-    fn as_ref(&self) -> &[F] {
-        &self.0
-    }
-}
-
-impl<F> From<Prio2OutputShare<F>> for Prio2AggregateShare<F> {
-    fn from(value: Prio2OutputShare<F>) -> Self {
-        Prio2AggregateShare(value.0)
-    }
-}
-
-impl<F> Encode for Prio2AggregateShare<F>
-where
-    F: FieldElement,
-{
-    fn encode(&self, bytes: &mut Vec<u8>) {
-        encode_fieldvec(self, bytes)
-    }
-}
-
-impl<'a, F> ParameterizedDecode<(&'a Prio2, &'a ())> for Prio2AggregateShare<F>
+impl<'a, F> ParameterizedDecode<(&'a Prio2, &'a ())> for AggregateShare<F>
 where
     F: FieldElement,
 {
@@ -371,22 +320,7 @@ where
         (prio2, _): &(&'a Prio2, &'a ()),
         bytes: &mut Cursor<&[u8]>,
     ) -> Result<Self, CodecError> {
-        decode_fieldvec(prio2.input_len, bytes).map(Prio2AggregateShare)
-    }
-}
-
-impl<F> Aggregatable for Prio2AggregateShare<F>
-where
-    F: FieldElement,
-{
-    type OutputShare = Prio2OutputShare<F>;
-
-    fn merge(&mut self, agg_share: &Self) -> Result<(), VdafError> {
-        add_fieldvec(&mut self.0, agg_share.as_ref())
-    }
-
-    fn accumulate(&mut self, output_share: &Self::OutputShare) -> Result<(), VdafError> {
-        add_fieldvec(&mut self.0, output_share.as_ref())
+        decode_fieldvec(prio2.input_len, bytes).map(AggregateShare)
     }
 }
 
@@ -520,16 +454,12 @@ mod tests {
     #[test]
     fn roundtrip_output_share() {
         let vdaf = Prio2::new(31).unwrap();
-        fieldvec_roundtrip_test::<FieldPrio2, Prio2, Prio2OutputShare<FieldPrio2>>(&vdaf, &(), 31);
+        fieldvec_roundtrip_test::<FieldPrio2, Prio2, OutputShare<FieldPrio2>>(&vdaf, &(), 31);
     }
 
     #[test]
     fn roundtrip_aggregate_share() {
         let vdaf = Prio2::new(31).unwrap();
-        fieldvec_roundtrip_test::<FieldPrio2, Prio2, Prio2AggregateShare<FieldPrio2>>(
-            &vdaf,
-            &(),
-            31,
-        );
+        fieldvec_roundtrip_test::<FieldPrio2, Prio2, AggregateShare<FieldPrio2>>(&vdaf, &(), 31);
     }
 }

--- a/src/vdaf/prio3.rs
+++ b/src/vdaf/prio3.rs
@@ -1067,7 +1067,7 @@ where
         (vdaf, _): &(&'a Prio3<T, P, L>, &'a ()),
         bytes: &mut Cursor<&[u8]>,
     ) -> Result<Self, CodecError> {
-        decode_fieldvec(vdaf.output_len(), bytes).map(OutputShare)
+        decode_fieldvec(vdaf.output_len(), bytes).map(Self)
     }
 }
 
@@ -1082,7 +1082,7 @@ where
         (vdaf, _): &(&'a Prio3<T, P, L>, &'a ()),
         bytes: &mut Cursor<&[u8]>,
     ) -> Result<Self, CodecError> {
-        decode_fieldvec(vdaf.output_len(), bytes).map(AggregateShare)
+        decode_fieldvec(vdaf.output_len(), bytes).map(Self)
     }
 }
 

--- a/src/vdaf/prio3.rs
+++ b/src/vdaf/prio3.rs
@@ -29,9 +29,8 @@
 
 #[cfg(feature = "crypto-dependencies")]
 use super::prg::PrgAes128;
-use super::{decode_fieldvec, AggregateShare, OutputShare, DST_LEN, VERSION};
 use crate::codec::{CodecError, Decode, Encode, ParameterizedDecode};
-use crate::field::FieldElement;
+use crate::field::{decode_fieldvec, FieldElement};
 #[cfg(feature = "crypto-dependencies")]
 use crate::field::{Field128, Field64};
 #[cfg(feature = "multithreaded")]
@@ -48,8 +47,8 @@ use crate::flp::Type;
 use crate::prng::Prng;
 use crate::vdaf::prg::{Prg, RandSource, Seed};
 use crate::vdaf::{
-    Aggregatable, Aggregator, Client, Collector, PrepareTransition, Share, ShareDecodingParameter,
-    Vdaf, VdafError,
+    Aggregatable, AggregateShare, Aggregator, Client, Collector, OutputShare, PrepareTransition,
+    Share, ShareDecodingParameter, Vdaf, VdafError, DST_LEN, VERSION,
 };
 #[cfg(feature = "crypto-dependencies")]
 use fixed::traits::Fixed;

--- a/src/vdaf/prio3.rs
+++ b/src/vdaf/prio3.rs
@@ -29,7 +29,7 @@
 
 #[cfg(feature = "crypto-dependencies")]
 use super::prg::PrgAes128;
-use super::{add_fieldvec, decode_fieldvec, encode_fieldvec, DST_LEN, VERSION};
+use super::{decode_fieldvec, AggregateShare, OutputShare, DST_LEN, VERSION};
 use crate::codec::{CodecError, Decode, Encode, ParameterizedDecode};
 use crate::field::FieldElement;
 #[cfg(feature = "crypto-dependencies")]
@@ -53,7 +53,6 @@ use crate::vdaf::{
 };
 #[cfg(feature = "crypto-dependencies")]
 use fixed::traits::Fixed;
-use serde::{Deserialize, Serialize};
 use std::convert::TryFrom;
 use std::fmt::Debug;
 use std::io::Cursor;
@@ -527,8 +526,8 @@ where
     type AggregationParam = ();
     type PublicShare = ();
     type InputShare = Prio3InputShare<T::Field, L>;
-    type OutputShare = Prio3OutputShare<T::Field>;
-    type AggregateShare = Prio3AggregateShare<T::Field>;
+    type OutputShare = OutputShare<T::Field>;
+    type AggregateShare = AggregateShare<T::Field>;
 
     fn num_aggregators(&self) -> usize {
         self.num_aggregators as usize
@@ -968,7 +967,7 @@ where
         };
 
         let output_share = match self.typ.truncate(input_share) {
-            Ok(data) => Prio3OutputShare(data),
+            Ok(data) => OutputShare(data),
             Err(err) => {
                 return Err(VdafError::from(err));
             }
@@ -978,12 +977,12 @@ where
     }
 
     /// Aggregates a sequence of output shares into an aggregate share.
-    fn aggregate<It: IntoIterator<Item = Prio3OutputShare<T::Field>>>(
+    fn aggregate<It: IntoIterator<Item = OutputShare<T::Field>>>(
         &self,
         _agg_param: &(),
         output_shares: It,
-    ) -> Result<Prio3AggregateShare<T::Field>, VdafError> {
-        let mut agg_share = Prio3AggregateShare(vec![T::Field::zero(); self.typ.output_len()]);
+    ) -> Result<AggregateShare<T::Field>, VdafError> {
+        let mut agg_share = AggregateShare(vec![T::Field::zero(); self.typ.output_len()]);
         for output_share in output_shares.into_iter() {
             agg_share.accumulate(&output_share)?;
         }
@@ -998,13 +997,13 @@ where
     P: Prg<L>,
 {
     /// Combines aggregate shares into the aggregate result.
-    fn unshard<It: IntoIterator<Item = Prio3AggregateShare<T::Field>>>(
+    fn unshard<It: IntoIterator<Item = AggregateShare<T::Field>>>(
         &self,
         _agg_param: &Self::AggregationParam,
         agg_shares: It,
         num_measurements: usize,
     ) -> Result<T::AggregateResult, VdafError> {
-        let mut agg = Prio3AggregateShare(vec![T::Field::zero(); self.typ.output_len()]);
+        let mut agg = AggregateShare(vec![T::Field::zero(); self.typ.output_len()]);
         for agg_share in agg_shares.into_iter() {
             agg.merge(&agg_share)?;
         }
@@ -1058,33 +1057,8 @@ fn check_num_aggregators(num_aggregators: u8) -> Result<(), VdafError> {
     Ok(())
 }
 
-/// A Prio3 output share comprised of a vector of field elements.
-#[derive(Clone, Debug, PartialEq, Eq)]
-pub struct Prio3OutputShare<F>(Vec<F>);
-
-impl<F> AsRef<[F]> for Prio3OutputShare<F> {
-    fn as_ref(&self) -> &[F] {
-        &self.0
-    }
-}
-
-impl<F> From<Vec<F>> for Prio3OutputShare<F> {
-    fn from(other: Vec<F>) -> Self {
-        Self(other)
-    }
-}
-
-impl<F> Encode for Prio3OutputShare<F>
-where
-    F: FieldElement,
-{
-    fn encode(&self, bytes: &mut Vec<u8>) {
-        encode_fieldvec(self, bytes)
-    }
-}
-
 impl<'a, F, T, P, const L: usize> ParameterizedDecode<(&'a Prio3<T, P, L>, &'a ())>
-    for Prio3OutputShare<F>
+    for OutputShare<F>
 where
     F: FieldElement,
     T: Type,
@@ -1094,68 +1068,12 @@ where
         (vdaf, _): &(&'a Prio3<T, P, L>, &'a ()),
         bytes: &mut Cursor<&[u8]>,
     ) -> Result<Self, CodecError> {
-        decode_fieldvec(vdaf.output_len(), bytes).map(Prio3OutputShare)
-    }
-}
-
-/// A Prio3 aggregate share, comprised of a vector of field elements.
-#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
-pub struct Prio3AggregateShare<F>(Vec<F>);
-
-impl<F> AsRef<[F]> for Prio3AggregateShare<F> {
-    fn as_ref(&self) -> &[F] {
-        &self.0
-    }
-}
-
-impl<F> From<Prio3OutputShare<F>> for Prio3AggregateShare<F> {
-    fn from(other: Prio3OutputShare<F>) -> Self {
-        Self(other.0)
-    }
-}
-
-impl<F> From<Vec<F>> for Prio3AggregateShare<F> {
-    fn from(other: Vec<F>) -> Self {
-        Self(other)
-    }
-}
-
-impl<F> Aggregatable for Prio3AggregateShare<F>
-where
-    F: FieldElement,
-{
-    type OutputShare = Prio3OutputShare<F>;
-
-    fn merge(&mut self, agg_share: &Self) -> Result<(), VdafError> {
-        self.sum(agg_share.as_ref())
-    }
-
-    fn accumulate(&mut self, output_share: &Self::OutputShare) -> Result<(), VdafError> {
-        // For prio3, no conversion is needed between output shares and aggregation shares.
-        self.sum(output_share.as_ref())
-    }
-}
-
-impl<F> Prio3AggregateShare<F>
-where
-    F: FieldElement,
-{
-    fn sum(&mut self, other: &[F]) -> Result<(), VdafError> {
-        add_fieldvec(&mut self.0, other)
-    }
-}
-
-impl<F> Encode for Prio3AggregateShare<F>
-where
-    F: FieldElement,
-{
-    fn encode(&self, bytes: &mut Vec<u8>) {
-        encode_fieldvec(self, bytes)
+        decode_fieldvec(vdaf.output_len(), bytes).map(OutputShare)
     }
 }
 
 impl<'a, F, T, P, const L: usize> ParameterizedDecode<(&'a Prio3<T, P, L>, &'a ())>
-    for Prio3AggregateShare<F>
+    for AggregateShare<F>
 where
     F: FieldElement,
     T: Type,
@@ -1165,7 +1083,7 @@ where
         (vdaf, _): &(&'a Prio3<T, P, L>, &'a ()),
         bytes: &mut Cursor<&[u8]>,
     ) -> Result<Self, CodecError> {
-        decode_fieldvec(vdaf.output_len(), bytes).map(Prio3AggregateShare)
+        decode_fieldvec(vdaf.output_len(), bytes).map(AggregateShare)
     }
 }
 
@@ -1511,21 +1429,13 @@ mod tests {
     #[test]
     fn roundtrip_output_share() {
         let vdaf = Prio3::new_aes128_count(2).unwrap();
-        fieldvec_roundtrip_test::<Field64, Prio3Aes128Count, Prio3OutputShare<Field64>>(
-            &vdaf,
-            &(),
-            1,
-        );
+        fieldvec_roundtrip_test::<Field64, Prio3Aes128Count, OutputShare<Field64>>(&vdaf, &(), 1);
 
         let vdaf = Prio3::new_aes128_sum(2, 17).unwrap();
-        fieldvec_roundtrip_test::<Field128, Prio3Aes128Sum, Prio3OutputShare<Field128>>(
-            &vdaf,
-            &(),
-            1,
-        );
+        fieldvec_roundtrip_test::<Field128, Prio3Aes128Sum, OutputShare<Field128>>(&vdaf, &(), 1);
 
         let vdaf = Prio3::new_aes128_histogram(2, &[1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11]).unwrap();
-        fieldvec_roundtrip_test::<Field128, Prio3Aes128Histogram, Prio3OutputShare<Field128>>(
+        fieldvec_roundtrip_test::<Field128, Prio3Aes128Histogram, OutputShare<Field128>>(
             &vdaf,
             &(),
             12,
@@ -1535,21 +1445,21 @@ mod tests {
     #[test]
     fn roundtrip_aggregate_share() {
         let vdaf = Prio3::new_aes128_count(2).unwrap();
-        fieldvec_roundtrip_test::<Field64, Prio3Aes128Count, Prio3AggregateShare<Field64>>(
+        fieldvec_roundtrip_test::<Field64, Prio3Aes128Count, AggregateShare<Field64>>(
             &vdaf,
             &(),
             1,
         );
 
         let vdaf = Prio3::new_aes128_sum(2, 17).unwrap();
-        fieldvec_roundtrip_test::<Field128, Prio3Aes128Sum, Prio3AggregateShare<Field128>>(
+        fieldvec_roundtrip_test::<Field128, Prio3Aes128Sum, AggregateShare<Field128>>(
             &vdaf,
             &(),
             1,
         );
 
         let vdaf = Prio3::new_aes128_histogram(2, &[1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11]).unwrap();
-        fieldvec_roundtrip_test::<Field128, Prio3Aes128Histogram, Prio3AggregateShare<Field128>>(
+        fieldvec_roundtrip_test::<Field128, Prio3Aes128Histogram, AggregateShare<Field128>>(
             &vdaf,
             &(),
             12,


### PR DESCRIPTION
This implements the idea [here](https://github.com/divviup/libprio-rs/issues/382#issuecomment-1349900873), adding `Encode` and `ParameterizedDecode` trait bounds to the `OutputShare` and `AggregateShare` associated types, replacing `Into<Vec<u8>>` and `TryFrom<&'a [u8]>`.

This change is necessitated by Poplar1 as specified in VDAF-03, because encoded output shares for one prefix at the leaf level or four prefixes at an inner level are indistinguishable.

Note that this is a breaking change that affects all consumers of `prio::vdaf::Vdaf`.

Closes #382.