### PR TITLE
prng: Reduce internal buffer size

### DIFF
--- a/benches/speed_tests.rs
+++ b/benches/speed_tests.rs
@@ -397,12 +397,12 @@ pub fn idpf(c: &mut Criterion) {
 }
 
 #[cfg(all(feature = "prio2", feature = "experimental"))]
-criterion_group!(benches, count_vec, prio3_client, poly_mul, prng, fft, idpf);
+criterion_group!(benches, prio3_client, idpf, count_vec, prng, fft, poly_mul);
 #[cfg(all(not(feature = "prio2"), feature = "experimental"))]
-criterion_group!(benches, prio3_client, poly_mul, prng, fft, idpf);
+criterion_group!(benches, prio3_client, idpf, prng, fft, poly_mul);
 #[cfg(all(feature = "prio2", not(feature = "experimental")))]
-criterion_group!(benches, count_vec, prio3_client, poly_mul, prng, fft);
+criterion_group!(benches, prio3_client, count_vec, prng, fft, poly_mul);
 #[cfg(all(not(feature = "prio2"), not(feature = "experimental")))]
-criterion_group!(benches, prng, prio3_client, poly_mul, fft);
+criterion_group!(benches, prio3_client, prng, fft, poly_mul);
 
 criterion_main!(benches);

--- a/src/prng.rs
+++ b/src/prng.rs
@@ -14,7 +14,7 @@ use getrandom::getrandom;
 
 use std::marker::PhantomData;
 
-const BUFFER_SIZE_IN_ELEMENTS: usize = 128;
+const BUFFER_SIZE_IN_ELEMENTS: usize = 32;
 
 /// Errors propagated by methods in this module.
 #[derive(Debug, thiserror::Error)]


### PR DESCRIPTION
By current benchmarks, Prio3 prove time reduces by up to 30%, and none of the benchmarks regress.

Whilte at it, re-order the speed tests so that the most relevant bennchmarks are run first. (Things like "poly_mul" and "fft" are quite low-level.)