### PR TITLE
Bump cargo-vet to 0.3.1 - 0.10 backport

### DIFF
--- a/.github/workflows/supply-chain.yml
+++ b/.github/workflows/supply-chain.yml
@@ -16,7 +16,7 @@ jobs:
     name: Vet Dependencies
     runs-on: ubuntu-latest
     env:
-      CARGO_VET_VERSION: 0.3.0
+      CARGO_VET_VERSION: 0.3.1
     steps:
     - uses: actions/checkout@v3
     - name: Install Rust toolchain


### PR DESCRIPTION
This backports #417 to `release/0.10`.