### PR TITLE
Audit several smaller crates

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -134,9 +134,9 @@ dependencies = [
 
 [[package]]
 name = "bumpalo"
-version = "3.11.0"
+version = "3.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c1ad822118d20d2c234f427000d5acc36eabe1e29a348c89b63dd60b13f28e5d"
+checksum = "572f695136211188308f16ad2ca5c851a712c464060ae6974944458eb83880ba"
 
 [[package]]
 name = "bytemuck"

--- a/supply-chain/audits.toml
+++ b/supply-chain/audits.toml
@@ -1,10 +1,45 @@
 
 # cargo-vet audits file
 
+[[audits.assert_matches]]
+who = "David Cook <dcook@divviup.org>"
+criteria = "safe-to-run"
+version = "1.5.0"
+
 [[audits.base64]]
 who = "David Cook <dcook@divviup.org>"
 criteria = "safe-to-deploy"
 delta = "0.20.0 -> 0.21.0"
+
+[[audits.block-buffer]]
+who = "David Cook <dcook@divviup.org>"
+criteria = "safe-to-deploy"
+version = "0.9.0"
+
+[[audits.ciborium-io]]
+who = "David Cook <dcook@divviup.org>"
+criteria = "safe-to-run"
+version = "0.2.0"
+
+[[audits.cmac]]
+who = "David Cook <dcook@divviup.org>"
+criteria = "safe-to-deploy"
+version = "0.7.1"
+
+[[audits.crunchy]]
+who = "David Cook <dcook@divviup.org>"
+criteria = "safe-to-deploy"
+version = "0.2.2"
+
+[[audits.dbl]]
+who = "David Cook <dcook@divviup.org>"
+criteria = "safe-to-deploy"
+version = "0.3.2"
+
+[[audits.either]]
+who = "David Cook <dcook@divviup.org>"
+criteria = "safe-to-deploy"
+version = "1.6.1"
 
 [[audits.fiat-crypto]]
 who = "David Cook <dcook@divviup.org>"
@@ -25,6 +60,26 @@ who = "David Cook <dcook@divviup.org>"
 criteria = "safe-to-deploy"
 delta = "1.20.0 -> 1.21.0"
 
+[[audits.fixed-macro]]
+who = "David Cook <dcook@divviup.org>"
+criteria = "safe-to-run"
+version = "1.2.0"
+
+[[audits.fixed-macro-impl]]
+who = "David Cook <dcook@divviup.org>"
+criteria = "safe-to-run"
+version = "1.2.0"
+
+[[audits.ghash]]
+who = "David Cook <dcook@divviup.org>"
+criteria = "safe-to-deploy"
+version = "0.5.0"
+
+[[audits.modinverse]]
+who = "David Cook <dcook@divviup.org>"
+criteria = "safe-to-run"
+version = "0.1.1"
+
 [[audits.once_cell]]
 who = "David Cook <dcook@divviup.org>"
 criteria = "safe-to-deploy"
@@ -44,3 +99,38 @@ Options. The new implementation based on critical_section appears to be sound.
 who = "David Cook <dcook@divviup.org>"
 criteria = "safe-to-deploy"
 delta = "1.16.0 -> 1.17.0"
+
+[[audits.opaque-debug]]
+who = "David Cook <dcook@divviup.org>"
+criteria = "safe-to-deploy"
+version = "0.3.0"
+
+[[audits.proc-macro-error-attr]]
+who = "David Cook <dcook@divviup.org>"
+criteria = "safe-to-run"
+version = "1.0.4"
+
+[[audits.proc-macro2]]
+who = "David Cook <dcook@divviup.org>"
+criteria = "safe-to-deploy"
+delta = "1.0.49 -> 1.0.47"
+
+[[audits.unicode-ident]]
+who = "David Cook <dcook@divviup.org>"
+criteria = "safe-to-deploy"
+delta = "1.0.2 -> 1.0.3"
+
+[[audits.universal-hash]]
+who = "David Cook <dcook@divviup.org>"
+criteria = "safe-to-deploy"
+version = "0.4.1"
+
+[[audits.untrusted]]
+who = "David Cook <dcook@divviup.org>"
+criteria = "safe-to-deploy"
+version = "0.7.1"
+
+[[audits.wasm-bindgen-shared]]
+who = "David Cook <dcook@divviup.org>"
+criteria = "safe-to-deploy"
+version = "0.2.83"

--- a/supply-chain/config.toml
+++ b/supply-chain/config.toml
@@ -51,10 +51,6 @@ criteria = "safe-to-run"
 version = "0.12.1"
 criteria = "safe-to-run"
 
-[[exemptions.assert_matches]]
-version = "1.5.0"
-criteria = "safe-to-run"
-
 [[exemptions.az]]
 version = "1.2.1"
 criteria = "safe-to-deploy"
@@ -66,16 +62,6 @@ criteria = "safe-to-deploy"
 [[exemptions.bitflags]]
 version = "1.3.2"
 criteria = "safe-to-run"
-
-[[exemptions.block-buffer]]
-version = "0.10.3"
-criteria = "safe-to-deploy"
-notes = "This is only used when the \"crypto-dependencies\" feature is enabled."
-
-[[exemptions.bumpalo]]
-version = "3.11.0"
-criteria = "safe-to-deploy"
-notes = "This is only used when the \"prio2\" feature is enabled, and only on WASM targets."
 
 [[exemptions.bytemuck]]
 version = "1.12.1"
@@ -90,10 +76,6 @@ version = "0.3.0"
 criteria = "safe-to-run"
 
 [[exemptions.ciborium]]
-version = "0.2.0"
-criteria = "safe-to-run"
-
-[[exemptions.ciborium-io]]
 version = "0.2.0"
 criteria = "safe-to-run"
 
@@ -117,11 +99,6 @@ criteria = "safe-to-run"
 [[exemptions.clap_lex]]
 version = "0.2.4"
 criteria = "safe-to-run"
-
-[[exemptions.cmac]]
-version = "0.7.1"
-criteria = "safe-to-deploy"
-notes = "This is only used when the \"crypto-dependencies\" feature is enabled."
 
 [[exemptions.color-eyre]]
 version = "0.6.2"
@@ -164,17 +141,8 @@ version = "0.8.11"
 criteria = "safe-to-deploy"
 notes = "This is only used when the \"multithreaded\" feature is enabled."
 
-[[exemptions.crunchy]]
-version = "0.2.2"
-criteria = "safe-to-deploy"
-
 [[exemptions.ctr]]
 version = "0.9.2"
-criteria = "safe-to-deploy"
-notes = "This is only used when the \"crypto-dependencies\" feature is enabled."
-
-[[exemptions.dbl]]
-version = "0.3.2"
 criteria = "safe-to-deploy"
 notes = "This is only used when the \"crypto-dependencies\" feature is enabled."
 
@@ -183,11 +151,6 @@ version = "0.10.3"
 criteria = "safe-to-deploy"
 notes = "This is only used when the \"crypto-dependencies\" feature is enabled."
 
-[[exemptions.either]]
-version = "1.8.0"
-criteria = "safe-to-deploy"
-notes = "This is only used when the \"multithreaded\" feature is enabled."
-
 [[exemptions.eyre]]
 version = "0.6.8"
 criteria = "safe-to-run"
@@ -195,14 +158,6 @@ criteria = "safe-to-run"
 [[exemptions.fixed]]
 version = "1.20.0"
 criteria = "safe-to-deploy"
-
-[[exemptions.fixed-macro]]
-version = "1.2.0"
-criteria = "safe-to-run"
-
-[[exemptions.fixed-macro-impl]]
-version = "1.2.0"
-criteria = "safe-to-run"
 
 [[exemptions.fixed-macro-types]]
 version = "1.2.0"
@@ -216,11 +171,6 @@ notes = "This is only used when the \"crypto-dependencies\" or \"prio2\" feature
 [[exemptions.getrandom]]
 version = "0.2.8"
 criteria = "safe-to-deploy"
-
-[[exemptions.ghash]]
-version = "0.5.0"
-criteria = "safe-to-deploy"
-notes = "This is only used when the \"prio2\" feature is enabled."
 
 [[exemptions.gimli]]
 version = "0.26.2"
@@ -285,10 +235,6 @@ notes = "This is only used when the \"multithreaded\" feature is enabled."
 version = "0.5.4"
 criteria = "safe-to-run"
 
-[[exemptions.modinverse]]
-version = "0.1.1"
-criteria = "safe-to-run"
-
 [[exemptions.num_cpus]]
 version = "1.13.1"
 criteria = "safe-to-deploy"
@@ -305,11 +251,6 @@ criteria = "safe-to-deploy"
 [[exemptions.oorandom]]
 version = "11.1.3"
 criteria = "safe-to-run"
-
-[[exemptions.opaque-debug]]
-version = "0.3.0"
-criteria = "safe-to-deploy"
-notes = "This is only used when the \"prio2\" feature is enabled."
 
 [[exemptions.os_str_bytes]]
 version = "6.3.0"
@@ -352,14 +293,6 @@ notes = "This is only used when the \"test-util\" feature is enabled."
 [[exemptions.proc-macro-error]]
 version = "1.0.4"
 criteria = "safe-to-run"
-
-[[exemptions.proc-macro-error-attr]]
-version = "1.0.4"
-criteria = "safe-to-run"
-
-[[exemptions.proc-macro2]]
-version = "1.0.47"
-criteria = "safe-to-deploy"
 
 [[exemptions.rand]]
 version = "0.8.5"
@@ -494,10 +427,6 @@ criteria = "safe-to-run"
 version = "1.15.0"
 criteria = "safe-to-deploy"
 
-[[exemptions.unicode-ident]]
-version = "1.0.3"
-criteria = "safe-to-deploy"
-
 [[exemptions.unicode-segmentation]]
 version = "1.9.0"
 criteria = "safe-to-run"
@@ -505,16 +434,6 @@ criteria = "safe-to-run"
 [[exemptions.unicode-width]]
 version = "0.1.9"
 criteria = "safe-to-run"
-
-[[exemptions.universal-hash]]
-version = "0.5.0"
-criteria = "safe-to-deploy"
-notes = "This is only used when the \"prio2\" feature is enabled."
-
-[[exemptions.untrusted]]
-version = "0.7.1"
-criteria = "safe-to-deploy"
-notes = "This is only used when the \"prio2\" feature is enabled."
 
 [[exemptions.valuable]]
 version = "0.1.0"
@@ -553,11 +472,6 @@ criteria = "safe-to-deploy"
 notes = "This is only used when the \"prio2\" feature is enabled, and only on WASM targets."
 
 [[exemptions.wasm-bindgen-macro-support]]
-version = "0.2.83"
-criteria = "safe-to-deploy"
-notes = "This is only used when the \"prio2\" feature is enabled, and only on WASM targets."
-
-[[exemptions.wasm-bindgen-shared]]
 version = "0.2.83"
 criteria = "safe-to-deploy"
 notes = "This is only used when the \"prio2\" feature is enabled, and only on WASM targets."

--- a/supply-chain/imports.lock
+++ b/supply-chain/imports.lock
@@ -347,6 +347,11 @@ who = "Mike Hommey <mh+mozilla@glandium.org>"
 criteria = "safe-to-deploy"
 delta = "1.0.39 -> 1.0.43"
 
+[[audits.firefox.audits.proc-macro2]]
+who = "Mike Hommey <mh+mozilla@glandium.org>"
+criteria = "safe-to-deploy"
+delta = "1.0.43 -> 1.0.49"
+
 [[audits.firefox.audits.quote]]
 who = "Nika Layzell <nika@thelayzells.com>"
 criteria = "safe-to-deploy"


### PR DESCRIPTION
This adds audits of several smaller crates, covering everything under ~750 lines. I also upgraded `bumpalo` in `Cargo.lock` both to pick up a soundness fix and to use a version for which we have an imported audit. (`bumpalo` is only used for WASM targets to begin with)