### PR TITLE
Bump cargo-vet to 0.3.1

### DIFF
--- a/.github/workflows/supply-chain.yml
+++ b/.github/workflows/supply-chain.yml
@@ -16,7 +16,7 @@ jobs:
     name: Vet Dependencies
     runs-on: ubuntu-latest
     env:
-      CARGO_VET_VERSION: 0.3.0
+      CARGO_VET_VERSION: 0.3.1
     steps:
     - uses: actions/checkout@v3
     - name: Install Rust toolchain


### PR DESCRIPTION
This relaxes import parsing to ensure that adoption of the next major release by other projects doesn't break imports for this project. See [mozilla/cargo-vet#360 (comment)](https://github.com/mozilla/cargo-vet/issues/360#issuecomment-1384605968)