### PR TITLE
Clippy fixes

### DIFF
--- a/src/fp.rs
+++ b/src/fp.rs
@@ -202,7 +202,7 @@ impl FieldParameters {
         // ========
         // b1,s1,s0
         let (s0, b0) = prod.overflowing_sub(self.p);
-        let (_s1, b1) = (cc as u128).overflowing_sub(b0 as u128);
+        let (_s1, b1) = cc.overflowing_sub(b0 as u128);
         // if b1 == 1: return z
         // else:       return s0
         let mask = 0u128.wrapping_sub(b1 as u128);

--- a/src/vdaf.rs
+++ b/src/vdaf.rs
@@ -271,7 +271,7 @@ impl<F> From<Vec<F>> for OutputShare<F> {
 
 impl<F: FieldElement> From<OutputShare<F>> for Vec<u8> {
     fn from(output_share: OutputShare<F>) -> Self {
-        fieldvec_to_vec(&output_share.0)
+        fieldvec_to_vec(output_share.0)
     }
 }
 
@@ -349,7 +349,7 @@ impl<'a, F: FieldElement> TryFrom<&'a [u8]> for AggregateShare<F> {
 
 impl<F: FieldElement> From<AggregateShare<F>> for Vec<u8> {
     fn from(aggregate_share: AggregateShare<F>) -> Self {
-        fieldvec_to_vec(&aggregate_share.0)
+        fieldvec_to_vec(aggregate_share.0)
     }
 }
 


### PR DESCRIPTION
This removes a no-op conversion and some extra `&`s to fix CI on Rust 1.66.0.