### PR TITLE
Clippy fixes, 1.67

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,7 +2,7 @@
 name = "prio"
 version = "0.10.0"
 authors = ["Josh Aas <jaas@kflag.net>", "Tim Geoghegan <timg@letsencrypt.org>", "Christopher Patton <cpatton@cloudflare.com", "Karl Tarbe <tarbe@apple.com>"]
-edition = "2018"
+edition = "2021"
 description = "Implementation of the Prio aggregation system core: https://crypto.stanford.edu/prio/"
 license = "MPL-2.0"
 repository = "https://github.com/divviup/libprio-rs"

--- a/benches/speed_tests.rs
+++ b/benches/speed_tests.rs
@@ -228,7 +228,7 @@ pub fn prio3_client(c: &mut Criterion) {
         bits,
         prio3_input_share_size(&prio3.shard(&measurement).unwrap().1)
     );
-    c.bench_function(&format!("prio3 sum ({} bits)", bits), |b| {
+    c.bench_function(&format!("prio3 sum ({bits} bits)"), |b| {
         b.iter(|| {
             prio3.shard(&measurement).unwrap();
         })
@@ -242,7 +242,7 @@ pub fn prio3_client(c: &mut Criterion) {
         len,
         prio3_input_share_size(&prio3.shard(&measurement).unwrap().1)
     );
-    c.bench_function(&format!("prio3 countvec ({} len)", len), |b| {
+    c.bench_function(&format!("prio3 countvec ({len} len)"), |b| {
         b.iter(|| {
             prio3.shard(&measurement).unwrap();
         })
@@ -257,7 +257,7 @@ pub fn prio3_client(c: &mut Criterion) {
             len,
             prio3_input_share_size(&prio3.shard(&measurement).unwrap().1)
         );
-        c.bench_function(&format!("prio3 parallel countvec ({} len)", len), |b| {
+        c.bench_function(&format!("prio3 parallel countvec ({len} len)"), |b| {
             b.iter(|| {
                 prio3.shard(&measurement).unwrap();
             })
@@ -276,7 +276,7 @@ pub fn prio3_client(c: &mut Criterion) {
             prio3_input_share_size(&prio3.shard(&measurement).unwrap().1)
         );
         c.bench_function(
-            &format!("prio3 fixedpoint16 boundedl2 vec ({} entries)", len),
+            &format!("prio3 fixedpoint16 boundedl2 vec ({len} entries)"),
             |b| {
                 b.iter(|| {
                     prio3.shard(&measurement).unwrap();
@@ -297,10 +297,7 @@ pub fn prio3_client(c: &mut Criterion) {
             prio3_input_share_size(&prio3.shard(&measurement).unwrap().1)
         );
         c.bench_function(
-            &format!(
-                "prio3 fixedpoint16 boundedl2 vec multithreaded ({} entries)",
-                len
-            ),
+            &format!("prio3 fixedpoint16 boundedl2 vec multithreaded ({len} entries)"),
             |b| {
                 b.iter(|| {
                     prio3.shard(&measurement).unwrap();

--- a/binaries/src/bin/crypt.rs
+++ b/binaries/src/bin/crypt.rs
@@ -73,7 +73,7 @@ impl FromStr for Input {
         }
 
         Ok(Self::Path(PathBuf::from_str(s).map_err(|e| {
-            format!("argument could not be parsed as base64 or path: {:?}", e)
+            format!("argument could not be parsed as base64 or path: {e:?}")
         })?))
     }
 }
@@ -114,7 +114,7 @@ impl FromStr for Output {
         }
 
         Ok(Self::Path(PathBuf::from_str(s).map_err(|e| {
-            format!("argument could not be parsed as base64 or path: {:?}", e)
+            format!("argument could not be parsed as base64 or path: {e:?}")
         })?))
     }
 }
@@ -215,7 +215,7 @@ fn decrypt(
         .ok_or_else(|| eyre!("failed to reconstruct input shares"))?;
 
     if pretty_print {
-        writeln!(&mut decrypted_input.into_writer()?, "{:?}", reconstructed)
+        writeln!(&mut decrypted_input.into_writer()?, "{reconstructed:?}")
             .wrap_err("failed to pretty-print reconstructed output")
     } else {
         decrypted_input

--- a/binaries/src/bin/generate_test_vector.rs
+++ b/binaries/src/bin/generate_test_vector.rs
@@ -35,7 +35,7 @@ fn generate_and_print_priov2_vector(number_of_inputs: usize, dimension: usize) -
         .wrap_err("failed to create test vector")?;
     let json =
         serde_json::to_string(&test_vector).wrap_err("failed to encode test vector to JSON")?;
-    println!("{}", json);
+    println!("{json}");
 
     Ok(())
 }

--- a/examples/sum.rs
+++ b/examples/sum.rs
@@ -26,7 +26,7 @@ fn main() {
     let mut client2 = Client::new(dim, pub_key1, pub_key2).unwrap();
 
     let data1_u32 = [0, 0, 1, 0, 0, 0, 0, 0];
-    println!("Client 1 Input: {:?}", data1_u32);
+    println!("Client 1 Input: {data1_u32:?}");
 
     let data1 = data1_u32
         .iter()
@@ -34,7 +34,7 @@ fn main() {
         .collect::<Vec<Field32>>();
 
     let data2_u32 = [0, 0, 1, 0, 0, 0, 0, 0];
-    println!("Client 2 Input: {:?}", data2_u32);
+    println!("Client 2 Input: {data2_u32:?}");
 
     let data2 = data2_u32
         .iter()

--- a/src/encrypt.rs
+++ b/src/encrypt.rs
@@ -154,7 +154,6 @@ fn x963_kdf(z: &[u8], shared_info: &[u8]) -> [u8; 32] {
     hasher.update(&1u32.to_be_bytes());
     hasher.update(shared_info);
     let digest = hasher.finish();
-    use std::convert::TryInto;
     // unwrap never fails because SHA256 output len is 32
     digest.as_ref().try_into().unwrap()
 }

--- a/src/field.rs
+++ b/src/field.rs
@@ -1113,17 +1113,16 @@ mod tests {
             assert_eq!(
                 F::generator().pow(int_order),
                 F::root(l).unwrap(),
-                "failure for F::root({})",
-                l
+                "failure for F::root({l})"
             );
             int_order = int_order >> 1;
         }
 
         // formatting
-        assert_eq!(format!("{}", zero), "0");
-        assert_eq!(format!("{}", one), "1");
-        assert_eq!(format!("{:?}", zero), "0");
-        assert_eq!(format!("{:?}", one), "1");
+        assert_eq!(format!("{zero}"), "0");
+        assert_eq!(format!("{one}"), "1");
+        assert_eq!(format!("{zero:?}"), "0");
+        assert_eq!(format!("{one:?}"), "1");
 
         let three = F::from(F::Integer::try_from(3).unwrap());
         let mut powers_of_three = Vec::with_capacity(500);

--- a/src/field/field255.rs
+++ b/src/field/field255.rs
@@ -220,7 +220,7 @@ impl Display for Field255 {
         let encoded: [u8; Self::ENCODED_SIZE] = (*self).into();
         write!(f, "0x")?;
         for byte in encoded {
-            write!(f, "{:02x}", byte)?;
+            write!(f, "{byte:02x}")?;
         }
         Ok(())
     }

--- a/src/flp.rs
+++ b/src/flp.rs
@@ -403,8 +403,7 @@ pub trait Type: Sized + Eq + Clone + Debug {
                     == Self::Field::one()
                 {
                     return Err(FlpError::Query(format!(
-                        "invalid query randomness: encountered 2^{}-th root of unity",
-                        m
+                        "invalid query randomness: encountered 2^{m}-th root of unity"
                     )));
                 }
 

--- a/src/flp/types.rs
+++ b/src/flp/types.rs
@@ -236,7 +236,7 @@ impl<F: FftFriendlyFieldElement> Type for Average<F> {
         // Compute the average from the aggregated sum.
         let data = decode_result(data)?;
         let data: u64 = data.try_into().map_err(|err| {
-            FlpError::Decode(format!("failed to convert {:?} to u64: {}", data, err,))
+            FlpError::Decode(format!("failed to convert {data:?} to u64: {err}",))
         })?;
         let result = (data as f64) / (num_measurements as f64);
         Ok(result)
@@ -1087,14 +1087,12 @@ mod test_utils {
         let v = typ.valid(&mut gadgets, input, &joint_rand, 1)?;
         if v != T::Field::zero() && t.expect_valid {
             return Err(FlpError::Test(format!(
-                "expected valid input: valid() returned {}",
-                v
+                "expected valid input: valid() returned {v}"
             )));
         }
         if v == T::Field::zero() && !t.expect_valid {
             return Err(FlpError::Test(format!(
-                "expected invalid input: valid() returned {}",
-                v
+                "expected invalid input: valid() returned {v}"
             )));
         }
 
@@ -1215,8 +1213,7 @@ mod test_utils {
 
             if &got != want {
                 return Err(FlpError::Test(format!(
-                    "unexpected output: got {:?}; want {:?}",
-                    got, want
+                    "unexpected output: got {got:?}; want {want:?}"
                 )));
             }
         }

--- a/src/flp/types/fixedpoint_l2.rs
+++ b/src/flp/types/fixedpoint_l2.rs
@@ -233,8 +233,7 @@ where
             .map_err(|_| FlpError::Encode("Could not convert u32 into usize.".to_string()))?;
         if !F::valid_integer_bitlength(bits_per_entry) {
             return Err(FlpError::Encode(format!(
-                "fixed point type bit length ({}) too large for field modulus",
-                bits_per_entry,
+                "fixed point type bit length ({bits_per_entry}) too large for field modulus",
             )));
         }
 
@@ -244,8 +243,7 @@ where
         let bits_for_norm = 2 * bits_per_entry - 2;
         if !F::valid_integer_bitlength(bits_for_norm) {
             return Err(FlpError::Encode(format!(
-                "maximal norm bit length ({}) too large for field modulus",
-                bits_for_norm,
+                "maximal norm bit length ({bits_for_norm}) too large for field modulus",
             )));
         }
 
@@ -256,8 +254,7 @@ where
         // upper bound to that value is `entries * 2^(2*bits - 2)` (see docs of
         // compute_norm_of_entries for details). It has to fit into the field.
         let err = Err(FlpError::Encode(format!(
-            "number of entries ({}) not compatible with field size",
-            entries,
+            "number of entries ({entries}) not compatible with field size",
         )));
 
         if let Some(val) = (entries as u128).checked_mul(1 << bits_for_norm) {

--- a/src/polynomial.rs
+++ b/src/polynomial.rs
@@ -312,7 +312,7 @@ mod tests {
         for i in start..end {
             let x = Field64::from(i as u64);
             let y = poly_eval(&p, x);
-            assert_eq!(y, Field64::zero(), "range check failed for {}", i);
+            assert_eq!(y, Field64::zero(), "range check failed for {i}");
         }
 
         // Check the number below the range.

--- a/src/prng.rs
+++ b/src/prng.rs
@@ -79,7 +79,7 @@ where
                 if let Some(x) = match F::try_from_random(&self.buffer[i..j]) {
                     Ok(x) => Some(x),
                     Err(FieldError::ModulusOverflow) => None, // reject this sample
-                    Err(err) => panic!("unexpected error: {}", err),
+                    Err(err) => panic!("unexpected error: {err}"),
                 } {
                     // Set the buffer index to the next chunk.
                     self.buffer_index = j;

--- a/src/vdaf/poplar1.rs
+++ b/src/vdaf/poplar1.rs
@@ -809,7 +809,7 @@ mod tests {
                 &input.prefix(prefix_len),
                 &[Field128::one(), Field128::one()],
             );
-            assert!(res.is_ok(), "prefix_len={} error: {:?}", prefix_len, res);
+            assert!(res.is_ok(), "prefix_len={prefix_len} error: {res:?}");
         }
 
         // Try evaluating the IDPF keys on incorrect prefixes.

--- a/src/vdaf/poplar1.rs
+++ b/src/vdaf/poplar1.rs
@@ -562,8 +562,7 @@ where
 
         if count != 2 {
             return Err(VdafError::Uncategorized(format!(
-                "unexpected message count: got {}; want 2",
-                count,
+                "unexpected message count: got {count}; want 2",
             )));
         }
 
@@ -847,8 +846,7 @@ mod tests {
 
         if expected_output != &output {
             return Err(VdafError::Uncategorized(format!(
-                "eval_idpf(): unexpected output: got {:?}; want {:?}",
-                output, expected_output
+                "eval_idpf(): unexpected output: got {output:?}; want {expected_output:?}"
             )));
         }
 

--- a/src/vdaf/prio3.rs
+++ b/src/vdaf/prio3.rs
@@ -125,8 +125,7 @@ impl Prio3Aes128Sum {
     pub fn new_aes128_sum(num_aggregators: u8, bits: u32) -> Result<Self, VdafError> {
         if bits > 64 {
             return Err(VdafError::Uncategorized(format!(
-                "bit length ({}) exceeds limit for aggregate type (64)",
-                bits
+                "bit length ({bits}) exceeds limit for aggregate type (64)"
             )));
         }
 
@@ -243,8 +242,7 @@ impl Prio3Aes128Average {
 
         if bits > 64 {
             return Err(VdafError::Uncategorized(format!(
-                "bit length ({}) exceeds limit for aggregate type (64)",
-                bits
+                "bit length ({bits}) exceeds limit for aggregate type (64)"
             )));
         }
 
@@ -1055,13 +1053,11 @@ impl<const L: usize> HelperShare<L> {
 fn check_num_aggregators(num_aggregators: u8) -> Result<(), VdafError> {
     if num_aggregators == 0 {
         return Err(VdafError::Uncategorized(format!(
-            "at least one aggregator is required; got {}",
-            num_aggregators
+            "at least one aggregator is required; got {num_aggregators}"
         )));
     } else if num_aggregators > 254 {
         return Err(VdafError::Uncategorized(format!(
-            "number of aggregators must not exceed 254; got {}",
-            num_aggregators
+            "number of aggregators must not exceed 254; got {num_aggregators}"
         )));
     }
 

--- a/src/vdaf/prio3_test.rs
+++ b/src/vdaf/prio3_test.rs
@@ -64,20 +64,18 @@ fn check_prep_test_vec<M, T, P, const L: usize>(
         .test_vec_shard(&t.measurement)
         .expect("failed to generate input shares");
 
-    assert_eq!(2, t.input_shares.len(), "#{}", test_num);
+    assert_eq!(2, t.input_shares.len(), "#{test_num}");
     for (agg_id, want) in t.input_shares.iter().enumerate() {
         assert_eq!(
             input_shares[agg_id],
             Prio3InputShare::get_decoded_with_param(&(prio3, agg_id), want.as_ref())
                 .unwrap_or_else(|e| err!(test_num, e, "decode test vector (input share)")),
-            "#{}",
-            test_num
+            "#{test_num}"
         );
         assert_eq!(
             input_shares[agg_id].get_encoded(),
             want.as_ref(),
-            "#{}",
-            test_num
+            "#{test_num}"
         )
     }
 
@@ -91,16 +89,15 @@ fn check_prep_test_vec<M, T, P, const L: usize>(
         prep_shares.push(prep_share);
     }
 
-    assert_eq!(1, t.prep_shares.len(), "#{}", test_num);
+    assert_eq!(1, t.prep_shares.len(), "#{test_num}");
     for (i, want) in t.prep_shares[0].iter().enumerate() {
         assert_eq!(
             prep_shares[i],
             Prio3PrepareShare::get_decoded_with_param(&states[i], want.as_ref())
                 .unwrap_or_else(|e| err!(test_num, e, "decode test vector (prep share)")),
-            "#{}",
-            test_num
+            "#{test_num}"
         );
-        assert_eq!(prep_shares[i].get_encoded(), want.as_ref(), "#{}", test_num);
+        assert_eq!(prep_shares[i].get_encoded(), want.as_ref(), "#{test_num}");
     }
 
     let inbound = prio3


### PR DESCRIPTION
This updates the edition to 2021 (necessary for a change to `panic!()`) and fixes lints related to format strings.