### PR TITLE
Add `experimental` Cargo feature

### DIFF
--- a/.github/workflows/ci-build.yml
+++ b/.github/workflows/ci-build.yml
@@ -57,6 +57,8 @@ jobs:
           "--features=prio2,test-util",
           "--features=prio2,multithreaded",
           "--features=prio2,test-util,multithreaded",
+          "--features=experimental",
+          "--features=experimental,multithreaded",
         ]
         rust-toolchain: [
           # MSRV from Cargo.toml

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,7 +15,7 @@ ctr = { version = "0.9.2", optional = true }
 cmac = { version = "0.7.1", optional = true }
 base64 = "0.20.0"
 byteorder = "1.4.3"
-fixed = "1.20"
+fixed = { version = "1.20", optional = true }
 getrandom = { version = "0.2.8", features = ["std"] }
 serde = { version = "1.0", features = ["derive"] }
 static_assertions = "1.1.0"
@@ -41,7 +41,7 @@ itertools = "0.10.5"
 modinverse = "0.1.0"
 num-bigint = "0.4.3"
 serde_json = "1.0"
-hex = { version = "0.4.3" , features = ["serde"] }
+hex = { version = "0.4.3", features = ["serde"] }
 # Enable test_vector module for test targets
 # https://github.com/rust-lang/cargo/issues/2911#issuecomment-749580481
 prio = { path = ".", features = ["test-util"] }
@@ -49,6 +49,7 @@ cfg-if = "1.0.0"
 
 [features]
 default = ["crypto-dependencies"]
+experimental = ["fixed"]
 test-util = ["rand", "serde_json"]
 multithreaded = ["rayon"]
 prio2 = ["aes-gcm", "ring"]

--- a/README.md
+++ b/README.md
@@ -42,5 +42,5 @@ This crate defines the following feature flags:
 |`crypto-dependencies`|Yes|Enables dependencies on various RustCrypto crates, and uses them to implement `PrgAes128` to support VDAFs.|
 |`experimental`|No|Certain experimental APIs are guarded by this feature. They may undergo breaking changes in future patch releases, as an exception to semantic versioning.|
 |`multithreaded`|No|Enables certain Prio3 VDAF implementations that use `rayon` for parallelization of gadget evaluations.|
-|`prio2`|No|Enables a VDAF based on the Prio2 system.|
+|`prio2`|No|Enables the Prio v2 API, and a VDAF based on the Prio2 system.|
 |`test-util`|No|For internal use only, to support the test suite and test vectors.|

--- a/README.md
+++ b/README.md
@@ -37,14 +37,10 @@ also forthcoming. Prio3 should not yet be used in production applications.
 
 This crate defines the following feature flags:
 
-- `crypto-dependencies`: Enables dependencies on various RustCrypto crates, and
-  uses them to implement `PrgAes128` to support VDAFs. This is enabled by
-  default.
-- `experimental`: Certain experimental APIs are guarded by this feature. They
-  may undergo breaking changes in future patch releases, as an exception to
-  semantic versioning.
-- `multithreaded`: Enables certain Prio3 VDAF implementations that use `serde`
-  for parallelization of gadget evaluations.
-- `prio2`: Enables a VDAF based on the Prio2 system.
-- `test-util`: For internal use only, to support the test suite and test
-  vectors.
+|Name|Default feature?|Description|
+|---|---|---|
+|`crypto-dependencies`|Yes|Enables dependencies on various RustCrypto crates, and uses them to implement `PrgAes128` to support VDAFs.|
+|`experimental`|No|Certain experimental APIs are guarded by this feature. They may undergo breaking changes in future patch releases, as an exception to semantic versioning.|
+|`multithreaded`|No|Enables certain Prio3 VDAF implementations that use `rayon` for parallelization of gadget evaluations.|
+|`prio2`|No|Enables a VDAF based on the Prio2 system.|
+|`test-util`|No|For internal use only, to support the test suite and test vectors.|

--- a/README.md
+++ b/README.md
@@ -32,3 +32,19 @@ also forthcoming. Prio3 should not yet be used in production applications.
 [prio-server]: https://github.com/divviup/prio-server
 [vdaf]: https://datatracker.ietf.org/doc/draft-irtf-cfrg-vdaf/
 [dap]: https://datatracker.ietf.org/doc/draft-ietf-ppm-dap/
+
+## Cargo Features
+
+This crate defines the following feature flags:
+
+- `crypto-dependencies`: Enables dependencies on various RustCrypto crates, and
+  uses them to implement `PrgAes128` to support VDAFs. This is enabled by
+  default.
+- `experimental`: Certain experimental APIs are guarded by this feature. They
+  may undergo breaking changes in future patch releases, as an exception to
+  semantic versioning.
+- `multithreaded`: Enables certain Prio3 VDAF implementations that use `serde`
+  for parallelization of gadget evaluations.
+- `prio2`: Enables a VDAF based on the Prio2 system.
+- `test-util`: For internal use only, to support the test suite and test
+  vectors.

--- a/benches/speed_tests.rs
+++ b/benches/speed_tests.rs
@@ -2,6 +2,7 @@
 
 use criterion::{criterion_group, criterion_main, Criterion};
 
+#[cfg(feature = "experimental")]
 use fixed_macro::fixed;
 use prio::benchmarked::*;
 #[cfg(feature = "prio2")]
@@ -263,25 +264,28 @@ pub fn prio3_client(c: &mut Criterion) {
         });
     }
 
