### PR TITLE
Clippy fixes, 0.10

### DIFF
--- a/src/fp.rs
+++ b/src/fp.rs
@@ -202,7 +202,7 @@ impl FieldParameters {
         // ========
         // b1,s1,s0
         let (s0, b0) = prod.overflowing_sub(self.p);
-        let (_s1, b1) = (cc as u128).overflowing_sub(b0 as u128);
+        let (_s1, b1) = cc.overflowing_sub(b0 as u128);
         // if b1 == 1: return z
         // else:       return s0
         let mask = 0u128.wrapping_sub(b1 as u128);


### PR DESCRIPTION
This fixes one Clippy warning with Rust 1.66.