### PR TITLE
poplar1: Stub out the code and revise types

### DIFF
--- a/src/vdaf/poplar1.rs
+++ b/src/vdaf/poplar1.rs
@@ -1,646 +1,250 @@
 // SPDX-License-Identifier: MPL-2.0
 
-//! **(NOTE: This module is experimental. Applications should not use it yet.)** This module
-//! partially implements the core component of the Poplar protocol [[BBCG+21]]. Named for the
-//! Poplar1 section of [[draft-irtf-cfrg-vdaf-03]], the specification of this VDAF is under active
-//! development. Thus this code should be regarded as experimental and not compliant with any
-//! existing speciication.
+//! Work-in-progress implementation of Poplar1 as specified in [[draft-irtf-cfrg-vdaf-03]].
 //!
-//! TODO Make the input shares stateful so that applications can efficiently evaluate the IDPF over
-//! multiple rounds. Question: Will this require API changes to [`crate::vdaf::Vdaf`]?
-//!
-//! TODO Remove trait [`Idpf`] and integrate IdpfPoplar.
-//!
-//! [BBCG+21]: https://eprint.iacr.org/2021/017
 //! [draft-irtf-cfrg-vdaf-03]: https://datatracker.ietf.org/doc/draft-irtf-cfrg-vdaf/03/
 