-    let len = 1000;
-    let prio3 = Prio3::new_aes128_fixedpoint_boundedl2_vec_sum(num_shares, len).unwrap();
-    let fp_num = fixed!(0.0001: I1F15);
-    let measurement = vec![fp_num; len];
-    println!(
-        "prio3 fixedpoint16 boundedl2 vec ({} entries) size = {}",
-        len,
-        prio3_input_share_size(&prio3.shard(&measurement).unwrap().1)
-    );
-    c.bench_function(
-        &format!("prio3 fixedpoint16 boundedl2 vec ({} entries)", len),
-        |b| {
-            b.iter(|| {
-                prio3.shard(&measurement).unwrap();
-            })
-        },
-    );
+    #[cfg(feature = "experimental")]
+    {
+        let len = 1000;
+        let prio3 = Prio3::new_aes128_fixedpoint_boundedl2_vec_sum(num_shares, len).unwrap();
+        let fp_num = fixed!(0.0001: I1F15);
+        let measurement = vec![fp_num; len];
+        println!(
+            "prio3 fixedpoint16 boundedl2 vec ({} entries) size = {}",
+            len,
+            prio3_input_share_size(&prio3.shard(&measurement).unwrap().1)
+        );
+        c.bench_function(
+            &format!("prio3 fixedpoint16 boundedl2 vec ({} entries)", len),
+            |b| {
+                b.iter(|| {
+                    prio3.shard(&measurement).unwrap();
+                })
+            },
+        );
+    }
 
-    #[cfg(feature = "multithreaded")]
+    #[cfg(all(feature = "experimental", feature = "multithreaded"))]
     {
         let prio3 =
             Prio3::new_aes128_fixedpoint_boundedl2_vec_sum_multithreaded(num_shares, len).unwrap();

--- a/src/field.rs
+++ b/src/field.rs
@@ -743,7 +743,7 @@ pub(crate) fn merge_vector<F: FieldElement>(
 }
 
 /// Outputs an additive secret sharing of the input.
-#[cfg(feature = "crypto-dependencies")]
+#[cfg(all(feature = "crypto-dependencies", any(test, feature = "experimental")))]
 pub(crate) fn split_vector<F: FieldElement>(
     inp: &[F],
     num_shares: usize,

--- a/src/flp/types.rs
+++ b/src/flp/types.rs
@@ -1223,4 +1223,6 @@ mod test_utils {
     }
 }
 
+#[cfg(feature = "experimental")]
+#[cfg_attr(docsrs, doc(cfg(feature = "experimental")))]
 pub mod fixedpoint_l2;

--- a/src/vdaf.rs
+++ b/src/vdaf.rs
@@ -534,7 +534,8 @@ mod tests {
     }
 }
 
-#[cfg(feature = "crypto-dependencies")]
+#[cfg(all(feature = "crypto-dependencies", feature = "experimental"))]
+#[cfg_attr(docsrs, doc(cfg(feature = "experimental")))]
 pub mod poplar1;
 pub mod prg;
 #[cfg(feature = "prio2")]

--- a/src/vdaf/prio3.rs
+++ b/src/vdaf/prio3.rs
@@ -36,12 +36,14 @@ use crate::field::FieldElement;
 use crate::field::{Field128, Field64};
 #[cfg(feature = "multithreaded")]
 use crate::flp::gadgets::ParallelSumMultithreaded;
+#[cfg(all(feature = "crypto-dependencies", feature = "experimental"))]
+use crate::flp::gadgets::PolyEval;
 #[cfg(feature = "crypto-dependencies")]
-use crate::flp::gadgets::{BlindPolyEval, ParallelSum, PolyEval};
-#[cfg(feature = "crypto-dependencies")]
-use crate::flp::types::fixedpoint_l2::compatible_float::CompatibleFloat;
-#[cfg(feature = "crypto-dependencies")]
-use crate::flp::types::fixedpoint_l2::FixedPointBoundedL2VecSum;
+use crate::flp::gadgets::{BlindPolyEval, ParallelSum};
+#[cfg(all(feature = "crypto-dependencies", feature = "experimental"))]
+use crate::flp::types::fixedpoint_l2::{
+    compatible_float::CompatibleFloat, FixedPointBoundedL2VecSum,
+};
 #[cfg(feature = "crypto-dependencies")]
 use crate::flp::types::{Average, Count, CountVec, Histogram, Sum};
 use crate::flp::Type;
@@ -51,7 +53,7 @@ use crate::vdaf::{
     Aggregatable, AggregateShare, Aggregator, Client, Collector, OutputShare, PrepareTransition,
     Share, ShareDecodingParameter, Vdaf, VdafError,
 };
