### PR TITLE
prng: Implement conversion of `Prng` to new field type

### DIFF
--- a/benches/speed_tests.rs
+++ b/benches/speed_tests.rs
@@ -403,6 +403,6 @@ criterion_group!(benches, prio3_client, poly_mul, prng, fft, idpf);
 #[cfg(all(feature = "prio2", not(feature = "experimental")))]
 criterion_group!(benches, count_vec, prio3_client, poly_mul, prng, fft);
 #[cfg(all(not(feature = "prio2"), not(feature = "experimental")))]
-criterion_group!(benches, prio3_client, poly_mul, prng, fft);
+criterion_group!(benches, prng, prio3_client, poly_mul, fft);
 
 criterion_main!(benches);


### PR DESCRIPTION
Partially addresses #141.

Poplar1 requires the same seed stream to be used for producing multiple field types. To facilitate this, add a new method on `Prng` for converting the state to the desired field.