### PR TITLE
Benchmark cleanup

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -875,6 +875,7 @@ version = "0.5.0"
 dependencies = [
  "base64",
  "color-eyre",
+ "fixed-macro",
  "prio",
  "serde_json",
  "structopt",

--- a/benches/speed_tests.rs
+++ b/benches/speed_tests.rs
@@ -1,8 +1,8 @@
 // SPDX-License-Identifier: MPL-2.0
 
-use criterion::{criterion_group, criterion_main, Criterion};
 #[cfg(feature = "experimental")]
-use criterion::{BenchmarkId, Throughput};
+use criterion::Throughput;
+use criterion::{criterion_group, criterion_main, BenchmarkId, Criterion};
 #[cfg(feature = "experimental")]
 use fixed_macro::fixed;
 #[cfg(feature = "multithreaded")]
@@ -43,17 +43,18 @@ use zipf::ZipfDistribution;
 /// This benchmark compares the performance of recursive and iterative FFT.
 pub fn fft(c: &mut Criterion) {
     let test_sizes = [16, 256, 1024, 4096];
-    for size in test_sizes.iter() {
-        let inp = random_vector(*size).unwrap();
-        let mut outp = vec![F::zero(); *size];
+    let mut group = c.benchmark_group("fft");
+    for size in test_sizes {
+        let inp = random_vector(size).unwrap();
+        let mut outp = vec![F::zero(); size];
 
-        c.bench_function(&format!("iterative FFT, size={}", *size), |b| {
+        group.bench_function(BenchmarkId::new("iterative", size), |b| {
             b.iter(|| {
                 benchmarked_iterative_fft(&mut outp, &inp);
             })
         });
 
-        c.bench_function(&format!("recursive FFT, size={}", *size), |b| {
+        group.bench_function(BenchmarkId::new("recursive", size), |b| {
             b.iter(|| {
                 benchmarked_recursive_fft(&mut outp, &inp);
             })
@@ -63,10 +64,11 @@ pub fn fft(c: &mut Criterion) {
 
 /// Speed test for generating a seed and deriving a pseudorandom sequence of field elements.
 pub fn prng(c: &mut Criterion) {
+    let mut group = c.benchmark_group("rand");
     let test_sizes = [16, 256, 1024, 4096];
-    for size in test_sizes.iter() {
-        c.bench_function(&format!("rand, size={}", *size), |b| {
-            b.iter(|| random_vector::<F>(*size))
+    for size in test_sizes {
+        group.bench_function(BenchmarkId::from_parameter(size), |b| {
+            b.iter(|| random_vector::<F>(size))
         });
     }
 }
@@ -77,19 +79,21 @@ pub fn prng(c: &mut Criterion) {
 /// `src/flp/gadgets.rs`.
 pub fn poly_mul(c: &mut Criterion) {
     let test_sizes = [1_usize, 30, 60, 90, 120, 150];
-    for size in test_sizes.iter() {
-        let m = (*size + 1).next_power_of_two();
-        let mut g: Mul<F> = Mul::new(*size);
+
+    let mut group = c.benchmark_group("poly_mul");
+    for size in test_sizes {
+        let m = (size + 1).next_power_of_two();
+        let mut g: Mul<F> = Mul::new(size);
         let mut outp = vec![F::zero(); 2 * m];
         let inp = vec![random_vector(m).unwrap(); 2];
 
-        c.bench_function(&format!("poly mul FFT, size={}", *size), |b| {
+        group.bench_function(BenchmarkId::new("fft", size), |b| {
             b.iter(|| {
                 benchmarked_gadget_mul_call_poly_fft(&mut g, &mut outp, &inp).unwrap();
             })
         });
 
-        c.bench_function(&format!("poly mul direct, size={}", *size), |b| {
+        group.bench_function(BenchmarkId::new("direct", size), |b| {
             b.iter(|| {
                 benchmarked_gadget_mul_call_poly_direct(&mut g, &mut outp, &inp).unwrap();
             })
@@ -99,36 +103,38 @@ pub fn poly_mul(c: &mut Criterion) {
 
 /// Benchmark generation and verification of boolean vectors.
 pub fn count_vec(c: &mut Criterion) {
+    let mut group = c.benchmark_group("count_vec");
     let test_sizes = [10, 100, 1_000];
-    for size in test_sizes.iter() {
-        let input = vec![F::zero(); *size];
-
+    for size in test_sizes {
+        let input = vec![F::zero(); size];
         #[cfg(feature = "prio2")]
         {
             // Public keys used to instantiate the v2 client.
             const PUBKEY1: &str = "BIl6j+J6dYttxALdjISDv6ZI4/VWVEhUzaS05LgrsfswmbLOgNt9HUC2E0w+9RqZx3XMkdEHBHfNuCSMpOwofVQ=";
             const PUBKEY2: &str = "BNNOqoU54GPo+1gTPv+hCgA9U2ZCKd76yOMrWa1xTWgeb4LhFLMQIQoRwDVaW64g/WTdcxT4rDULoycUNFB60LE=";
-
-            // Prio2
             let pk1 = PublicKey::from_base64(PUBKEY1).unwrap();
             let pk2 = PublicKey::from_base64(PUBKEY2).unwrap();
-            let mut client: Prio2Client<F> =
-                Prio2Client::new(input.len(), pk1.clone(), pk2.clone()).unwrap();
 
-            c.bench_function(&format!("prio2 prove, input size={}", *size), |b| {
+            // Prio2
+            let mut client: Prio2Client<F> =
+                Prio2Client::new(size, pk1.clone(), pk2.clone()).unwrap();
+
+            group.bench_function(BenchmarkId::new("prio2_prove", size), |b| {
                 b.iter(|| {
                     benchmarked_v2_prove(&input, &mut client);
                 })
             });
 
+            let mut client: Prio2Client<F> =
+                Prio2Client::new(size, pk1.clone(), pk2.clone()).unwrap();
             let input_and_proof = benchmarked_v2_prove(&input, &mut client);
             let mut validator: ValidationMemory<F> = ValidationMemory::new(input.len());
             let eval_at = random_vector(1).unwrap()[0];
 
-            c.bench_function(&format!("prio2 query, input size={}", *size), |b| {
+            group.bench_function(BenchmarkId::new("prio2_query", size), |b| {
                 b.iter(|| {
                     generate_verification_message(
-                        input.len(),
+                        size,
                         eval_at,
                         &input_and_proof,
                         true,
@@ -140,54 +146,48 @@ pub fn count_vec(c: &mut Criterion) {
         }
 
         // Prio3
-        let count_vec: SumVec<F, ParallelSum<F, BlindPolyEval<F>>> = SumVec::new(1, *size).unwrap();
-        let joint_rand = random_vector(count_vec.joint_rand_len()).unwrap();
-        let prove_rand = random_vector(count_vec.prove_rand_len()).unwrap();
-        let proof = count_vec.prove(&input, &prove_rand, &joint_rand).unwrap();
+        let sum_vec: SumVec<F, ParallelSum<F, BlindPolyEval<F>>> = SumVec::new(1, size).unwrap();
+        let joint_rand = random_vector(sum_vec.joint_rand_len()).unwrap();
+        let prove_rand = random_vector(sum_vec.prove_rand_len()).unwrap();
+        let proof = sum_vec.prove(&input, &prove_rand, &joint_rand).unwrap();
 
-        c.bench_function(
-            &format!("prio3 countvec prove, input size={}", *size),
-            |b| {
-                b.iter(|| {
-                    let prove_rand = random_vector(count_vec.prove_rand_len()).unwrap();
-                    count_vec.prove(&input, &prove_rand, &joint_rand).unwrap();
-                })
-            },
-        );
+        group.bench_function(BenchmarkId::new("prio3_countvec_prove", size), |b| {
+            b.iter(|| {
+                let prove_rand = random_vector(sum_vec.prove_rand_len()).unwrap();
+                sum_vec.prove(&input, &prove_rand, &joint_rand).unwrap();
+            })
+        });
 
-        c.bench_function(
-            &format!("prio3 countvec query, input size={}", *size),
-            |b| {
-                b.iter(|| {
-                    let query_rand = random_vector(count_vec.query_rand_len()).unwrap();
-                    count_vec
-                        .query(&input, &proof, &query_rand, &joint_rand, 1)
-                        .unwrap();
-                })
-            },
-        );
+        group.bench_function(BenchmarkId::new("prio3_countvec_query", size), |b| {
+            b.iter(|| {
+                let query_rand = random_vector(sum_vec.query_rand_len()).unwrap();
+                sum_vec
+                    .query(&input, &proof, &query_rand, &joint_rand, 1)
+                    .unwrap();
+            })
+        });
 
         #[cfg(feature = "multithreaded")]
         {
-            let count_vec: SumVec<F, ParallelSumMultithreaded<F, BlindPolyEval<F>>> =
-                SumVec::new(1, *size).unwrap();
+            let sum_vec: SumVec<F, ParallelSumMultithreaded<F, BlindPolyEval<F>>> =
+                SumVec::new(1, size).unwrap();
 
-            c.bench_function(
-                &format!("prio3 countvec multithreaded prove, input size={}", *size),
+            group.bench_function(
+                BenchmarkId::new("prio3_countvec_multithreaded_prove", size),
                 |b| {
                     b.iter(|| {
-                        let prove_rand = random_vector(count_vec.prove_rand_len()).unwrap();
-                        count_vec.prove(&input, &prove_rand, &joint_rand).unwrap();
+                        let prove_rand = random_vector(sum_vec.prove_rand_len()).unwrap();
+                        sum_vec.prove(&input, &prove_rand, &joint_rand).unwrap();
                     })
                 },
             );
 
-            c.bench_function(
-                &format!("prio3 countvec multithreaded query, input size={}", *size),
+            group.bench_function(
+                BenchmarkId::new("prio3_countvec_multithreaded_query", size),
                 |b| {
                     b.iter(|| {
-                        let query_rand = random_vector(count_vec.query_rand_len()).unwrap();
-                        count_vec
+                        let query_rand = random_vector(sum_vec.query_rand_len()).unwrap();
+                        sum_vec
                             .query(&input, &proof, &query_rand, &joint_rand, 1)
                             .unwrap();
                     })
@@ -200,10 +200,11 @@ pub fn count_vec(c: &mut Criterion) {
 /// Benchmark prio3 client performance.
 pub fn prio3_client(c: &mut Criterion) {
     let num_shares = 2;
+    let mut group = c.benchmark_group("prio3_client");
 
     let prio3 = Prio3::new_aes128_count(num_shares).unwrap();
     let measurement = 1;
-    c.bench_function("prio3 count", |b| {
+    group.bench_function("count", |b| {
         b.iter(|| {
             prio3.shard(&measurement).unwrap();
         })
@@ -212,19 +213,16 @@ pub fn prio3_client(c: &mut Criterion) {
     let buckets: Vec<u64> = (1..10).collect();
     let prio3 = Prio3::new_aes128_histogram(num_shares, &buckets).unwrap();
     let measurement = 17;
-    c.bench_function(
-        &format!("prio3 histogram ({} buckets)", buckets.len() + 1),
-        |b| {
-            b.iter(|| {
-                prio3.shard(&measurement).unwrap();
-            })
-        },
-    );
+    group.bench_function(BenchmarkId::new("histogram", buckets.len() + 1), |b| {
+        b.iter(|| {
+            prio3.shard(&measurement).unwrap();
+        })
+    });
 
     let bits = 32;
     let prio3 = Prio3::new_aes128_sum(num_shares, bits).unwrap();
     let measurement = 1337;
-    c.bench_function(&format!("prio3 sum ({bits} bits)"), |b| {
+    group.bench_function(BenchmarkId::new("sum", bits), |b| {
         b.iter(|| {
             prio3.shard(&measurement).unwrap();
         })
@@ -233,7 +231,7 @@ pub fn prio3_client(c: &mut Criterion) {
     let len = 1000;
     let prio3 = Prio3::new_aes128_sum_vec(num_shares, 1, len).unwrap();
     let measurement = vec![0; len];
-    c.bench_function(&format!("prio3 countvec ({len} len)"), |b| {
+    group.bench_function(BenchmarkId::new("countvec", len), |b| {
         b.iter(|| {
             prio3.shard(&measurement).unwrap();
         })
@@ -243,7 +241,7 @@ pub fn prio3_client(c: &mut Criterion) {
     {
         let prio3 = Prio3::new_aes128_sum_vec_multithreaded(num_shares, 1, len).unwrap();
         let measurement = vec![0; len];
-        c.bench_function(&format!("prio3 parallel countvec ({len} len)"), |b| {
+        group.bench_function(BenchmarkId::new("countvec_parallel", len), |b| {
             b.iter(|| {
                 prio3.shard(&measurement).unwrap();
             })
@@ -256,14 +254,11 @@ pub fn prio3_client(c: &mut Criterion) {
         let prio3 = Prio3::new_aes128_fixedpoint_boundedl2_vec_sum(num_shares, len).unwrap();
         let fp_num = fixed!(0.0001: I1F15);
         let measurement = vec![fp_num; len];
-        c.bench_function(
-            &format!("prio3 fixedpoint16 boundedl2 vec ({len} entries)"),
-            |b| {
-                b.iter(|| {
-                    prio3.shard(&measurement).unwrap();
-                })
-            },
-        );
+        group.bench_function(BenchmarkId::new("fixedpoint16_boundedl2_vec", len), |b| {
+            b.iter(|| {
+                prio3.shard(&measurement).unwrap();
+            })
+        });
     }
 
     #[cfg(all(feature = "experimental", feature = "multithreaded"))]
@@ -272,8 +267,8 @@ pub fn prio3_client(c: &mut Criterion) {
             Prio3::new_aes128_fixedpoint_boundedl2_vec_sum_multithreaded(num_shares, len).unwrap();
         let fp_num = fixed!(0.0001: I1F15);
         let measurement = vec![fp_num; len];
-        c.bench_function(
-            &format!("prio3 fixedpoint16 boundedl2 vec multithreaded ({len} entries)"),
+        group.bench_function(
+            BenchmarkId::new("prio3_fixedpoint16_boundedl2_vec_multithreaded", len),
             |b| {
                 b.iter(|| {
                     prio3.shard(&measurement).unwrap();

--- a/benches/speed_tests.rs
+++ b/benches/speed_tests.rs
@@ -40,28 +40,6 @@ use std::iter;
 #[cfg(feature = "experimental")]
 use zipf::ZipfDistribution;
 
-/// This benchmark compares the performance of recursive and iterative FFT.
-pub fn fft(c: &mut Criterion) {
-    let test_sizes = [16, 256, 1024, 4096];
-    let mut group = c.benchmark_group("fft");
-    for size in test_sizes {
-        let inp = random_vector(size).unwrap();
-        let mut outp = vec![F::zero(); size];
-
-        group.bench_function(BenchmarkId::new("iterative", size), |b| {
-            b.iter(|| {
-                benchmarked_iterative_fft(&mut outp, &inp);
-            })
-        });
-
-        group.bench_function(BenchmarkId::new("recursive", size), |b| {
-            b.iter(|| {
-                benchmarked_recursive_fft(&mut outp, &inp);
-            })
-        });
-    }
-}
-
 /// Speed test for generating a seed and deriving a pseudorandom sequence of field elements.
 pub fn prng(c: &mut Criterion) {
     let mut group = c.benchmark_group("rand");
@@ -485,14 +463,13 @@ criterion_group!(
     count_vec,
     poly_mul,
     prng,
-    fft,
     idpf
 );
 #[cfg(all(not(feature = "prio2"), feature = "experimental"))]
-criterion_group!(benches, poplar1, prio3_client, poly_mul, prng, fft, idpf);
+criterion_group!(benches, poplar1, prio3_client, poly_mul, prng, idpf);
 #[cfg(all(feature = "prio2", not(feature = "experimental")))]
-criterion_group!(benches, prio3_client, count_vec, prng, fft, poly_mul);
+criterion_group!(benches, prio3_client, count_vec, prng, poly_mul);
 #[cfg(all(not(feature = "prio2"), not(feature = "experimental")))]
-criterion_group!(benches, prio3_client, prng, fft, poly_mul);
+criterion_group!(benches, prio3_client, prng, poly_mul);
 
 criterion_main!(benches);

--- a/benches/speed_tests.rs
+++ b/benches/speed_tests.rs
@@ -9,17 +9,13 @@ use fixed_macro::fixed;
 use prio::flp::gadgets::ParallelSumMultithreaded;
 use prio::{
     benchmarked::*,
-    codec::Encode,
-    field::{random_vector, FftFriendlyFieldElement, Field128 as F, FieldElement},
+    field::{random_vector, Field128 as F, FieldElement},
     flp::{
         gadgets::{BlindPolyEval, Mul, ParallelSum},
         types::SumVec,
         Type,
     },
-    vdaf::{
-        prio3::{Prio3, Prio3InputShare},
-        Client as Prio3Client,
-    },
+    vdaf::{prio3::Prio3, Client as Prio3Client},
 };
 #[cfg(feature = "prio2")]
 use prio::{
@@ -119,11 +115,6 @@ pub fn count_vec(c: &mut Criterion) {
             let mut client: Prio2Client<F> =
                 Prio2Client::new(input.len(), pk1.clone(), pk2.clone()).unwrap();
 
-            println!(
-                "prio2 proof size={}\n",
-                benchmarked_v2_prove(&input, &mut client).len()
-            );
-
             c.bench_function(&format!("prio2 prove, input size={}", *size), |b| {
                 b.iter(|| {
                     benchmarked_v2_prove(&input, &mut client);
@@ -153,8 +144,6 @@ pub fn count_vec(c: &mut Criterion) {
         let joint_rand = random_vector(count_vec.joint_rand_len()).unwrap();
         let prove_rand = random_vector(count_vec.prove_rand_len()).unwrap();
         let proof = count_vec.prove(&input, &prove_rand, &joint_rand).unwrap();
-
-        println!("prio3 countvec proof size={}\n", proof.len());
 
         c.bench_function(
             &format!("prio3 countvec prove, input size={}", *size),
@@ -214,24 +203,15 @@ pub fn prio3_client(c: &mut Criterion) {
 
     let prio3 = Prio3::new_aes128_count(num_shares).unwrap();
     let measurement = 1;
-    println!(
-        "prio3 count share size = {}",
-        prio3_input_share_size(&prio3.shard(&measurement).unwrap().1)
-    );
     c.bench_function("prio3 count", |b| {
         b.iter(|| {
-            prio3.shard(&1).unwrap();
+            prio3.shard(&measurement).unwrap();
         })
     });
 
     let buckets: Vec<u64> = (1..10).collect();
     let prio3 = Prio3::new_aes128_histogram(num_shares, &buckets).unwrap();
     let measurement = 17;
-    println!(
-        "prio3 histogram ({} buckets) share size = {}",
-        buckets.len() + 1,
-        prio3_input_share_size(&prio3.shard(&measurement).unwrap().1)
-    );
     c.bench_function(
         &format!("prio3 histogram ({} buckets)", buckets.len() + 1),
         |b| {
@@ -244,11 +224,6 @@ pub fn prio3_client(c: &mut Criterion) {
     let bits = 32;
     let prio3 = Prio3::new_aes128_sum(num_shares, bits).unwrap();
     let measurement = 1337;
-    println!(
-        "prio3 sum ({} bits) share size = {}",
-        bits,
-        prio3_input_share_size(&prio3.shard(&measurement).unwrap().1)
-    );
     c.bench_function(&format!("prio3 sum ({bits} bits)"), |b| {
         b.iter(|| {
             prio3.shard(&measurement).unwrap();
@@ -258,11 +233,6 @@ pub fn prio3_client(c: &mut Criterion) {
     let len = 1000;
     let prio3 = Prio3::new_aes128_sum_vec(num_shares, 1, len).unwrap();
     let measurement = vec![0; len];
-    println!(
-        "prio3 countvec ({} len) share size = {}",
-        len,
-        prio3_input_share_size(&prio3.shard(&measurement).unwrap().1)
-    );
     c.bench_function(&format!("prio3 countvec ({len} len)"), |b| {
         b.iter(|| {
             prio3.shard(&measurement).unwrap();
@@ -273,11 +243,6 @@ pub fn prio3_client(c: &mut Criterion) {
     {
         let prio3 = Prio3::new_aes128_sum_vec_multithreaded(num_shares, 1, len).unwrap();
         let measurement = vec![0; len];
-        println!(
-            "prio3 countvec multithreaded ({} len) share size = {}",
-            len,
-            prio3_input_share_size(&prio3.shard(&measurement).unwrap().1)
-        );
         c.bench_function(&format!("prio3 parallel countvec ({len} len)"), |b| {
             b.iter(|| {
                 prio3.shard(&measurement).unwrap();
@@ -291,11 +256,6 @@ pub fn prio3_client(c: &mut Criterion) {
         let prio3 = Prio3::new_aes128_fixedpoint_boundedl2_vec_sum(num_shares, len).unwrap();
         let fp_num = fixed!(0.0001: I1F15);
         let measurement = vec![fp_num; len];
-        println!(
-            "prio3 fixedpoint16 boundedl2 vec ({} entries) size = {}",
-            len,
-            prio3_input_share_size(&prio3.shard(&measurement).unwrap().1)
-        );
         c.bench_function(
             &format!("prio3 fixedpoint16 boundedl2 vec ({len} entries)"),
             |b| {
@@ -312,11 +272,6 @@ pub fn prio3_client(c: &mut Criterion) {
             Prio3::new_aes128_fixedpoint_boundedl2_vec_sum_multithreaded(num_shares, len).unwrap();
         let fp_num = fixed!(0.0001: I1F15);
         let measurement = vec![fp_num; len];
-        println!(
-            "prio3 fixedpoint16 boundedl2 vec multithreaded ({} entries) size = {}",
-            len,
-            prio3_input_share_size(&prio3.shard(&measurement).unwrap().1)
-        );
         c.bench_function(
             &format!("prio3 fixedpoint16 boundedl2 vec multithreaded ({len} entries)"),
             |b| {
@@ -326,17 +281,6 @@ pub fn prio3_client(c: &mut Criterion) {
             },
         );
     }
-}
-
-fn prio3_input_share_size<F: FftFriendlyFieldElement, const L: usize>(
-    input_shares: &[Prio3InputShare<F, L>],
-) -> usize {
-    let mut size = 0;
-    for input_share in input_shares {
-        size += input_share.get_encoded().len();
-    }
-
-    size
 }
 
 /// Benchmark IdpfPoplar performance.

--- a/binaries/Cargo.toml
+++ b/binaries/Cargo.toml
@@ -8,8 +8,9 @@ repository = "https://github.com/divviup/libprio-rs"
 
 [dependencies]
 base64 = "0.21.0"
-prio = { path = "..", features = ["test-util", "prio2"] }
 color-eyre = { version = "^0.6" }
+fixed-macro = "1.2.0"
+prio = { path = "..", features = ["test-util", "prio2", "experimental", "multithreaded"] }
 serde_json = { version = "1.0" }
 structopt = { version = "0.3.26" }
 

--- a/binaries/src/bin/vdaf_message_sizes.rs
+++ b/binaries/src/bin/vdaf_message_sizes.rs
@@ -1,0 +1,120 @@
+use fixed_macro::fixed;
+use prio::{
+    benchmarked::benchmarked_v2_prove,
+    client::Client as Prio2Client,
+    codec::Encode,
+    encrypt::PublicKey,
+    field::{random_vector, FftFriendlyFieldElement, Field128, FieldElement},
+    flp::{
+        gadgets::{BlindPolyEval, ParallelSum},
+        types::SumVec,
+        Type,
+    },
+    vdaf::{
+        prio3::{Prio3, Prio3InputShare},
+        Client,
+    },
+};
+
+fn main() {
+    let num_shares = 2;
+
+    let prio3 = Prio3::new_aes128_count(num_shares).unwrap();
+    let measurement = 1;
+    println!(
+        "prio3 count share size = {}",
+        prio3_input_share_size(&prio3.shard(&measurement).unwrap().1)
+    );
+
+    let buckets: Vec<u64> = (1..10).collect();
+    let prio3 = Prio3::new_aes128_histogram(num_shares, &buckets).unwrap();
+    let measurement = 17;
+    println!(
+        "prio3 histogram ({} buckets) share size = {}",
+        buckets.len() + 1,
+        prio3_input_share_size(&prio3.shard(&measurement).unwrap().1)
+    );
+
+    let bits = 32;
+    let prio3 = Prio3::new_aes128_sum(num_shares, bits).unwrap();
+    let measurement = 1337;
+    println!(
+        "prio3 sum ({} bits) share size = {}",
+        bits,
+        prio3_input_share_size(&prio3.shard(&measurement).unwrap().1)
+    );
+
+    let len = 1000;
+    let prio3 = Prio3::new_aes128_sum_vec(num_shares, 1, len).unwrap();
+    let measurement = vec![0; len];
+    println!(
+        "prio3 countvec ({} len) share size = {}",
+        len,
+        prio3_input_share_size(&prio3.shard(&measurement).unwrap().1)
+    );
+
+    let prio3 = Prio3::new_aes128_sum_vec_multithreaded(num_shares, 1, len).unwrap();
+    println!(
+        "prio3 countvec multithreaded ({} len) share size = {}",
+        len,
+        prio3_input_share_size(&prio3.shard(&measurement).unwrap().1)
+    );
+
+    let len = 1000;
+    let prio3 = Prio3::new_aes128_fixedpoint_boundedl2_vec_sum(num_shares, len).unwrap();
+    let fp_num = fixed!(0.0001: I1F15);
+    let measurement = vec![fp_num; len];
+    println!(
+        "prio3 fixedpoint16 boundedl2 vec ({} entries) size = {}",
+        len,
+        prio3_input_share_size(&prio3.shard(&measurement).unwrap().1)
+    );
+
+    let prio3 =
+        Prio3::new_aes128_fixedpoint_boundedl2_vec_sum_multithreaded(num_shares, len).unwrap();
+    println!(
+        "prio3 fixedpoint16 boundedl2 vec multithreaded ({} entries) size = {}",
+        len,
+        prio3_input_share_size(&prio3.shard(&measurement).unwrap().1)
+    );
+
+    println!();
+
+    for size in [10, 100, 1_000] {
+        // Prio2
+        // Public keys used to instantiate the v2 client.
+        const PUBKEY1: &str =
+        "BIl6j+J6dYttxALdjISDv6ZI4/VWVEhUzaS05LgrsfswmbLOgNt9HUC2E0w+9RqZx3XMkdEHBHfNuCSMpOwofVQ=";
+        const PUBKEY2: &str =
+        "BNNOqoU54GPo+1gTPv+hCgA9U2ZCKd76yOMrWa1xTWgeb4LhFLMQIQoRwDVaW64g/WTdcxT4rDULoycUNFB60LE=";
+        let pk1 = PublicKey::from_base64(PUBKEY1).unwrap();
+        let pk2 = PublicKey::from_base64(PUBKEY2).unwrap();
+        let input = vec![Field128::zero(); size];
+        let mut client: Prio2Client<Field128> =
+            Prio2Client::new(input.len(), pk1.clone(), pk2.clone()).unwrap();
+        println!(
+            "prio2 ({} len) proof size={}",
+            size,
+            benchmarked_v2_prove(&input, &mut client).len()
+        );
+
+        // Prio3
+        let count_vec: SumVec<Field128, ParallelSum<Field128, BlindPolyEval<Field128>>> =
+            SumVec::new(1, size).unwrap();
+        let joint_rand = random_vector(count_vec.joint_rand_len()).unwrap();
+        let prove_rand = random_vector(count_vec.prove_rand_len()).unwrap();
+        let proof = count_vec.prove(&input, &prove_rand, &joint_rand).unwrap();
+        println!("prio3 countvec ({} len) proof size={}", size, proof.len());
+    }
+}
+
+fn prio3_input_share_size<F: FftFriendlyFieldElement, const L: usize>(
+    input_shares: &[Prio3InputShare<F, L>],
+) -> usize {
+    let mut size = 0;
+    for input_share in input_shares {
+        size += input_share.get_encoded().len();
+    }
+
+    size
+}


### PR DESCRIPTION
This cleans up the `speed_tests` benchmark by moving reporting of message sizes out to a separate binary, renaming benchmarks, organizing benchmarks hierarchically with groups, and moving sizes to the "parameter" part of `BenchmarkId`s.