-#[cfg(feature = "crypto-dependencies")]
+#[cfg(all(feature = "crypto-dependencies", feature = "experimental"))]
 use fixed::traits::Fixed;
 use std::convert::TryFrom;
 use std::fmt::Debug;
@@ -145,7 +147,8 @@ impl Prio3Aes128Sum {
 /// allows an easy conversion to the integer type used in internal computation, while leaving
 /// conversion to the client. The model itself will have floating point parameters, so the output
 /// sum has that type as well.
-#[cfg(feature = "crypto-dependencies")]
+#[cfg(all(feature = "crypto-dependencies", feature = "experimental"))]
+#[cfg_attr(docsrs, doc(cfg(feature = "experimental")))]
 pub type Prio3Aes128FixedPointBoundedL2VecSum<Fx> = Prio3<
     FixedPointBoundedL2VecSum<
         Fx,
@@ -157,7 +160,8 @@ pub type Prio3Aes128FixedPointBoundedL2VecSum<Fx> = Prio3<
     16,
 >;
 
-#[cfg(feature = "crypto-dependencies")]
+#[cfg(all(feature = "crypto-dependencies", feature = "experimental"))]
+#[cfg_attr(docsrs, doc(cfg(feature = "experimental")))]
 impl<Fx: Fixed + CompatibleFloat<Field128>> Prio3Aes128FixedPointBoundedL2VecSum<Fx> {
     /// Construct an instance of this VDAF with the given number of aggregators and number of
     /// vector entries.
@@ -173,8 +177,12 @@ impl<Fx: Fixed + CompatibleFloat<Field128>> Prio3Aes128FixedPointBoundedL2VecSum
 /// The fixed point vector sum type. Each measurement is a vector of fixed point numbers
 /// and the aggregate is the sum represented as 64-bit floats. The verification function
 /// ensures the L2 norm of the input vector is < 1.
-#[cfg(feature = "multithreaded")]
-#[cfg(feature = "crypto-dependencies")]
+#[cfg(all(
+    feature = "crypto-dependencies",
+    feature = "experimental",
+    feature = "multithreaded"
+))]
+#[cfg_attr(docsrs, doc(cfg(feature = "experimental")))]
 #[cfg_attr(docsrs, doc(cfg(feature = "multithreaded")))]
 pub type Prio3Aes128FixedPointBoundedL2VecSumMultithreaded<Fx> = Prio3<
     FixedPointBoundedL2VecSum<
@@ -187,8 +195,12 @@ pub type Prio3Aes128FixedPointBoundedL2VecSumMultithreaded<Fx> = Prio3<
     16,
 >;
 
-#[cfg(feature = "multithreaded")]
-#[cfg(feature = "crypto-dependencies")]
+#[cfg(all(
+    feature = "crypto-dependencies",
+    feature = "experimental",
+    feature = "multithreaded"
+))]
+#[cfg_attr(docsrs, doc(cfg(feature = "experimental")))]
 #[cfg_attr(docsrs, doc(cfg(feature = "multithreaded")))]
 impl<Fx: Fixed + CompatibleFloat<Field128>> Prio3Aes128FixedPointBoundedL2VecSumMultithreaded<Fx> {
     /// Construct an instance of this VDAF with the given number of aggregators and number of
@@ -1060,11 +1072,16 @@ fn check_num_aggregators(num_aggregators: u8) -> Result<(), VdafError> {
 #[cfg(test)]
 mod tests {
     use super::*;
+    #[cfg(feature = "experimental")]
     use crate::flp::gadgets::ParallelSumGadget;
     use crate::vdaf::{run_vdaf, run_vdaf_prepare};
     use assert_matches::assert_matches;
-    use fixed::types::extra::{U15, U31, U63};
-    use fixed::{FixedI16, FixedI32, FixedI64};
+    #[cfg(feature = "experimental")]
+    use fixed::{
+        types::extra::{U15, U31, U63},
+        FixedI16, FixedI32, FixedI64,
+    };
+    #[cfg(feature = "experimental")]
     use fixed_macro::fixed;
     use rand::prelude::*;
 
@@ -1167,6 +1184,7 @@ mod tests {
     }
 
     #[test]
+    #[cfg(feature = "experimental")]
     fn test_prio3_bounded_fpvec_sum() {
         type P<Fx> = Prio3Aes128FixedPointBoundedL2VecSum<Fx>;
         let ctor_16 = P::<FixedI16<U15>>::new_aes128_fixedpoint_boundedl2_vec_sum;


### PR DESCRIPTION
This PR makes the following changes:

- Create a new `experimental` Cargo feature.
- Put the "fixed point bounded L2 vector sum" Prio3 instance behind the experimental feature. (closes #369)
- Put the existing Poplar1/toy IDPF implementation behind the experimental feature.
- Document the Cargo features in the README, including that changes to APIs behind the experimental feature may be excepted from semantic versioning. (motivated by upcoming major changes to Poplar1)
- Add a couple new feature flag combinations to CI.