### PR TITLE
CI: Run supply-chain workflow on release branches

### DIFF
--- a/.github/workflows/supply-chain.yml
+++ b/.github/workflows/supply-chain.yml
@@ -4,9 +4,11 @@ on:
   push:
     branches:
      - main
+     - release/**
   pull_request:
     branches:
      - main
+     - release/**
   workflow_dispatch:
 
 jobs:


### PR DESCRIPTION
This is a small follow-up to #398.