### PR TITLE
Generalize `CountVec` into `SumVec`

### DIFF
--- a/benches/cycle_counts.rs
+++ b/benches/cycle_counts.rs
@@ -130,7 +130,7 @@ fn prio3_client_sum_32() -> Vec<Prio3InputShare<Field128, 16>> {
 
 fn prio3_client_count_vec_1000() -> Vec<Prio3InputShare<Field128, 16>> {
     let len = 1000;
-    let prio3 = Prio3::new_aes128_count_vec(2, len).unwrap();
+    let prio3 = Prio3::new_aes128_sum_vec(2, 1, len).unwrap();
     let measurement = vec![0; len];
     prio3.shard(&black_box(measurement)).unwrap().1
 }
@@ -138,7 +138,7 @@ fn prio3_client_count_vec_1000() -> Vec<Prio3InputShare<Field128, 16>> {
 #[cfg(feature = "multithreaded")]
 fn prio3_client_count_vec_multithreaded_1000() -> Vec<Prio3InputShare<Field128, 16>> {
     let len = 1000;
-    let prio3 = Prio3::new_aes128_count_vec_multithreaded(2, len).unwrap();
+    let prio3 = Prio3::new_aes128_sum_vec_multithreaded(2, 1, len).unwrap();
     let measurement = vec![0; len];
     prio3.shard(&black_box(measurement)).unwrap().1
 }

--- a/benches/speed_tests.rs
+++ b/benches/speed_tests.rs
@@ -15,7 +15,7 @@ use prio::field::{random_vector, FftFriendlyFieldElement, Field128 as F, FieldEl
 use prio::flp::gadgets::ParallelSumMultithreaded;
 use prio::flp::{
     gadgets::{BlindPolyEval, Mul, ParallelSum},
-    types::CountVec,
+    types::SumVec,
     Type,
 };
 #[cfg(feature = "prio2")]
@@ -128,7 +128,7 @@ pub fn count_vec(c: &mut Criterion) {
         }
 
         // Prio3
-        let count_vec: CountVec<F, ParallelSum<F, BlindPolyEval<F>>> = CountVec::new(*size);
+        let count_vec: SumVec<F, ParallelSum<F, BlindPolyEval<F>>> = SumVec::new(1, *size).unwrap();
         let joint_rand = random_vector(count_vec.joint_rand_len()).unwrap();
         let prove_rand = random_vector(count_vec.prove_rand_len()).unwrap();
         let proof = count_vec.prove(&input, &prove_rand, &joint_rand).unwrap();
@@ -159,8 +159,8 @@ pub fn count_vec(c: &mut Criterion) {
 
         #[cfg(feature = "multithreaded")]
         {
-            let count_vec: CountVec<F, ParallelSumMultithreaded<F, BlindPolyEval<F>>> =
-                CountVec::new(*size);
+            let count_vec: SumVec<F, ParallelSumMultithreaded<F, BlindPolyEval<F>>> =
+                SumVec::new(1, *size).unwrap();
 
             c.bench_function(
                 &format!("prio3 countvec multithreaded prove, input size={}", *size),
@@ -235,7 +235,7 @@ pub fn prio3_client(c: &mut Criterion) {
     });
 
     let len = 1000;
-    let prio3 = Prio3::new_aes128_count_vec(num_shares, len).unwrap();
+    let prio3 = Prio3::new_aes128_sum_vec(num_shares, 1, len).unwrap();
     let measurement = vec![0; len];
     println!(
         "prio3 countvec ({} len) share size = {}",
@@ -250,7 +250,7 @@ pub fn prio3_client(c: &mut Criterion) {
 
     #[cfg(feature = "multithreaded")]
     {
-        let prio3 = Prio3::new_aes128_count_vec_multithreaded(num_shares, len).unwrap();
+        let prio3 = Prio3::new_aes128_sum_vec_multithreaded(num_shares, 1, len).unwrap();
         let measurement = vec![0; len];
         println!(
             "prio3 countvec multithreaded ({} len) share size = {}",

--- a/src/flp.rs
+++ b/src/flp.rs
@@ -92,6 +92,10 @@ pub enum FlpError {
     #[error("truncate error: {0}")]
     Truncate(String),
 
+    /// Generic invalid parameter. This may be returned when an FLP type cannot be constructed.
+    #[error("invalid paramter: {0}")]
+    InvalidParameter(String),
+
     /// Returned if an FFT operation propagates an error.
     #[error("FFT error: {0}")]
     Fft(#[from] FftError),

--- a/src/vdaf/prio2.rs
+++ b/src/vdaf/prio2.rs
@@ -23,8 +23,8 @@ use std::{
 };
 
 /// The Prio2 VDAF. It supports the same measurement type as
-/// [`Prio3Aes128CountVec`](crate::vdaf::prio3::Prio3Aes128CountVec) but uses the proof system
-/// and finite field deployed in ENPA.
+/// [`Prio3Aes128SumVec`](crate::vdaf::prio3::Prio3Aes128SumVec) with `bits == 1` but uses the
+/// proof system and finite field deployed in ENPA.
 #[derive(Clone, Debug)]
 pub struct Prio2 {
     input_len: usize,


### PR DESCRIPTION
The new FLP type, `SumVec`, is used to compute the element-wise sum of a vector of integers in range `[0, 2^bits)`. Each element of the vector is encoded as a bit-vector then concatenated together into the FLP input. The prover then proves that each element of the flattened vector is a bit in the desired range.

Using `SumVec` is equivalent to using as many `Sum` proofs as there are elements of the vector. Combining them into one proof improves efficiency by reducing overall communication cost.

The valididty circuit is identical to `CountVec`; only the chunk size has changed. In fact, `SumVec` with `bits = 1` should be wire-compatible with `CountVec`.

cc/ @simon-friedberger 