### PR TITLE
Clippy fixes, 1.67, 0.8 backport

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,7 +2,7 @@
 name = "prio"
 version = "0.8.5"
 authors = ["Josh Aas <jaas@kflag.net>", "Tim Geoghegan <timg@letsencrypt.org>", "Christopher Patton <cpatton@cloudflare.com", "Karl Tarbe <tarbe@apple.com>"]
-edition = "2018"
+edition = "2021"
 description = "Implementation of the Prio aggregation system core: https://crypto.stanford.edu/prio/"
 license = "MPL-2.0"
 repository = "https://github.com/divviup/libprio-rs"

--- a/benches/speed_tests.rs
+++ b/benches/speed_tests.rs
@@ -220,7 +220,7 @@ pub fn prio3_client(c: &mut Criterion) {
         bits,
         prio3_input_share_size(&prio3.shard(&measurement).unwrap())
     );
-    c.bench_function(&format!("prio3 sum ({} bits)", bits), |b| {
+    c.bench_function(&format!("prio3 sum ({bits} bits)"), |b| {
         b.iter(|| {
             prio3.shard(&measurement).unwrap();
         })
@@ -234,7 +234,7 @@ pub fn prio3_client(c: &mut Criterion) {
         len,
         prio3_input_share_size(&prio3.shard(&measurement).unwrap())
     );
-    c.bench_function(&format!("prio3 countvec ({} len)", len), |b| {
+    c.bench_function(&format!("prio3 countvec ({len} len)"), |b| {
         b.iter(|| {
             prio3.shard(&measurement).unwrap();
         })
@@ -249,7 +249,7 @@ pub fn prio3_client(c: &mut Criterion) {
             len,
             prio3_input_share_size(&prio3.shard(&measurement).unwrap())
         );
-        c.bench_function(&format!("prio3 parallel countvec ({} len)", len), |b| {
+        c.bench_function(&format!("prio3 parallel countvec ({len} len)"), |b| {
             b.iter(|| {
                 prio3.shard(&measurement).unwrap();
             })

--- a/binaries/src/bin/crypt.rs
+++ b/binaries/src/bin/crypt.rs
@@ -73,7 +73,7 @@ impl FromStr for Input {
         }
 
         Ok(Self::Path(PathBuf::from_str(s).map_err(|e| {
-            format!("argument could not be parsed as base64 or path: {:?}", e)
+            format!("argument could not be parsed as base64 or path: {e:?}")
         })?))
     }
 }
@@ -114,7 +114,7 @@ impl FromStr for Output {
         }
 
         Ok(Self::Path(PathBuf::from_str(s).map_err(|e| {
-            format!("argument could not be parsed as base64 or path: {:?}", e)
+            format!("argument could not be parsed as base64 or path: {e:?}")
         })?))
     }
 }
@@ -215,7 +215,7 @@ fn decrypt(
         .ok_or_else(|| eyre!("failed to reconstruct input shares"))?;
 
     if pretty_print {
-        writeln!(&mut decrypted_input.into_writer()?, "{:?}", reconstructed)
+        writeln!(&mut decrypted_input.into_writer()?, "{reconstructed:?}")
             .wrap_err("failed to pretty-print reconstructed output")
     } else {
         decrypted_input

--- a/binaries/src/bin/generate_test_vector.rs
+++ b/binaries/src/bin/generate_test_vector.rs
@@ -35,7 +35,7 @@ fn generate_and_print_priov2_vector(number_of_inputs: usize, dimension: usize) -
         .wrap_err("failed to create test vector")?;
     let json =
         serde_json::to_string(&test_vector).wrap_err("failed to encode test vector to JSON")?;
-    println!("{}", json);
+    println!("{json}");
 
     Ok(())
 }

--- a/examples/sum.rs
+++ b/examples/sum.rs
@@ -26,7 +26,7 @@ fn main() {
     let mut client2 = Client::new(dim, pub_key1, pub_key2).unwrap();
 
     let data1_u32 = [0, 0, 1, 0, 0, 0, 0, 0];
-    println!("Client 1 Input: {:?}", data1_u32);
+    println!("Client 1 Input: {data1_u32:?}");
 
     let data1 = data1_u32
         .iter()
@@ -34,7 +34,7 @@ fn main() {
         .collect::<Vec<Field32>>();
 
     let data2_u32 = [0, 0, 1, 0, 0, 0, 0, 0];
-    println!("Client 2 Input: {:?}", data2_u32);
+    println!("Client 2 Input: {data2_u32:?}");
 
     let data2 = data2_u32
         .iter()

--- a/src/encrypt.rs
+++ b/src/encrypt.rs
@@ -155,7 +155,6 @@ fn x963_kdf(z: &[u8], shared_info: &[u8]) -> [u8; 32] {
     hasher.update(&1u32.to_be_bytes());
     hasher.update(shared_info);
     let digest = hasher.finish();
-    use std::convert::TryInto;
     // unwrap never fails because SHA256 output len is 32
     digest.as_ref().try_into().unwrap()
 }

--- a/src/field.rs
+++ b/src/field.rs
@@ -861,8 +861,7 @@ mod tests {
             assert_eq!(
                 F::generator().pow(int_order),
                 F::root(l).unwrap(),
-                "failure for F::root({})",
-                l
+                "failure for F::root({l})"
             );
             int_order = int_order >> int_one;
         }

--- a/src/flp.rs
+++ b/src/flp.rs
@@ -394,8 +394,7 @@ pub trait Type: Sized + Eq + Clone + Debug {
                     == Self::Field::one()
                 {
                     return Err(FlpError::Query(format!(
-                        "invalid query randomness: encountered 2^{}-th root of unity",
-                        m
+                        "invalid query randomness: encountered 2^{m}-th root of unity"
                     )));
                 }
 

--- a/src/flp/types.rs
+++ b/src/flp/types.rs
@@ -880,14 +880,12 @@ mod tests {
         let v = typ.valid(&mut gadgets, input, &joint_rand, 1)?;
         if v != T::Field::zero() && t.expect_valid {
             return Err(FlpError::Test(format!(
-                "expected valid input: valid() returned {}",
-                v
+                "expected valid input: valid() returned {v}"
             )));
         }
         if v == T::Field::zero() && !t.expect_valid {
             return Err(FlpError::Test(format!(
-                "expected invalid input: valid() returned {}",
-                v
+                "expected invalid input: valid() returned {v}"
             )));
         }
 
@@ -1008,8 +1006,7 @@ mod tests {
 
             if &got != want {
                 return Err(FlpError::Test(format!(
-                    "unexpected output: got {:?}; want {:?}",
-                    got, want
+                    "unexpected output: got {got:?}; want {want:?}"
                 )));
             }
         }

--- a/src/polynomial.rs
+++ b/src/polynomial.rs
@@ -311,7 +311,7 @@ fn test_poly_range_check() {
     for i in start..end {
         let x = Field64::from(i as u64);
         let y = poly_eval(&p, x);
-        assert_eq!(y, Field64::zero(), "range check failed for {}", i);
+        assert_eq!(y, Field64::zero(), "range check failed for {i}");
     }
 
     // Check the number below the range.

--- a/src/prng.rs
+++ b/src/prng.rs
@@ -79,7 +79,7 @@ where
                 if let Some(x) = match F::try_from_random(&self.buffer[i..j]) {
                     Ok(x) => Some(x),
                     Err(FieldError::ModulusOverflow) => None, // reject this sample
-                    Err(err) => panic!("unexpected error: {}", err),
+                    Err(err) => panic!("unexpected error: {err}"),
                 } {
                     // Set the buffer index to the next chunk.
                     self.buffer_index = j;

--- a/src/vdaf/poplar1.rs
+++ b/src/vdaf/poplar1.rs
@@ -551,8 +551,7 @@ where
 
         if count != 2 {
             return Err(VdafError::Uncategorized(format!(
-                "unexpected message count: got {}; want 2",
-                count,
+                "unexpected message count: got {count}; want 2",
             )));
         }
 
@@ -808,8 +807,7 @@ mod tests {
 
         if expected_output != &output {
             return Err(VdafError::Uncategorized(format!(
-                "eval_idpf(): unexpected output: got {:?}; want {:?}",
-                output, expected_output
+                "eval_idpf(): unexpected output: got {output:?}; want {expected_output:?}"
             )));
         }
 

--- a/src/vdaf/poplar1.rs
+++ b/src/vdaf/poplar1.rs
@@ -770,7 +770,7 @@ mod tests {
                 &input.prefix(prefix_len),
                 &[Field128::one(), Field128::one()],
             );
-            assert!(res.is_ok(), "prefix_len={} error: {:?}", prefix_len, res);
+            assert!(res.is_ok(), "prefix_len={prefix_len} error: {res:?}");
         }
 
         // Try evaluating the IDPF keys on incorrect prefixes.

--- a/src/vdaf/prio3.rs
+++ b/src/vdaf/prio3.rs
@@ -121,8 +121,7 @@ impl Prio3Aes128Sum {
     pub fn new_aes128_sum(num_aggregators: u8, bits: u32) -> Result<Self, VdafError> {
         if bits > 64 {
             return Err(VdafError::Uncategorized(format!(
-                "bit length ({}) exceeds limit for aggregate type (64)",
-                bits
+                "bit length ({bits}) exceeds limit for aggregate type (64)"
             )));
         }
 
@@ -900,13 +899,11 @@ impl<const L: usize> HelperShare<L> {
 fn check_num_aggregators(num_aggregators: u8) -> Result<(), VdafError> {
     if num_aggregators == 0 {
         return Err(VdafError::Uncategorized(format!(
-            "at least one aggregator is required; got {}",
-            num_aggregators
+            "at least one aggregator is required; got {num_aggregators}"
         )));
     } else if num_aggregators > 254 {
         return Err(VdafError::Uncategorized(format!(
-            "number of aggregators must not exceed 254; got {}",
-            num_aggregators
+            "number of aggregators must not exceed 254; got {num_aggregators}"
         )));
     }
 

--- a/src/vdaf/prio3_test.rs
+++ b/src/vdaf/prio3_test.rs
@@ -64,20 +64,18 @@ fn check_prep_test_vec<M, T, P, const L: usize>(
         .test_vec_shard(&t.measurement)
         .expect("failed to generate input shares");
 
-    assert_eq!(2, t.input_shares.len(), "#{}", test_num);
+    assert_eq!(2, t.input_shares.len(), "#{test_num}");
     for (agg_id, want) in t.input_shares.iter().enumerate() {
         assert_eq!(
             input_shares[agg_id],
             Prio3InputShare::get_decoded_with_param(&(prio3, agg_id), want.as_ref())
                 .unwrap_or_else(|e| err!(test_num, e, "decode test vector (input share)")),
-            "#{}",
-            test_num
+            "#{test_num}"
         );
         assert_eq!(
             input_shares[agg_id].get_encoded(),
             want.as_ref(),
-            "#{}",
-            test_num
+            "#{test_num}"
         )
     }
 
@@ -91,16 +89,15 @@ fn check_prep_test_vec<M, T, P, const L: usize>(
         prep_shares.push(prep_share);
     }
 
-    assert_eq!(1, t.prep_shares.len(), "#{}", test_num);
+    assert_eq!(1, t.prep_shares.len(), "#{test_num}");
     for (i, want) in t.prep_shares[0].iter().enumerate() {
         assert_eq!(
             prep_shares[i],
             Prio3PrepareShare::get_decoded_with_param(&states[i], want.as_ref())
                 .unwrap_or_else(|e| err!(test_num, e, "decode test vector (prep share)")),
-            "#{}",
-            test_num
+            "#{test_num}"
         );
-        assert_eq!(prep_shares[i].get_encoded(), want.as_ref(), "#{}", test_num);
+        assert_eq!(prep_shares[i].get_encoded(), want.as_ref(), "#{test_num}");
     }
 
     let inbound = prio3


### PR DESCRIPTION
This backports the Clippy fixes from #425 onto the 0.8 release branch.