-use std::cmp::Ordering;
-use std::collections::{BTreeMap, BTreeSet};
-use std::convert::TryInto;
-use std::fmt::Debug;
-use std::io::Cursor;
-use std::iter::FromIterator;
-use std::marker::PhantomData;
-
-use crate::codec::{
-    decode_u16_items, decode_u24_items, encode_u16_items, encode_u24_items, CodecError, Decode,
-    Encode, ParameterizedDecode,
+use crate::{
+    codec::{CodecError, Decode, Encode, ParameterizedDecode},
+    field::{Field255, Field64},
+    idpf::{IdpfInput, IdpfPublicShare},
+    vdaf::{
+        prg::{Prg, PrgAes128},
+        Aggregatable, Aggregator, Client, Collector, PrepareTransition, Vdaf, VdafError,
+    },
 };
-use crate::field::{decode_fieldvec, FieldElement, FieldElementWithInteger};
-use crate::prng::Prng;
-use crate::vdaf::prg::{Prg, Seed};
-use crate::vdaf::{
-    Aggregatable, AggregateShare, Aggregator, Client, Collector, OutputShare, PrepareTransition,
-    Share, ShareDecodingParameter, Vdaf, VdafError,
-};
+use std::{fmt::Debug, io::Cursor, marker::PhantomData};
 
-/// An input for an IDPF ([`Idpf`]).
-///
-/// TODO Use `prio::idpf::IdpfInput` instead.
-#[derive(Copy, Clone, Debug, Eq, PartialEq)]
-pub struct IdpfInput {
-    index: usize,
-    level: usize,
-}
+/// Poplar1 with [`PrgAes128`].
+pub type Poplar1Aes128 = Poplar1<PrgAes128, 16>;
 
-impl IdpfInput {
-    /// Constructs an IDPF input using the first `level` bits of `data`.
-    pub fn new(data: &[u8], level: usize) -> Result<Self, VdafError> {
-        if level > data.len() << 3 {
-            return Err(VdafError::Uncategorized(format!(
-                "desired bit length ({} bits) exceeds data length ({} bytes)",
-                level,
-                data.len()
-            )));
-        }
-
-        let mut index = 0;
-        let mut i = 0;
-        for byte in data {
-            for j in 0..8 {
-                let bit = (byte >> j) & 1;
-                if i < level {
-                    index |= (bit as usize) << i;
-                }
-                i += 1;
-            }
-        }
-
-        Ok(Self { index, level })
-    }
-}
-
-impl Ord for IdpfInput {
-    fn cmp(&self, other: &Self) -> Ordering {
-        match self.level.cmp(&other.level) {
-            Ordering::Equal => self.index.cmp(&other.index),
-            ord => ord,
-        }
-    }
-}
-
-impl PartialOrd for IdpfInput {
-    fn partial_cmp(&self, other: &Self) -> Option<Ordering> {
-        Some(self.cmp(other))
-    }
-}
-
-impl Encode for IdpfInput {
-    fn encode(&self, bytes: &mut Vec<u8>) {
-        (self.index as u64).encode(bytes);
-        (self.level as u64).encode(bytes);
-    }
-}
-
-impl Decode for IdpfInput {
-    fn decode(bytes: &mut Cursor<&[u8]>) -> Result<Self, CodecError> {
-        let index = u64::decode(bytes)? as usize;
-        let level = u64::decode(bytes)? as usize;
-
-        Ok(Self { index, level })
-    }
-}
-
-/// An Incremental Distributed Point Function (IDPF), as defined by [[BBCG+21]].
-///
-/// [BBCG+21]: https://eprint.iacr.org/2021/017
-//
-// NOTE(cjpatton) The real IDPF API probably needs to be stateful.
-pub trait Idpf<const KEY_LEN: usize, const OUT_LEN: usize>:
-    Sized + Clone + Debug + Encode + Decode
-{
-    /// The finite field over which the IDPF is defined.
-    //
-    // NOTE(cjpatton) The IDPF of [BBCG+21] might use different fields for different levels of the
-    // prefix tree.
-    type Field: FieldElementWithInteger;
-
-    /// Generate and return a sequence of IDPF shares for `input`. Parameter `output` is an
-    /// iterator that is invoked to get the output value for each successive level of the prefix
-    /// tree.
-    fn gen<M: IntoIterator<Item = [Self::Field; OUT_LEN]>>(
-        input: &IdpfInput,
-        values: M,
-    ) -> Result<[Self; KEY_LEN], VdafError>;
-
-    /// Evaluate an IDPF share on `prefix`.
-    fn eval(&self, prefix: &IdpfInput) -> Result<[Self::Field; OUT_LEN], VdafError>;
-}
-
-impl Encode for BTreeSet<IdpfInput> {
-    fn encode(&self, bytes: &mut Vec<u8>) {
-        // Encodes the aggregation parameter as a variable length vector of
-        // [`IdpfInput`], because the size of the aggregation parameter is not
-        // determined by the VDAF.
-        let items: Vec<IdpfInput> = self.iter().map(IdpfInput::clone).collect();
-        encode_u24_items(bytes, &(), &items);
-    }
-}
-
-impl Decode for BTreeSet<IdpfInput> {
-    fn decode(bytes: &mut Cursor<&[u8]>) -> Result<Self, CodecError> {
-        let inputs = decode_u24_items(&(), bytes)?;
-        Ok(Self::from_iter(inputs.into_iter()))
-    }
-}
-
-/// An input share for the `poplar1` VDAF.
-#[derive(Debug, Clone)]
-pub struct Poplar1InputShare<I: Idpf<2, 2>, const L: usize> {
-    /// IDPF share of input
-    idpf: I,
-
-    /// PRNG seed used to generate the aggregator's share of the randomness used in the first part
-    /// of the sketching protocol.
-    sketch_start_seed: Seed<L>,
-
-    /// Aggregator's share of the randomness used in the second part of the sketching protocol.
-    sketch_next: Share<I::Field, L>,
-}
-
-impl<I: Idpf<2, 2>, const L: usize> Encode for Poplar1InputShare<I, L> {
-    fn encode(&self, bytes: &mut Vec<u8>) {
-        self.idpf.encode(bytes);
-        self.sketch_start_seed.encode(bytes);
-        self.sketch_next.encode(bytes);
-    }
-}
-
-impl<'a, I, P, const L: usize> ParameterizedDecode<(&'a Poplar1<I, P, L>, usize)>
-    for Poplar1InputShare<I, L>
-where
-    I: Idpf<2, 2>,
-{
-    fn decode_with_param(
-        (poplar1, agg_id): &(&'a Poplar1<I, P, L>, usize),
-        bytes: &mut Cursor<&[u8]>,
-    ) -> Result<Self, CodecError> {
-        let idpf = I::decode(bytes)?;
-        let sketch_start_seed = Seed::decode(bytes)?;
-        let is_leader = role_try_from(*agg_id).map_err(|e| CodecError::Other(Box::new(e)))?;
-
-        let share_decoding_parameter = if is_leader {
-            // The sketch is two field elements for every bit of input, plus two more, corresponding
-            // to construction of shares in `Poplar1::shard`.
-            ShareDecodingParameter::Leader((poplar1.input_length + 1) * 2)
-        } else {
-            ShareDecodingParameter::Helper
-        };
-
-        let sketch_next =
-            <Share<I::Field, L>>::decode_with_param(&share_decoding_parameter, bytes)?;
-
-        Ok(Self {
-            idpf,
-            sketch_start_seed,
-            sketch_next,
-        })
-    }
-}
-
-/// The poplar1 VDAF.
-#[derive(Debug)]
-pub struct Poplar1<I, P, const L: usize> {
-    input_length: usize,
-    phantom: PhantomData<(I, P)>,
-}
-
-impl<I, P, const L: usize> Poplar1<I, P, L> {
-    /// Create an instance of the poplar1 VDAF. The caller provides a cipher suite `suite` used for
-    /// deriving pseudorandom sequences of field elements, and a input length in bits, corresponding
-    /// to `BITS` as defined in the [VDAF specification][1].
+impl Poplar1Aes128 {
+    /// Create an instance of [`Poplar1Aes128`]. The caller provides the bit length of each
+    /// measurement (`BITS` as defined in the [[draft-irtf-cfrg-vdaf-03]]).
     ///
-    /// [1]: https://datatracker.ietf.org/doc/draft-irtf-cfrg-vdaf/03/
-    pub fn new(bits: usize) -> Self {
+    /// [draft-irtf-cfrg-vdaf-03]: https://datatracker.ietf.org/doc/draft-irtf-cfrg-vdaf/03/
+    pub fn new_aes128(bits: usize) -> Self {
         Self {
-            input_length: bits,
+            bits,
             phantom: PhantomData,
         }
     }
 }
 
-impl<I, P, const L: usize> Clone for Poplar1<I, P, L> {
+/// The poplar1 VDAF.
+#[derive(Debug)]
+pub struct Poplar1<P, const L: usize> {
+    bits: usize,
+    phantom: PhantomData<P>,
+}
+
+impl<P, const L: usize> Clone for Poplar1<P, L> {
     fn clone(&self) -> Self {
-        Self::new(self.input_length)
+        Self {
+            bits: self.bits,
+            phantom: PhantomData,
+        }
     }
 }
-impl<I, P, const L: usize> Vdaf for Poplar1<I, P, L>
-where
-    I: Idpf<2, 2>,
-    P: Prg<L>,
+
+/// Poplar1 public share. This is comprised of the correction words generated for the IDPF.
+pub type Poplar1PublicShare<const L: usize> = IdpfPublicShare<Field64, Field255, L, 2>;
+
+impl<P, const L: usize> ParameterizedDecode<Poplar1<P, L>> for Poplar1PublicShare<L> {
+    fn decode_with_param(
+        _poplar1: &Poplar1<P, L>,
+        _bytes: &mut Cursor<&[u8]>,
+    ) -> Result<Self, CodecError> {
+        todo!()
+    }
+}
+
+/// Poplar1 input share. Comprised of an IDPF key share and the correlated randomness used to
+/// compute the sketch during preparation.
+#[derive(Debug, Clone)]
+pub struct Poplar1InputShare<const L: usize> {}
+
+impl<const L: usize> Encode for Poplar1InputShare<L> {
+    fn encode(&self, _bytes: &mut Vec<u8>) {
+        todo!()
+    }
+}
+
+impl<'a, P, const L: usize> ParameterizedDecode<(&'a Poplar1<P, L>, usize)>
+    for Poplar1InputShare<L>
 {
-    // TODO: This currently uses a codepoint reserved for testing purposes. Replace it with
-    // 0x00001000 once the implementation is updated to match draft-irtf-cfrg-vdaf-03.
-    const ID: u32 = 0xFFFF0000;
+    fn decode_with_param(
+        (_poplar1, _agg_id): &(&'a Poplar1<P, L>, usize),
+        _bytes: &mut Cursor<&[u8]>,
+    ) -> Result<Self, CodecError> {
+        todo!()
+    }
+}
+
+/// Poplar1 preparation state.
+#[derive(Clone, Debug)]
+pub struct Poplar1PrepareState();
+
+/// Poplar1 preparation message.
+#[derive(Clone, Debug)]
+pub struct Poplar1PrepareMessage();
+
+impl Encode for Poplar1PrepareMessage {
+    fn encode(&self, _bytes: &mut Vec<u8>) {
+        todo!()
+    }
+}
+
+impl ParameterizedDecode<Poplar1PrepareState> for Poplar1PrepareMessage {
+    fn decode_with_param(
+        _state: &Poplar1PrepareState,
+        _bytes: &mut Cursor<&[u8]>,
+    ) -> Result<Self, CodecError> {
+        todo!()
+    }
+}
+
+/// A vector of field elements transmitted whilst evaluating Poplar1.
+#[derive(Clone, Debug)]
+pub enum Poplar1FieldVec {
+    /// Field type for inner nodes of the IDPF tree.
+    Inner(Vec<Field64>),
+
+    /// Field type for leaf nodes of the IDPF tree.
+    Leaf(Vec<Field255>),
+}
+
+impl Encode for Poplar1FieldVec {
+    fn encode(&self, _bytes: &mut Vec<u8>) {
+        todo!()
+    }
+}
+
+impl<'a, P: Prg<L>, const L: usize>
+    ParameterizedDecode<(&'a Poplar1<P, L>, &'a Poplar1AggregationParam)> for Poplar1FieldVec
+{
+    fn decode_with_param(
+        (_poplar1, _agg_param): &(&'a Poplar1<P, L>, &'a Poplar1AggregationParam),
+        _bytes: &mut Cursor<&[u8]>,
+    ) -> Result<Self, CodecError> {
+        todo!()
+    }
+}
+
+impl ParameterizedDecode<Poplar1PrepareState> for Poplar1FieldVec {
+    fn decode_with_param(
+        _state: &Poplar1PrepareState,
+        _bytes: &mut Cursor<&[u8]>,
+    ) -> Result<Self, CodecError> {
+        todo!()
+    }
+}
+
+impl Aggregatable for Poplar1FieldVec {
+    type OutputShare = Self;
+
+    fn merge(&mut self, _agg_share: &Self) -> Result<(), VdafError> {
+        todo!()
+    }
+
+    fn accumulate(&mut self, _output_share: &Self) -> Result<(), VdafError> {
+        todo!()
+    }
+}
+
+/// Poplar1 aggregation parameter. This includes an indication of what level of the IDPF tree is
+/// being evaluated and the set of prefixes to evaluate at that level.
+//
+// TODO(cjpatton) spec: Make sure repeated prefixes are disallowed. To make this check easier,
+// consider requring the prefixes to be in lexicographic order.
+#[derive(Clone, Debug)]
+pub struct Poplar1AggregationParam {}
+
+impl Encode for Poplar1AggregationParam {
+    fn encode(&self, _bytes: &mut Vec<u8>) {
+        todo!()
+    }
+}
+
+impl Decode for Poplar1AggregationParam {
+    fn decode(_bytes: &mut Cursor<&[u8]>) -> Result<Self, CodecError> {
+        todo!()
+    }
+}
+
+impl<P: Prg<L>, const L: usize> Vdaf for Poplar1<P, L> {
+    const ID: u32 = 0x00001000;
     type Measurement = IdpfInput;
-    type AggregateResult = BTreeMap<IdpfInput, u64>;
-    type AggregationParam = BTreeSet<IdpfInput>;
-    type PublicShare = (); // TODO: Replace this when the IDPF from [BBCGGI21] is implemented.
-    type InputShare = Poplar1InputShare<I, L>;
-    type OutputShare = OutputShare<I::Field>;
-    type AggregateShare = AggregateShare<I::Field>;
+    type AggregateResult = Vec<u64>;
+    type AggregationParam = Poplar1AggregationParam;
+    type PublicShare = Poplar1PublicShare<L>;
+    type InputShare = Poplar1InputShare<L>;
+    type OutputShare = Poplar1FieldVec;
+    type AggregateShare = Poplar1FieldVec;
 
     fn num_aggregators(&self) -> usize {
         2
     }
 }
 
-impl<I, P, const L: usize> Client for Poplar1<I, P, L>
-where
-    I: Idpf<2, 2>,
-    P: Prg<L>,
-{
-    #[allow(clippy::many_single_char_names)]
+impl<P: Prg<L>, const L: usize> Client for Poplar1<P, L> {
     fn shard(
         &self,
-        input: &IdpfInput,
-    ) -> Result<(Self::PublicShare, Vec<Poplar1InputShare<I, L>>), VdafError> {
-        let idpf_values: Vec<[I::Field; 2]> = Prng::new()?
-            .take(input.level + 1)
-            .map(|k| [I::Field::one(), k])
-            .collect();
-
-        // For each level of the prefix tree, generate correlated randomness that the aggregators use
-        // to validate the output. See [BBCG+21, Appendix C.4].
-        let leader_sketch_start_seed = Seed::generate()?;
-        let helper_sketch_start_seed = Seed::generate()?;
-        let helper_sketch_next_seed = Seed::generate()?;
-        let mut leader_sketch_start_prng: Prng<I::Field, _> =
-            Prng::from_seed_stream(P::seed_stream(&leader_sketch_start_seed, b""));
-        let mut helper_sketch_start_prng: Prng<I::Field, _> =
-            Prng::from_seed_stream(P::seed_stream(&helper_sketch_start_seed, b""));
-        let mut helper_sketch_next_prng: Prng<I::Field, _> =
-            Prng::from_seed_stream(P::seed_stream(&helper_sketch_next_seed, b""));
-        let mut leader_sketch_next: Vec<I::Field> = Vec::with_capacity(2 * idpf_values.len());
-        for value in idpf_values.iter() {
-            let k = value[1];
-
-            // [BBCG+21, Appendix C.4]
-            //
-            // $(a, b, c)$
-            let a = leader_sketch_start_prng.get() + helper_sketch_start_prng.get();
-            let b = leader_sketch_start_prng.get() + helper_sketch_start_prng.get();
-            let c = leader_sketch_start_prng.get() + helper_sketch_start_prng.get();
-
-            // $A = -2a + k$
-            // $B = a^2 + b + -ak + c$
-            let d = k - (a + a);
-            let e = (a * a) + b - (a * k) + c;
-            leader_sketch_next.push(d - helper_sketch_next_prng.get());
-            leader_sketch_next.push(e - helper_sketch_next_prng.get());
-        }
-
-        // Generate IDPF shares of the data and authentication vectors.
-        let idpf_shares = I::gen(input, idpf_values)?;
-
-        Ok((
-            (),
-            vec![
-                Poplar1InputShare {
-                    idpf: idpf_shares[0].clone(),
-                    sketch_start_seed: leader_sketch_start_seed,
-                    sketch_next: Share::Leader(leader_sketch_next),
-                },
-                Poplar1InputShare {
-                    idpf: idpf_shares[1].clone(),
-                    sketch_start_seed: helper_sketch_start_seed,
-                    sketch_next: Share::Helper(helper_sketch_next_seed),
-                },
-            ],
-        ))
+        _input: &IdpfInput,
+    ) -> Result<(Self::PublicShare, Vec<Poplar1InputShare<L>>), VdafError> {
+        todo!()
     }
 }
 
-fn get_level(agg_param: &BTreeSet<IdpfInput>) -> Result<usize, VdafError> {
-    let mut level = None;
-    for prefix in agg_param {
-        if let Some(l) = level {
-            if prefix.level != l {
-                return Err(VdafError::Uncategorized(
-                    "prefixes must all have the same length".to_string(),
-                ));
-            }
-        } else {
-            level = Some(prefix.level);
-        }
-    }
-
-    match level {
-        Some(level) => Ok(level),
-        None => Err(VdafError::Uncategorized("prefix set is empty".to_string())),
-    }
-}
-
-impl<I, P, const L: usize> Aggregator<L> for Poplar1<I, P, L>
-where
-    I: Idpf<2, 2>,
-    P: Prg<L>,
-{
-    type PrepareState = Poplar1PrepareState<I::Field>;
-    type PrepareShare = Poplar1PrepareMessage<I::Field>;
-    type PrepareMessage = Poplar1PrepareMessage<I::Field>;
+impl<P: Prg<L>, const L: usize> Aggregator<L> for Poplar1<P, L> {
+    type PrepareState = Poplar1PrepareState;
+    type PrepareShare = Poplar1FieldVec;
+    type PrepareMessage = Poplar1PrepareMessage;
 
     #[allow(clippy::type_complexity)]
     fn prepare_init(
         &self,
-        verify_key: &[u8; L],
-        agg_id: usize,
-        agg_param: &BTreeSet<IdpfInput>,
-        nonce: &[u8],
-        _public_share: &Self::PublicShare,
-        input_share: &Self::InputShare,
-    ) -> Result<
-        (
-            Poplar1PrepareState<I::Field>,
-            Poplar1PrepareMessage<I::Field>,
-        ),
-        VdafError,
-    > {
-        let level = get_level(agg_param)?;
-        let is_leader = role_try_from(agg_id)?;
-
-        // Derive the verification randomness.
-        let mut p = P::init(verify_key);
-        p.update(nonce);
-        let mut verify_rand_prng: Prng<I::Field, _> = Prng::from_seed_stream(p.into_seed_stream());
-
-        // Evaluate the IDPF shares and compute the polynomial coefficients.
-        let mut z = [I::Field::zero(); 3];
-        let mut output_share = Vec::with_capacity(agg_param.len());
-        for prefix in agg_param.iter() {
-            let value = input_share.idpf.eval(prefix)?;
-            let (v, k) = (value[0], value[1]);
-            let r = verify_rand_prng.get();
-
-            // [BBCG+21, Appendix C.4]
-            //
-            // $(z_\sigma, z^*_\sigma, z^{**}_\sigma)$
-            let tmp = r * v;
-            z[0] += tmp;
-            z[1] += r * tmp;
-            z[2] += r * k;
-            output_share.push(v);
-        }
-
-        // [BBCG+21, Appendix C.4]
-        //
-        // Add blind shares $(a_\sigma b_\sigma, c_\sigma)$
-        //
-        // NOTE(cjpatton) We can make this faster by a factor of 3 by using three seed shares instead
-        // of one. On the other hand, if the input shares are made stateful, then we could store
-        // the PRNG state theire and avoid fast-forwarding.
-        let mut prng = Prng::<I::Field, _>::from_seed_stream(P::seed_stream(
-            &input_share.sketch_start_seed,
-            b"",
-        ))
-        .skip(3 * level);
-        z[0] += prng.next().unwrap();
-        z[1] += prng.next().unwrap();
-        z[2] += prng.next().unwrap();
-
-        let (d, e) = match &input_share.sketch_next {
-            Share::Leader(data) => (data[2 * level], data[2 * level + 1]),
-            Share::Helper(seed) => {
-                let mut prng = Prng::<I::Field, _>::from_seed_stream(P::seed_stream(seed, b""))
-                    .skip(2 * level);
-                (prng.next().unwrap(), prng.next().unwrap())
-            }
-        };
-
-        let x = if is_leader {
-            I::Field::one()
-        } else {
-            I::Field::zero()
-        };
-
-        Ok((
-            Poplar1PrepareState {
-                sketch: SketchState::RoundOne,
-                output_share: OutputShare(output_share),
-                d,
-                e,
-                x,
-            },
-            Poplar1PrepareMessage(z.to_vec()),
-        ))
+        _verify_key: &[u8; L],
+        _agg_id: usize,
+        _agg_param: &Poplar1AggregationParam,
+        _nonce: &[u8],
+        _public_share: &Poplar1PublicShare<L>,
+        _input_share: &Poplar1InputShare<L>,
+    ) -> Result<(Poplar1PrepareState, Poplar1FieldVec), VdafError> {
+        todo!()
     }
 
-    fn prepare_preprocess<M: IntoIterator<Item = Poplar1PrepareMessage<I::Field>>>(
+    fn prepare_preprocess<M: IntoIterator<Item = Poplar1FieldVec>>(
         &self,
-        inputs: M,
-    ) -> Result<Poplar1PrepareMessage<I::Field>, VdafError> {
-        let mut output: Option<Vec<I::Field>> = None;
-        let mut count = 0;
-        for data_share in inputs.into_iter() {
-            count += 1;
-            if let Some(ref mut data) = output {
-                if data_share.0.len() != data.len() {
-                    return Err(VdafError::Uncategorized(format!(
-                        "unexpected message length: got {}; want {}",
-                        data_share.0.len(),
-                        data.len(),
-                    )));
-                }
-
-                for (x, y) in data.iter_mut().zip(data_share.0.iter()) {
-                    *x += *y;
-                }
-            } else {
-                output = Some(data_share.0);
-            }
-        }
-
-        if count != 2 {
-            return Err(VdafError::Uncategorized(format!(
-                "unexpected message count: got {count}; want 2",
-            )));
-        }
-
-        Ok(Poplar1PrepareMessage(output.unwrap()))
+        _inputs: M,
+    ) -> Result<Poplar1PrepareMessage, VdafError> {
+        todo!()
     }
 
     fn prepare_step(
         &self,
-        mut state: Poplar1PrepareState<I::Field>,
-        msg: Poplar1PrepareMessage<I::Field>,
+        _state: Poplar1PrepareState,
+        _msg: Poplar1PrepareMessage,
     ) -> Result<PrepareTransition<Self, L>, VdafError> {
-        match &state.sketch {
-            SketchState::RoundOne => {
-                if msg.0.len() != 3 {
-                    return Err(VdafError::Uncategorized(format!(
-                        "unexpected message length ({:?}): got {}; want 3",
-                        state.sketch,
-                        msg.0.len(),
-                    )));
-                }
-
-                // Compute polynomial coefficients.
-                let z: [I::Field; 3] = msg.0.try_into().unwrap();
-                let y_share =
-                    vec![(state.d * z[0]) + state.e + state.x * ((z[0] * z[0]) - z[1] - z[2])];
-
-                state.sketch = SketchState::RoundTwo;
-                Ok(PrepareTransition::Continue(
-                    state,
-                    Poplar1PrepareMessage(y_share),
-                ))
-            }
-
-            SketchState::RoundTwo => {
-                if msg.0.len() != 1 {
-                    return Err(VdafError::Uncategorized(format!(
-                        "unexpected message length ({:?}): got {}; want 1",
-                        state.sketch,
-                        msg.0.len(),
-                    )));
-                }
-
-                let y = msg.0[0];
-                if y != I::Field::zero() {
-                    return Err(VdafError::Uncategorized(format!(
-                        "output is invalid: polynomial evaluated to {}; want {}",
-                        y,
-                        I::Field::zero(),
-                    )));
-                }
-
-                Ok(PrepareTransition::Finish(state.output_share))
-            }
-        }
+        todo!()
     }
 
-    fn aggregate<M: IntoIterator<Item = OutputShare<I::Field>>>(
+    fn aggregate<M: IntoIterator<Item = Poplar1FieldVec>>(
         &self,
-        agg_param: &BTreeSet<IdpfInput>,
-        output_shares: M,
-    ) -> Result<AggregateShare<I::Field>, VdafError> {
-        let mut agg_share = AggregateShare(vec![I::Field::zero(); agg_param.len()]);
-        for output_share in output_shares.into_iter() {
-            agg_share.accumulate(&output_share)?;
-        }
-
-        Ok(agg_share)
+        _agg_param: &Poplar1AggregationParam,
+        _output_shares: M,
+    ) -> Result<Poplar1FieldVec, VdafError> {
+        todo!()
     }
 }
 
-/// A prepare message sent exchanged between Poplar1 aggregators
-#[derive(Clone, Debug)]
-pub struct Poplar1PrepareMessage<F>(Vec<F>);
-
-impl<F> AsRef<[F]> for Poplar1PrepareMessage<F> {
-    fn as_ref(&self) -> &[F] {
-        &self.0
-    }
-}
-
-impl<F: FieldElement> Encode for Poplar1PrepareMessage<F> {
-    fn encode(&self, bytes: &mut Vec<u8>) {
-        // TODO: This is encoded as a variable length vector of F, but we may
-        // be able to make this a fixed-length vector for specific Poplar1
-        // instantations
-        encode_u16_items(bytes, &(), &self.0);
-    }
-}
-
-impl<F: FieldElement> ParameterizedDecode<Poplar1PrepareState<F>> for Poplar1PrepareMessage<F> {
-    fn decode_with_param(
-        _decoding_parameter: &Poplar1PrepareState<F>,
-        bytes: &mut Cursor<&[u8]>,
-    ) -> Result<Self, CodecError> {
-        // TODO: This is decoded as a variable length vector of F, but we may be
-        // able to make this a fixed-length vector for specific Poplar1
-        // instantiations.
-        let items = decode_u16_items(&(), bytes)?;
-
-        Ok(Self(items))
-    }
-}
-
-/// The state of each Aggregator during the Prepare process.
-#[derive(Clone, Debug)]
-pub struct Poplar1PrepareState<F> {
-    /// State of the secure sketching protocol.
-    sketch: SketchState,
-
-    /// The output share.
-    output_share: OutputShare<F>,
-
-    /// Aggregator's share of $A = -2a + k$.
-    d: F,
-
-    /// Aggregator's share of $B = a^2 + b -ak + c$.
-    e: F,
-
-    /// Equal to 1 if this Aggregator is the "leader" and 0 otherwise.
-    x: F,
-}
-
-#[derive(Clone, Debug)]
-enum SketchState {
-    RoundOne,
-    RoundTwo,
-}
-
-impl<I, P, const L: usize> Collector for Poplar1<I, P, L>
-where
-    I: Idpf<2, 2>,
-    P: Prg<L>,
-{
-    fn unshard<M: IntoIterator<Item = AggregateShare<I::Field>>>(
+impl<P: Prg<L>, const L: usize> Collector for Poplar1<P, L> {
+    fn unshard<M: IntoIterator<Item = Poplar1FieldVec>>(
         &self,
-        agg_param: &BTreeSet<IdpfInput>,
-        agg_shares: M,
+        _agg_param: &Poplar1AggregationParam,
+        _agg_shares: M,
         _num_measurements: usize,
-    ) -> Result<BTreeMap<IdpfInput, u64>, VdafError> {
-        let mut agg_data = AggregateShare(vec![I::Field::zero(); agg_param.len()]);
-        for agg_share in agg_shares.into_iter() {
-            agg_data.merge(&agg_share)?;
-        }
-
-        let mut agg = BTreeMap::new();
-        for (prefix, count) in agg_param.iter().zip(agg_data.as_ref()) {
-            let count = <I::Field as FieldElementWithInteger>::Integer::from(*count);
-            let count: u64 = count
-                .try_into()
-                .map_err(|_| VdafError::Uncategorized("aggregate overflow".to_string()))?;
-            agg.insert(*prefix, count);
-        }
-        Ok(agg)
-    }
-}
-
-impl<'a, F, I, P, const L: usize>
-    ParameterizedDecode<(&'a Poplar1<I, P, L>, &'a BTreeSet<IdpfInput>)> for OutputShare<F>
-where
-    F: FieldElement,
-    P: Prg<L>,
-{
-    fn decode_with_param(
-        (_, agg_param): &(&'a Poplar1<I, P, L>, &'a BTreeSet<IdpfInput>),
-        bytes: &mut Cursor<&[u8]>,
-    ) -> Result<Self, CodecError> {
-        decode_fieldvec(agg_param.len(), bytes).map(Self)
-    }
-}
-
-impl<'a, F, I, P, const L: usize>
-    ParameterizedDecode<(&'a Poplar1<I, P, L>, &'a BTreeSet<IdpfInput>)> for AggregateShare<F>
-where
-    F: FieldElement,
-    P: Prg<L>,
-{
-    fn decode_with_param(
-        (_, agg_param): &(&'a Poplar1<I, P, L>, &'a BTreeSet<IdpfInput>),
-        bytes: &mut Cursor<&[u8]>,
-    ) -> Result<Self, CodecError> {
-        decode_fieldvec(agg_param.len(), bytes).map(Self)
-    }
-}
-
-fn role_try_from(agg_id: usize) -> Result<bool, VdafError> {
-    match agg_id {
-        0 => Ok(true),
-        1 => Ok(false),
-        _ => Err(VdafError::Uncategorized("unexpected aggregator id".into())),
+    ) -> Result<Vec<u64>, VdafError> {
+        todo!()
     }
 }


### PR DESCRIPTION
Based on #432 (merge that first).
Partially addresses #141.=

Prepare the `poplar1` module for the new-and-improved `Poplar1` by removing the old code. While at it, update the types to those we know we're going to need.