### PR TITLE
Prio3: Add public share, replacing joint rand hint

### DIFF
--- a/src/vdaf/prio3.rs
+++ b/src/vdaf/prio3.rs
@@ -915,6 +915,13 @@ where
             }
             let own_joint_rand_part = joint_rand_part_prg.into_seed();
 
+            // Make an iterator over the joint randomness parts, but use this aggregator's
+            // contribution, computed from the input share, in lieu of the the corresponding part
+            // from the public share.
+            //
+            // The locally computed part should match the part from the public share for honestly
+            // generated reports. If they do not match, the joint randomness seed check during the
+            // next round of preparation should fail.
             let corrected_joint_rand_parts = public_share
                 .joint_rand_parts
                 .iter()

--- a/src/vdaf/prio3_test.rs
+++ b/src/vdaf/prio3_test.rs
@@ -5,7 +5,7 @@ use crate::{
     flp::Type,
     vdaf::{
         prg::Prg,
-        prio3::{Prio3, Prio3InputShare, Prio3PrepareShare},
+        prio3::{Prio3, Prio3InputShare, Prio3PrepareShare, Prio3PublicShare},
         Aggregator, PrepareTransition,
     },
 };
@@ -26,10 +26,11 @@ struct TPrio3Prep<M> {
     measurement: M,
     #[serde(with = "hex")]
     nonce: Vec<u8>,
+    public_share: TEncoded,
     input_shares: Vec<TEncoded>,
     prep_shares: Vec<Vec<TEncoded>>,
     prep_messages: Vec<TEncoded>,
-    out_shares: Vec<Vec<M>>,
+    out_shares: Vec<Vec<TEncoded>>,
 }
 
 #[derive(Deserialize, Serialize)]
@@ -61,10 +62,15 @@ fn check_prep_test_vec<M, T, P, const L: usize>(
     M: From<<T as Type>::Field> + Debug + PartialEq,
 {
     let nonce = <[u8; 16]>::try_from(t.nonce.clone()).unwrap();
-    let input_shares = prio3
+    let (public_share, input_shares) = prio3
         .test_vec_shard(&t.measurement, &nonce)
         .expect("failed to generate input shares");
 
+    assert_eq!(
+        public_share,
+        Prio3PublicShare::get_decoded_with_param(prio3, t.public_share.as_ref())
+            .unwrap_or_else(|e| err!(test_num, e, "decode test vector (public share)")),
+    );
     assert_eq!(2, t.input_shares.len(), "#{test_num}");
     for (agg_id, want) in t.input_shares.iter().enumerate() {
         assert_eq!(
@@ -84,7 +90,7 @@ fn check_prep_test_vec<M, T, P, const L: usize>(
     let mut prep_shares = Vec::new();
     for (agg_id, input_share) in input_shares.iter().enumerate() {
         let (state, prep_share) = prio3
-            .prepare_init(verify_key, agg_id, &(), &nonce, &(), input_share)
+            .prepare_init(verify_key, agg_id, &(), &nonce, &public_share, input_share)
             .unwrap_or_else(|e| err!(test_num, e, "prep state init"));
         states.push(state);
         prep_shares.push(prep_share);
@@ -118,8 +124,11 @@ fn check_prep_test_vec<M, T, P, const L: usize>(
     }
 
     for (got, want) in out_shares.iter().zip(t.out_shares.iter()) {
-        let got: Vec<M> = got.as_ref().iter().map(|x| M::from(*x)).collect();
-        assert_eq!(&got, want);
+        let got: Vec<Vec<u8>> = got.as_ref().iter().map(|x| x.get_encoded()).collect();
+        assert_eq!(got.len(), want.len());
+        for (got_elem, want_elem) in got.iter().zip(want.iter()) {
+            assert_eq!(got_elem.as_slice(), want_elem.as_ref());
+        }
     }
 }
 


### PR DESCRIPTION
This implements a change in Prio3 as of VDAF-04, removing joint randomness hints from input shares, and instead putting every aggregator's joint randomness part in the public share.

This PR also updates the parsing of Prio3 JSON test vectors to match the latest files, (including parsing the public share) though the related tests aren't ready to be re-enabled without other changes. Additionally, the "input share" inside `Prio3InputShare` is renamed to "measurement share", following a change that was made at the same time in VDAF.