### PR TITLE
Cut over VDAFs and tests to PrgSha3

### DIFF
--- a/benches/cycle_counts.rs
+++ b/benches/cycle_counts.rs
@@ -11,7 +11,7 @@ use prio::{
     idpf::{self, IdpfInput, IdpfPublicShare, RingBufferCache},
     vdaf::{
         poplar1::Poplar1IdpfValue,
-        prg::{PrgAes128, Seed},
+        prg::{PrgSha3, Seed},
     },
 };
 #[cfg(feature = "prio2")]
@@ -119,7 +119,7 @@ fn prio2_prove_and_verify_1000() -> VerificationMessage<FieldPrio2> {
 }
 
 fn prio3_client_count() -> Vec<Prio3InputShare<Field64, 16>> {
-    let prio3 = Prio3::new_aes128_count(2).unwrap();
+    let prio3 = Prio3::new_count(2).unwrap();
     let measurement = 1;
     let nonce = [0; 16];
     prio3
@@ -130,7 +130,7 @@ fn prio3_client_count() -> Vec<Prio3InputShare<Field64, 16>> {
 
 fn prio3_client_histogram_11() -> Vec<Prio3InputShare<Field128, 16>> {
     let buckets: Vec<u64> = (1..10).collect();
-    let prio3 = Prio3::new_aes128_histogram(2, &buckets).unwrap();
+    let prio3 = Prio3::new_histogram(2, &buckets).unwrap();
     let measurement = 17;
     let nonce = [0; 16];
     prio3
@@ -140,7 +140,7 @@ fn prio3_client_histogram_11() -> Vec<Prio3InputShare<Field128, 16>> {
 }
 
 fn prio3_client_sum_32() -> Vec<Prio3InputShare<Field128, 16>> {
-    let prio3 = Prio3::new_aes128_sum(2, 16).unwrap();
+    let prio3 = Prio3::new_sum(2, 16).unwrap();
     let measurement = 1337;
     let nonce = [0; 16];
     prio3
@@ -151,7 +151,7 @@ fn prio3_client_sum_32() -> Vec<Prio3InputShare<Field128, 16>> {
 
 fn prio3_client_count_vec_1000() -> Vec<Prio3InputShare<Field128, 16>> {
     let len = 1000;
-    let prio3 = Prio3::new_aes128_sum_vec(2, 1, len).unwrap();
+    let prio3 = Prio3::new_sum_vec(2, 1, len).unwrap();
     let measurement = vec![0; len];
     let nonce = [0; 16];
     prio3
@@ -163,7 +163,7 @@ fn prio3_client_count_vec_1000() -> Vec<Prio3InputShare<Field128, 16>> {
 #[cfg(feature = "multithreaded")]
 fn prio3_client_count_vec_multithreaded_1000() -> Vec<Prio3InputShare<Field128, 16>> {
     let len = 1000;
-    let prio3 = Prio3::new_aes128_sum_vec_multithreaded(2, 1, len).unwrap();
+    let prio3 = Prio3::new_sum_vec_multithreaded(2, 1, len).unwrap();
     let measurement = vec![0; len];
     let nonce = [0; 16];
     prio3
@@ -178,7 +178,7 @@ fn idpf_poplar_gen(
     inner_values: Vec<Poplar1IdpfValue<Field64>>,
     leaf_value: Poplar1IdpfValue<Field255>,
 ) {
-    idpf::gen::<_, _, _, PrgAes128, 16>(input, inner_values, leaf_value).unwrap();
+    idpf::gen::<_, _, _, PrgSha3, 16>(input, inner_values, leaf_value).unwrap();
 }
 
 #[cfg(feature = "experimental")]
@@ -221,7 +221,7 @@ fn idpf_poplar_eval(
     key: &Seed<16>,
 ) {
     let mut cache = RingBufferCache::new(1);
-    idpf::eval::<_, _, PrgAes128, 16>(0, public_share, key, input, &mut cache).unwrap();
+    idpf::eval::<_, _, PrgSha3, 16>(0, public_share, key, input, &mut cache).unwrap();
 }
 
 #[cfg(feature = "experimental")]

--- a/binaries/src/bin/vdaf_message_sizes.rs
+++ b/binaries/src/bin/vdaf_message_sizes.rs
@@ -20,7 +20,7 @@ fn main() {
     let num_shares = 2;
     let nonce = [0; 16];
 
-    let prio3 = Prio3::new_aes128_count(num_shares).unwrap();
+    let prio3 = Prio3::new_count(num_shares).unwrap();
     let measurement = 1;
     println!(
         "prio3 count share size = {}",
@@ -28,7 +28,7 @@ fn main() {
     );
 
     let buckets: Vec<u64> = (1..10).collect();
-    let prio3 = Prio3::new_aes128_histogram(num_shares, &buckets).unwrap();
+    let prio3 = Prio3::new_histogram(num_shares, &buckets).unwrap();
     let measurement = 17;
     println!(
         "prio3 histogram ({} buckets) share size = {}",
@@ -37,7 +37,7 @@ fn main() {
     );
 
     let bits = 32;
-    let prio3 = Prio3::new_aes128_sum(num_shares, bits).unwrap();
+    let prio3 = Prio3::new_sum(num_shares, bits).unwrap();
     let measurement = 1337;
     println!(
         "prio3 sum ({} bits) share size = {}",
@@ -46,7 +46,7 @@ fn main() {
     );
 
     let len = 1000;
-    let prio3 = Prio3::new_aes128_sum_vec(num_shares, 1, len).unwrap();
+    let prio3 = Prio3::new_sum_vec(num_shares, 1, len).unwrap();
     let measurement = vec![0; len];
     println!(
         "prio3 countvec ({} len) share size = {}",
@@ -54,7 +54,7 @@ fn main() {
         prio3_input_share_size(&prio3.shard(&measurement, &nonce).unwrap().1)
     );
 
-    let prio3 = Prio3::new_aes128_sum_vec_multithreaded(num_shares, 1, len).unwrap();
+    let prio3 = Prio3::new_sum_vec_multithreaded(num_shares, 1, len).unwrap();
     println!(
         "prio3 countvec multithreaded ({} len) share size = {}",
         len,
@@ -62,7 +62,7 @@ fn main() {
     );
 
     let len = 1000;
-    let prio3 = Prio3::new_aes128_fixedpoint_boundedl2_vec_sum(num_shares, len).unwrap();
+    let prio3 = Prio3::new_fixedpoint_boundedl2_vec_sum(num_shares, len).unwrap();
     let fp_num = fixed!(0.0001: I1F15);
     let measurement = vec![fp_num; len];
     println!(
@@ -71,8 +71,7 @@ fn main() {
         prio3_input_share_size(&prio3.shard(&measurement, &nonce).unwrap().1)
     );
 
-    let prio3 =
-        Prio3::new_aes128_fixedpoint_boundedl2_vec_sum_multithreaded(num_shares, len).unwrap();
+    let prio3 = Prio3::new_fixedpoint_boundedl2_vec_sum_multithreaded(num_shares, len).unwrap();
     println!(
         "prio3 fixedpoint16 boundedl2 vec multithreaded ({} entries) size = {}",
         len,

--- a/src/idpf.rs
+++ b/src/idpf.rs
@@ -845,7 +845,7 @@ mod tests {
         prng::Prng,
         vdaf::{
             poplar1::Poplar1IdpfValue,
-            prg::{Prg, PrgAes128, Seed},
+            prg::{Prg, PrgSha3, Seed},
         },
     };
 
@@ -933,14 +933,14 @@ mod tests {
     #[test]
     fn test_idpf_poplar() {
         let input = bitbox![0, 1, 1, 0, 1].into();
-        let (public_share, keys) = idpf::gen::<_, _, _, PrgAes128, 16>(
+        let (public_share, keys) = idpf::gen::<_, _, _, PrgSha3, 16>(
             &input,
             Vec::from([Poplar1IdpfValue::new([Field64::one(), Field64::one()]); 4]),
             Poplar1IdpfValue::new([Field255::one(), Field255::one()]),
         )
         .unwrap();
 
-        check_idpf_poplar_evaluation::<PrgAes128, 16>(
+        check_idpf_poplar_evaluation::<PrgSha3, 16>(
             &public_share,
             &keys,
             &bitbox![0].into(),
@@ -948,7 +948,7 @@ mod tests {
             &mut NoCache::new(),
             &mut NoCache::new(),
         );
-        check_idpf_poplar_evaluation::<PrgAes128, 16>(
+        check_idpf_poplar_evaluation::<PrgSha3, 16>(
             &public_share,
             &keys,
             &bitbox![1].into(),
@@ -956,7 +956,7 @@ mod tests {
             &mut NoCache::new(),
             &mut NoCache::new(),
         );
-        check_idpf_poplar_evaluation::<PrgAes128, 16>(
+        check_idpf_poplar_evaluation::<PrgSha3, 16>(
             &public_share,
             &keys,
             &bitbox![0, 1].into(),
@@ -964,7 +964,7 @@ mod tests {
             &mut NoCache::new(),
             &mut NoCache::new(),
         );
-        check_idpf_poplar_evaluation::<PrgAes128, 16>(
+        check_idpf_poplar_evaluation::<PrgSha3, 16>(
             &public_share,
             &keys,
             &bitbox![0, 0].into(),
@@ -972,7 +972,7 @@ mod tests {
             &mut NoCache::new(),
             &mut NoCache::new(),
         );
-        check_idpf_poplar_evaluation::<PrgAes128, 16>(
+        check_idpf_poplar_evaluation::<PrgSha3, 16>(
             &public_share,
             &keys,
             &bitbox![1, 0].into(),
@@ -980,7 +980,7 @@ mod tests {
             &mut NoCache::new(),
             &mut NoCache::new(),
         );
-        check_idpf_poplar_evaluation::<PrgAes128, 16>(
+        check_idpf_poplar_evaluation::<PrgSha3, 16>(
             &public_share,
             &keys,
             &bitbox![1, 1].into(),
@@ -988,7 +988,7 @@ mod tests {
             &mut NoCache::new(),
             &mut NoCache::new(),
         );
-        check_idpf_poplar_evaluation::<PrgAes128, 16>(
+        check_idpf_poplar_evaluation::<PrgSha3, 16>(
             &public_share,
             &keys,
             &bitbox![0, 1, 1].into(),
@@ -996,7 +996,7 @@ mod tests {
             &mut NoCache::new(),
             &mut NoCache::new(),
         );
-        check_idpf_poplar_evaluation::<PrgAes128, 16>(
+        check_idpf_poplar_evaluation::<PrgSha3, 16>(
             &public_share,
             &keys,
             &bitbox![0, 1, 1, 0].into(),
@@ -1004,7 +1004,7 @@ mod tests {
             &mut NoCache::new(),
             &mut NoCache::new(),
         );
-        check_idpf_poplar_evaluation::<PrgAes128, 16>(
+        check_idpf_poplar_evaluation::<PrgSha3, 16>(
             &public_share,
             &keys,
             &bitbox![0, 1, 1, 0, 1].into(),
@@ -1012,7 +1012,7 @@ mod tests {
             &mut NoCache::new(),
             &mut NoCache::new(),
         );
-        check_idpf_poplar_evaluation::<PrgAes128, 16>(
+        check_idpf_poplar_evaluation::<PrgSha3, 16>(
             &public_share,
             &keys,
             &bitbox![0, 1, 1, 0, 0].into(),
@@ -1020,7 +1020,7 @@ mod tests {
             &mut NoCache::new(),
             &mut NoCache::new(),
         );
-        check_idpf_poplar_evaluation::<PrgAes128, 16>(
+        check_idpf_poplar_evaluation::<PrgSha3, 16>(
             &public_share,
             &keys,
             &bitbox![1, 0, 1, 0, 0].into(),
@@ -1069,13 +1069,13 @@ mod tests {
             Poplar1IdpfValue::new([Field255::one(), Prng::new().unwrap().next().unwrap()]);
 
         let (public_share, keys) =
-            idpf::gen::<_, _, _, PrgAes128, 16>(&input, inner_values.clone(), leaf_values).unwrap();
+            idpf::gen::<_, _, _, PrgSha3, 16>(&input, inner_values.clone(), leaf_values).unwrap();
         let mut cache_0 = RingBufferCache::new(3);
         let mut cache_1 = RingBufferCache::new(3);
 
         for (level, values) in inner_values.iter().enumerate() {
             let mut prefix = BitBox::from_bitslice(&bits[..=level]).into();
-            check_idpf_poplar_evaluation::<PrgAes128, 16>(
+            check_idpf_poplar_evaluation::<PrgSha3, 16>(
                 &public_share,
                 &keys,
                 &prefix,
@@ -1085,7 +1085,7 @@ mod tests {
             );
             let flipped_bit = !prefix[level];
             prefix.index.set(level, flipped_bit);
-            check_idpf_poplar_evaluation::<PrgAes128, 16>(
+            check_idpf_poplar_evaluation::<PrgSha3, 16>(
                 &public_share,
                 &keys,
                 &prefix,
@@ -1094,7 +1094,7 @@ mod tests {
                 &mut cache_1,
             );
         }
-        check_idpf_poplar_evaluation::<PrgAes128, 16>(
+        check_idpf_poplar_evaluation::<PrgSha3, 16>(
             &public_share,
             &keys,
             &input,
@@ -1104,7 +1104,7 @@ mod tests {
         );
         let mut modified_bits = bits.clone();
         modified_bits.set(INPUT_LEN - 1, !bits[INPUT_LEN - 1]);
-        check_idpf_poplar_evaluation::<PrgAes128, 16>(
+        check_idpf_poplar_evaluation::<PrgSha3, 16>(
             &public_share,
             &keys,
             &modified_bits.into(),
@@ -1131,11 +1131,11 @@ mod tests {
             Poplar1IdpfValue::new([Field255::one(), Prng::new().unwrap().next().unwrap()]);
 
         let (public_share, keys) =
-            idpf::gen::<_, _, _, PrgAes128, 16>(&input, inner_values.clone(), leaf_values).unwrap();
+            idpf::gen::<_, _, _, PrgSha3, 16>(&input, inner_values.clone(), leaf_values).unwrap();
         let mut cache_0 = SnoopingCache::new(HashMapCache::new());
         let mut cache_1 = HashMapCache::new();
 
-        check_idpf_poplar_evaluation::<PrgAes128, 16>(
+        check_idpf_poplar_evaluation::<PrgSha3, 16>(
             &public_share,
             &keys,
             &bitbox![1, 1, 0, 0].into(),
@@ -1168,7 +1168,7 @@ mod tests {
             ],
         );
 
-        check_idpf_poplar_evaluation::<PrgAes128, 16>(
+        check_idpf_poplar_evaluation::<PrgSha3, 16>(
             &public_share,
             &keys,
             &bitbox![0].into(),
@@ -1196,7 +1196,7 @@ mod tests {
             vec![bitbox![0]],
         );
 
-        check_idpf_poplar_evaluation::<PrgAes128, 16>(
+        check_idpf_poplar_evaluation::<PrgSha3, 16>(
             &public_share,
             &keys,
             &bitbox![0, 1].into(),
@@ -1224,7 +1224,7 @@ mod tests {
             vec![bitbox![0, 1]],
         );
 
-        check_idpf_poplar_evaluation::<PrgAes128, 16>(
+        check_idpf_poplar_evaluation::<PrgSha3, 16>(
             &public_share,
             &keys,
             &input,
@@ -1265,7 +1265,7 @@ mod tests {
             ],
         );
 
-        check_idpf_poplar_evaluation::<PrgAes128, 16>(
+        check_idpf_poplar_evaluation::<PrgSha3, 16>(
             &public_share,
             &keys,
             &input,
@@ -1302,12 +1302,12 @@ mod tests {
             Poplar1IdpfValue::new([Field255::one(), Prng::new().unwrap().next().unwrap()]);
 
         let (public_share, keys) =
-            idpf::gen::<_, _, _, PrgAes128, 16>(&input, inner_values.clone(), leaf_values).unwrap();
+            idpf::gen::<_, _, _, PrgSha3, 16>(&input, inner_values.clone(), leaf_values).unwrap();
         let mut cache_0 = LossyCache::new();
         let mut cache_1 = LossyCache::new();
 
         for (level, values) in inner_values.iter().enumerate() {
-            check_idpf_poplar_evaluation::<PrgAes128, 16>(
+            check_idpf_poplar_evaluation::<PrgSha3, 16>(
                 &public_share,
                 &keys,
                 &input[..=level].to_owned().into(),
@@ -1316,7 +1316,7 @@ mod tests {
                 &mut cache_1,
             );
         }
-        check_idpf_poplar_evaluation::<PrgAes128, 16>(
+        check_idpf_poplar_evaluation::<PrgSha3, 16>(
             &public_share,
             &keys,
             &input,
@@ -1329,14 +1329,14 @@ mod tests {
     #[test]
     fn test_idpf_poplar_error_cases() {
         // Zero bits does not make sense.
-        idpf::gen::<_, _, _, PrgAes128, 16>(
+        idpf::gen::<_, _, _, PrgSha3, 16>(
             &bitbox![].into(),
             Vec::<Poplar1IdpfValue<Field64>>::new(),
             Poplar1IdpfValue::new([Field255::zero(); 2]),
         )
         .unwrap_err();
 
-        let (public_share, keys) = idpf::gen::<_, _, _, PrgAes128, 16>(
+        let (public_share, keys) = idpf::gen::<_, _, _, PrgSha3, 16>(
             &bitbox![0;10].into(),
             Vec::from([Poplar1IdpfValue::new([Field64::zero(); 2]); 9]),
             Poplar1IdpfValue::new([Field255::zero(); 2]),
@@ -1344,13 +1344,13 @@ mod tests {
         .unwrap();
 
         // Wrong number of values.
-        idpf::gen::<_, _, _, PrgAes128, 16>(
+        idpf::gen::<_, _, _, PrgSha3, 16>(
             &bitbox![0; 10].into(),
             Vec::from([Poplar1IdpfValue::new([Field64::zero(); 2]); 8]),
             Poplar1IdpfValue::new([Field255::zero(); 2]),
         )
         .unwrap_err();
-        idpf::gen::<_, _, _, PrgAes128, 16>(
+        idpf::gen::<_, _, _, PrgSha3, 16>(
             &bitbox![0; 10].into(),
             Vec::from([Poplar1IdpfValue::new([Field64::zero(); 2]); 10]),
             Poplar1IdpfValue::new([Field255::zero(); 2]),
@@ -1358,7 +1358,7 @@ mod tests {
         .unwrap_err();
 
         // Evaluating with empty prefix.
-        assert!(idpf::eval::<_, _, PrgAes128, 16>(
+        assert!(idpf::eval::<_, _, PrgSha3, 16>(
             0,
             &public_share,
             &keys[0],
@@ -1367,7 +1367,7 @@ mod tests {
         )
         .is_err());
         // Evaluating with too-long prefix.
-        assert!(idpf::eval::<_, _, PrgAes128, 16>(
+        assert!(idpf::eval::<_, _, PrgSha3, 16>(
             0,
             &public_share,
             &keys[0],
@@ -1713,7 +1713,7 @@ mod tests {
     #[test]
     fn idpf_poplar_public_share_deserialize() {
         // This encoded public share, and the expected struct below, are taken from the
-        // 1Aes128 test vector.
+        // Poplar1 test vector.
         let data = hex::decode(concat!(
             "9a",
             "0000000000000000000000000000000000000000000000",
@@ -1784,7 +1784,7 @@ mod tests {
     #[test]
     fn idpf_poplar_generate_test_vector() {
         let test_vector = load_idpfpoplar_test_vector();
-        let (public_share, keys) = idpf::gen_with_rand_source::<_, _, _, PrgAes128, 16>(
+        let (public_share, keys) = idpf::gen_with_rand_source::<_, _, _, PrgSha3, 16>(
             &test_vector.alpha,
             test_vector.beta_inner,
             test_vector.beta_leaf,

--- a/src/vdaf/prio2.rs
+++ b/src/vdaf/prio2.rs
@@ -23,8 +23,8 @@ use std::{
 };
 
 /// The Prio2 VDAF. It supports the same measurement type as
-/// [`Prio3Aes128SumVec`](crate::vdaf::prio3::Prio3Aes128SumVec) with `bits == 1` but uses the
-/// proof system and finite field deployed in ENPA.
+/// [`Prio3SumVec`](crate::vdaf::prio3::Prio3SumVec) with `bits == 1` but uses the proof system and
+/// finite field deployed in ENPA.
 #[derive(Clone, Debug)]
 pub struct Prio2 {
     input_len: usize,

--- a/src/vdaf/prio3_test.rs
+++ b/src/vdaf/prio3_test.rs
@@ -137,7 +137,7 @@ fn check_prep_test_vec<M, T, P, const L: usize>(
 fn test_vec_prio3_count() {
     let t: TPrio3<u64> =
         serde_json::from_str(include_str!("test_vec/03/Prio3Aes128Count_0.json")).unwrap();
-    let prio3 = Prio3::new_aes128_count(2).unwrap();
+    let prio3 = Prio3::new_count(2).unwrap();
     let verify_key = t.verify_key.as_ref().try_into().unwrap();
 
     for (test_num, p) in t.prep.iter().enumerate() {
@@ -150,7 +150,7 @@ fn test_vec_prio3_count() {
 fn test_vec_prio3_sum() {
     let t: TPrio3<u128> =
         serde_json::from_str(include_str!("test_vec/03/Prio3Aes128Sum_0.json")).unwrap();
-    let prio3 = Prio3::new_aes128_sum(2, 8).unwrap();
+    let prio3 = Prio3::new_sum(2, 8).unwrap();
     let verify_key = t.verify_key.as_ref().try_into().unwrap();
 
     for (test_num, p) in t.prep.iter().enumerate() {
@@ -163,7 +163,7 @@ fn test_vec_prio3_sum() {
 fn test_vec_prio3_histogram() {
     let t: TPrio3<u128> =
         serde_json::from_str(include_str!("test_vec/03/Prio3Aes128Histogram_0.json")).unwrap();
-    let prio3 = Prio3::new_aes128_histogram(2, &[1, 10, 100]).unwrap();
+    let prio3 = Prio3::new_histogram(2, &[1, 10, 100]).unwrap();
     let verify_key = t.verify_key.as_ref().try_into().unwrap();
 
     for (test_num, p) in t.prep.iter().enumerate() {


### PR DESCRIPTION
This cuts over the main public APIs to use the new PRG, and does the same the benchmarks and most (non-PRG specific) tests.