### PR TITLE
Reduce variance of Poplar1 benchmark

### DIFF
--- a/benches/speed_tests.rs
+++ b/benches/speed_tests.rs
@@ -45,6 +45,7 @@ pub fn prng(c: &mut Criterion) {
             b.iter(|| random_vector::<F>(size))
         });
     }
+    group.finish();
 }
 
 /// The asymptotic cost of polynomial multiplication is `O(n log n)` using FFT and `O(n^2)` using
@@ -73,6 +74,7 @@ pub fn poly_mul(c: &mut Criterion) {
             })
         });
     }
+    group.finish();
 }
 
 /// Benchmark generation and verification of boolean vectors.
@@ -156,6 +158,7 @@ pub fn count_vec(c: &mut Criterion) {
             );
         }
     }
+    group.finish();
 }
 
 /// Benchmark prio3 client performance.
@@ -237,6 +240,8 @@ pub fn prio3_client(c: &mut Criterion) {
             },
         );
     }
+
+    group.finish();
 }
 
 /// Benchmark IdpfPoplar performance.
@@ -265,7 +270,7 @@ pub fn idpf(c: &mut Criterion) {
             });
         });
     }
-    drop(group);
+    group.finish();
 
     let mut group = c.benchmark_group("idpf_eval");
     for size in test_sizes.iter() {
@@ -301,6 +306,7 @@ pub fn idpf(c: &mut Criterion) {
             });
         });
     }
+    group.finish();
 }
 
 /// Benchmark Poplar1.
@@ -321,7 +327,7 @@ pub fn poplar1(c: &mut Criterion) {
             });
         });
     }
-    drop(group);
+    group.finish();
 
     let mut group = c.benchmark_group("poplar1_prepare_init");
     for size in test_sizes.iter() {
@@ -365,6 +371,7 @@ pub fn poplar1(c: &mut Criterion) {
             });
         });
     }
+    group.finish();
 }
 
 /// Generate a set of Poplar1 measurements with the given bit length `bits`. They are sampled

--- a/benches/speed_tests.rs
+++ b/benches/speed_tests.rs
@@ -346,7 +346,6 @@ pub fn poplar1(c: &mut Criterion) {
 
     let mut group = c.benchmark_group("poplar1_prepare_init");
     for size in test_sizes.iter() {
-        group.throughput(Throughput::Bytes(*size as u64 / 8));
         group.measurement_time(Duration::from_secs(30)); // slower benchmark
         group.bench_with_input(BenchmarkId::from_parameter(size), size, |b, &size| {
             let vdaf = Poplar1::new_aes128(size);


### PR DESCRIPTION
Previously, the Poplar1 benchmarks randomly generated one set of inputs, and measured the time it took to run the relevant operation over that input repeatedly. This leads to higher variability in benchmark results, primarily through the aggregation parameter. If the prefixes in the aggregation parameter themselves share enough common prefixes, memoization in the preparation algorithm's IDPF evaluation calls influences the total runtime. (We could also be over-training the CPU branch predictor, etc.)

This PR reduces the variability of these benchmarks by both using the same random inputs between runs and using many random inputs in a single run. Calls to `Bencher::iter()` are replaced with `Bencher::iter_batched()`, which takes an additional closure to generate inputs, and a memory consumption hint. Inputs are generated randomly as before, but using an RNG initialized with a fixed seed. The library will do some warmup runs, generate a large number of inputs stored in a `Vec`, and then run the function under test on each input in turn. In my experimentation, this made a noticeable difference in the run-to-run variability. (changes went from +/-7% to +/-2%)

I also made a couple other Criteron-related cleanups: calling `BenchmarkGroup::finish()` and dropping the throughput annotation on `poplar1_prepare_init`. (This benchmark evaluates only the last IDPF level on a somewhat-arbitrary number of prefixes, so I think there are too many confounding factors to turn the results into a bytes/sec throughput)