### PR TITLE
poplar1: Add speed tests for sharding and preparation

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -866,6 +866,7 @@ dependencies = [
  "static_assertions",
  "subtle",
  "thiserror",
+ "zipf",
 ]
 
 [[package]]
@@ -1414,4 +1415,13 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "05f360fc0b24296329c78fda852a1e9ae82de9cf7b27dae4b7f62f118f77b9ed"
 dependencies = [
  "tap",
+]
+
+[[package]]
+name = "zipf"
+version = "7.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "835688a7a1b5d2dfaeb5b7e1b4cfb979e7095a70cd1c72fe083f4904ef3e995e"
+dependencies = [
+ "rand",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -50,6 +50,7 @@ hex = { version = "0.4.3", features = ["serde"] }
 prio = { path = ".", features = ["test-util"] }
 cfg-if = "1.0.0"
 once_cell = "1.17.0"
+zipf = "7.0.0"
 
 [features]
 default = ["crypto-dependencies"]


### PR DESCRIPTION
Based on #434 (merge that first).
Partially addresses #141.

The computationally intensive parts of Poplar1 are sharding and initializing preparation (requires evaluating the IDPF shares). Add speed tests for both of these computations.

The speed of the preparation step is dominated by the length and distribution of the candidate prefixes. As such, it is necessary to pick a distribution that is realistic. Following [BBCG+21], we sample the measurements from a Zipf distribution and derive the candidate prefixes from the prefix tree for these measurements.

While at it, add an additional unit test for `poplar1` for exercising the end-to-end heavy hitters functionality.