### PR TITLE
vdaf: Simplify trait bound on `Vdaf::PublicShare`

### DIFF
--- a/src/vdaf.rs
+++ b/src/vdaf.rs
@@ -141,7 +141,7 @@ pub trait Vdaf: Clone + Debug {
     type AggregationParam: Clone + Debug + Decode + Encode;
 
     /// A public share sent by a Client.
-    type PublicShare: Clone + Debug + for<'a> ParameterizedDecode<&'a Self> + Encode;
+    type PublicShare: Clone + Debug + ParameterizedDecode<Self> + Encode;
 
     /// An input share sent by a Client.
     type InputShare: Clone + Debug + for<'a> ParameterizedDecode<(&'a Self, usize)> + Encode;


### PR DESCRIPTION
Based on #429 (merge that first).
Partially addresses #141.

Using a reference to the `Vdaf` as the decoding parameter, as the `ParameterizedDecode::decode_with_param()` method already expects a reference. Note that this is only necessary in situation where we want the decoding parameter to be a tuple and we want to avoid cloning the tuple item. I.e., the bound on `Vdaf::InputShare` requires a lifetime.