### PR TITLE
Add length hints to encoding traits

### DIFF
--- a/benches/cycle_counts.rs
+++ b/benches/cycle_counts.rs
@@ -6,7 +6,7 @@ use iai::black_box;
 use prio::field::FieldElement;
 #[cfg(feature = "experimental")]
 use prio::{
-    codec::{Decode, ParameterizedDecode},
+    codec::{Decode, Encode, ParameterizedDecode},
     field::Field255,
     idpf::{self, IdpfInput, IdpfPublicShare, RingBufferCache},
     vdaf::{
@@ -248,6 +248,24 @@ fn idpf_poplar_eval_2048() {
     idpf_poplar_eval(&input, &public_share, &key);
 }
 
+#[cfg(feature = "experimental")]
+fn idpf_codec() {
+    let data = hex::decode(concat!(
+        "9a",
+        "0000000000000000000000000000000000000000000000",
+        "01eb3a1bd6b5fa4a4500000000000000000000000000000000",
+        "ffffffff0000000022522c3fd5a33cac00000000000000000000000000000000",
+        "ffffffff0000000069f41eee46542b6900000000000000000000000000000000",
+        "00000000000000000000000000000000000000000000000000000000000000",
+        "017d1fd6df94280145a0dcc933ceb706e9219d50e7c4f92fd8ca9a0ffb7d819646",
+    ))
+    .unwrap();
+    let bits = 4;
+    let public_share = IdpfPublicShare::<Poplar1IdpfValue<Field64>,Poplar1IdpfValue<Field255>,16>::get_decoded_with_param(&bits, &data).unwrap();
+    let encoded = public_share.get_encoded();
+    let _ = black_box(encoded.len());
+}
+
 macro_rules! main_base {
     ( $( $func_name:ident ),* $(,)* ) => {
         iai::main!(
@@ -311,6 +329,7 @@ macro_rules! main_add_multithreaded {
 macro_rules! main_add_experimental {
     ( $( $func_name:ident ),* $(,)* ) => {
         main_add_multithreaded!(
+            idpf_codec,
             idpf_poplar_gen_8,
             idpf_poplar_gen_128,
             idpf_poplar_gen_2048,

--- a/src/codec.rs
+++ b/src/codec.rs
@@ -103,6 +103,11 @@ pub trait Encode {
     fn get_encoded(&self) -> Vec<u8> {
         self.get_encoded_with_param(&())
     }
+
+    /// Returns a hint indicating how many bytes will be required to encode this value.
+    fn encoded_len(&self) -> Option<usize> {
+        None
+    }
 }
 
 /// Describes how to encode objects into a byte sequence.
@@ -114,9 +119,18 @@ pub trait ParameterizedEncode<P> {
 
     /// Convenience method to encode a value into a new `Vec<u8>`.
     fn get_encoded_with_param(&self, encoding_parameter: &P) -> Vec<u8> {
-        let mut ret = Vec::new();
+        let mut ret = if let Some(length) = self.encoded_len_with_param(encoding_parameter) {
+            Vec::with_capacity(length)
+        } else {
+            Vec::new()
+        };
         self.encode_with_param(encoding_parameter, &mut ret);
         ret
+    }
+
+    /// Returns a hint indicating how many bytes will be required to encode this value.
+    fn encoded_len_with_param(&self, _encoding_parameter: &P) -> Option<usize> {
+        None
     }
 }
 
@@ -125,6 +139,10 @@ pub trait ParameterizedEncode<P> {
 impl<E: Encode + ?Sized, T> ParameterizedEncode<T> for E {
     fn encode_with_param(&self, _encoding_parameter: &T, bytes: &mut Vec<u8>) {
         self.encode(bytes)
+    }
+
+    fn encoded_len_with_param(&self, _encoding_parameter: &T) -> Option<usize> {
+        <Self as Encode>::encoded_len(self)
     }
 }
 
@@ -136,6 +154,10 @@ impl Decode for () {
 
 impl Encode for () {
     fn encode(&self, _bytes: &mut Vec<u8>) {}
+
+    fn encoded_len(&self) -> Option<usize> {
+        Some(0)
+    }
 }
 
 impl Decode for u8 {
@@ -150,6 +172,10 @@ impl Encode for u8 {
     fn encode(&self, bytes: &mut Vec<u8>) {
         bytes.push(*self);
     }
+
+    fn encoded_len(&self) -> Option<usize> {
+        Some(1)
+    }
 }
 
 impl Decode for u16 {
@@ -161,6 +187,10 @@ impl Decode for u16 {
 impl Encode for u16 {
     fn encode(&self, bytes: &mut Vec<u8>) {
         bytes.extend_from_slice(&u16::to_be_bytes(*self));
+    }
+
+    fn encoded_len(&self) -> Option<usize> {
+        Some(2)
     }
 }
 
@@ -180,6 +210,10 @@ impl Encode for U24 {
         // Encode lower three bytes of the u32 as u24
         bytes.extend_from_slice(&u32::to_be_bytes(self.0)[1..]);
     }
+
+    fn encoded_len(&self) -> Option<usize> {
+        Some(3)
+    }
 }
 
 impl Decode for u32 {
@@ -192,6 +226,10 @@ impl Encode for u32 {
     fn encode(&self, bytes: &mut Vec<u8>) {
         bytes.extend_from_slice(&u32::to_be_bytes(*self));
     }
+
+    fn encoded_len(&self) -> Option<usize> {
+        Some(4)
+    }
 }
 
 impl Decode for u64 {
@@ -203,6 +241,10 @@ impl Decode for u64 {
 impl Encode for u64 {
     fn encode(&self, bytes: &mut Vec<u8>) {
         bytes.extend_from_slice(&u64::to_be_bytes(*self));
+    }
+
+    fn encoded_len(&self) -> Option<usize> {
+        Some(8)
     }
 }
 
@@ -484,6 +526,16 @@ mod tests {
             self.field_u32.encode(bytes);
             self.field_u64.encode(bytes);
         }
+
+        fn encoded_len(&self) -> Option<usize> {
+            Some(
+                self.field_u8.encoded_len()?
+                    + self.field_u16.encoded_len()?
+                    + self.field_u24.encoded_len()?
+                    + self.field_u32.encoded_len()?
+                    + self.field_u64.encoded_len()?,
+            )
+        }
     }
 
     impl Decode for TestMessage {
@@ -532,6 +584,7 @@ mod tests {
         let mut bytes = vec![];
         value.encode(&mut bytes);
         assert_eq!(bytes.len(), TestMessage::encoded_length());
+        assert_eq!(value.encoded_len().unwrap(), TestMessage::encoded_length());
 
         let decoded = TestMessage::decode(&mut Cursor::new(&bytes)).unwrap();
         assert_eq!(value, decoded);
@@ -665,5 +718,15 @@ mod tests {
             decode_items::<(), u8>(2, &(), &mut cursor).unwrap_err(),
             CodecError::LengthPrefixTooBig(2)
         );
+    }
+
+    #[test]
+    fn length_hint_correctness() {
+        assert_eq!(().encoded_len().unwrap(), ().get_encoded().len());
+        assert_eq!(0u8.encoded_len().unwrap(), 0u8.get_encoded().len());
+        assert_eq!(0u16.encoded_len().unwrap(), 0u16.get_encoded().len());
+        assert_eq!(U24(0).encoded_len().unwrap(), U24(0).get_encoded().len());
+        assert_eq!(0u32.encoded_len().unwrap(), 0u32.get_encoded().len());
+        assert_eq!(0u64.encoded_len().unwrap(), 0u64.get_encoded().len());
     }
 }

--- a/src/field.rs
+++ b/src/field.rs
@@ -623,6 +623,10 @@ macro_rules! make_field {
                 let slice = <[u8; $elem::ENCODED_SIZE]>::from(*self);
                 bytes.extend_from_slice(&slice);
             }
+
+            fn encoded_len(&self) -> Option<usize> {
+                Some(Self::ENCODED_SIZE)
+            }
         }
 
         impl Decode for $elem {
@@ -968,6 +972,7 @@ pub(crate) mod test_utils {
             want.encode(&mut bytes);
 
             assert_eq!(bytes.len(), F::ENCODED_SIZE);
+            assert_eq!(want.encoded_len().unwrap(), F::ENCODED_SIZE);
 
             let got = F::get_decoded(&bytes).unwrap();
             assert_eq!(got, *want);

--- a/src/field/field255.rs
+++ b/src/field/field255.rs
@@ -265,6 +265,10 @@ impl Encode for Field255 {
     fn encode(&self, bytes: &mut Vec<u8>) {
         bytes.extend_from_slice(&<[u8; Self::ENCODED_SIZE]>::from(*self));
     }
+
+    fn encoded_len(&self) -> Option<usize> {
+        Some(Self::ENCODED_SIZE)
+    }
 }
 
 impl Decode for Field255 {

--- a/src/idpf.rs
+++ b/src/idpf.rs
@@ -578,6 +578,17 @@ where
         Seed(self.leaf_correction_word.seed).encode(bytes);
         self.leaf_correction_word.value.encode(bytes);
     }
+
+    fn encoded_len(&self) -> Option<usize> {
+        let control_bits_count = (self.inner_correction_words.len() + 1) * 2;
+        let mut len =
+            (control_bits_count + 7) / 8 + SEED_SIZE * (self.inner_correction_words.len() + 1);
+        for correction_words in self.inner_correction_words.iter() {
+            len += correction_words.value.encoded_len()?;
+        }
+        len += self.leaf_correction_word.value.encoded_len()?;
+        Some(len)
+    }
 }
 
 impl<VI, VL, const SEED_SIZE: usize> ParameterizedDecode<usize>
@@ -1450,6 +1461,7 @@ mod tests {
         let decoded = IdpfPublicShare::get_decoded_with_param(&3, &message).unwrap();
         assert_eq!(public_share, decoded);
         assert_eq!(message, encoded);
+        assert_eq!(public_share.encoded_len().unwrap(), encoded.len());
 
         // check serialization of packed control bits when they span multiple bytes:
         let public_share = IdpfPublicShare {

--- a/src/vdaf.rs
+++ b/src/vdaf.rs
@@ -119,6 +119,19 @@ impl<F: FieldElement, const SEED_SIZE: usize> Encode for Share<F, SEED_SIZE> {
             }
         }
     }
+
+    fn encoded_len(&self) -> Option<usize> {
+        match self {
+            Share::Leader(share_data) => {
+                let mut len = 0;
+                for x in share_data {
+                    len += x.encoded_len()?;
+                }
+                Some(len)
+            }
+            Share::Helper(share_seed) => share_seed.encoded_len(),
+        }
+    }
 }
 
 /// The base trait for VDAF schemes. This trait is inherited by traits [`Client`], [`Aggregator`],
@@ -298,6 +311,10 @@ impl<F: FieldElement> Encode for OutputShare<F> {
     fn encode(&self, bytes: &mut Vec<u8>) {
         encode_fieldvec(&self.0, bytes)
     }
+
+    fn encoded_len(&self) -> Option<usize> {
+        Some(F::ENCODED_SIZE * self.0.len())
+    }
 }
 
 /// An aggregate share comprised of a vector of field elements.
@@ -342,6 +359,10 @@ impl<F: FieldElement> AggregateShare<F> {
 impl<F: FieldElement> Encode for AggregateShare<F> {
     fn encode(&self, bytes: &mut Vec<u8>) {
         encode_fieldvec(&self.0, bytes)
+    }
+
+    fn encoded_len(&self) -> Option<usize> {
+        Some(F::ENCODED_SIZE * self.0.len())
     }
 }
 

--- a/src/vdaf/poplar1.rs
+++ b/src/vdaf/poplar1.rs
@@ -926,6 +926,10 @@ where
         self.0[0].encode(bytes);
         self.0[1].encode(bytes);
     }
+
+    fn encoded_len(&self) -> Option<usize> {
+        Some(self.0[0].encoded_len()? + self.0[1].encoded_len()?)
+    }
 }
 
 impl<F> Decode for Poplar1IdpfValue<F>

--- a/src/vdaf/prg.rs
+++ b/src/vdaf/prg.rs
@@ -69,6 +69,10 @@ impl<const SEED_SIZE: usize> Encode for Seed<SEED_SIZE> {
     fn encode(&self, bytes: &mut Vec<u8>) {
         bytes.extend_from_slice(&self.0[..]);
     }
+
+    fn encoded_len(&self) -> Option<usize> {
+        Some(SEED_SIZE)
+    }
 }
 
 impl<const SEED_SIZE: usize> Decode for Seed<SEED_SIZE> {

--- a/src/vdaf/prio2.rs
+++ b/src/vdaf/prio2.rs
@@ -148,6 +148,10 @@ impl Encode for Prio2PrepareState {
     fn encode(&self, bytes: &mut Vec<u8>) {
         self.0.encode(bytes);
     }
+
+    fn encoded_len(&self) -> Option<usize> {
+        self.0.encoded_len()
+    }
 }
 
 impl<'a> ParameterizedDecode<(&'a Prio2, usize)> for Prio2PrepareState {
@@ -174,6 +178,10 @@ impl Encode for Prio2PrepareShare {
         self.0.f_r.encode(bytes);
         self.0.g_r.encode(bytes);
         self.0.h_r.encode(bytes);
+    }
+
+    fn encoded_len(&self) -> Option<usize> {
+        Some(self.0.f_r.encoded_len()? + self.0.g_r.encoded_len()? + self.0.h_r.encoded_len()?)
     }
 }
 

--- a/src/vdaf/prio3.rs
+++ b/src/vdaf/prio3.rs
@@ -596,6 +596,16 @@ impl<const SEED_SIZE: usize> Encode for Prio3PublicShare<SEED_SIZE> {
             }
         }
     }
+
+    fn encoded_len(&self) -> Option<usize> {
+        let mut len = 0;
+        if let Some(joint_rand_parts) = self.joint_rand_parts.as_ref() {
+            for part in joint_rand_parts.iter() {
+                len += part.encoded_len()?;
+            }
+        }
+        Some(len)
+    }
 }
 
 impl<T, P, const SEED_SIZE: usize> ParameterizedDecode<Prio3<T, P, SEED_SIZE>>
@@ -651,6 +661,14 @@ impl<F: FftFriendlyFieldElement, const SEED_SIZE: usize> Encode for Prio3InputSh
         if let Some(ref blind) = self.joint_rand_blind {
             blind.encode(bytes);
         }
+    }
+
+    fn encoded_len(&self) -> Option<usize> {
+        let mut len = self.measurement_share.encoded_len()? + self.proof_share.encoded_len()?;
+        if let Some(ref blind) = self.joint_rand_blind {
+            len += blind.encoded_len()?;
+        }
+        Some(len)
     }
 }
 
@@ -718,6 +736,17 @@ impl<F: FftFriendlyFieldElement, const SEED_SIZE: usize> Encode
             seed.encode(bytes);
         }
     }
+
+    fn encoded_len(&self) -> Option<usize> {
+        let mut len = 0;
+        for x in &self.verifier {
+            len += x.encoded_len()?;
+        }
+        if let Some(ref seed) = self.joint_rand_part {
+            len += seed.encoded_len()?;
+        }
+        Some(len)
+    }
 }
 
 impl<F: FftFriendlyFieldElement, const SEED_SIZE: usize>
@@ -756,6 +785,14 @@ impl<const SEED_SIZE: usize> Encode for Prio3PrepareMessage<SEED_SIZE> {
     fn encode(&self, bytes: &mut Vec<u8>) {
         if let Some(ref seed) = self.joint_rand_seed {
             seed.encode(bytes);
+        }
+    }
+
+    fn encoded_len(&self) -> Option<usize> {
+        if let Some(ref seed) = self.joint_rand_seed {
+            seed.encoded_len()
+        } else {
+            Some(0)
         }
     }
 }
@@ -810,6 +847,14 @@ impl<F: FftFriendlyFieldElement, const SEED_SIZE: usize> Encode
         if let Some(ref seed) = self.joint_rand_seed {
             seed.encode(bytes);
         }
+    }
+
+    fn encoded_len(&self) -> Option<usize> {
+        let mut len = self.measurement_share.encoded_len()?;
+        if let Some(ref seed) = self.joint_rand_seed {
+            len += seed.encoded_len()?;
+        }
+        Some(len)
     }
 }
 
@@ -1210,7 +1255,7 @@ mod tests {
         let (public_share, input_shares) = prio3.shard(&1, &nonce).unwrap();
         run_vdaf_prepare(&prio3, &verify_key, &(), &nonce, public_share, input_shares).unwrap();
 
-        test_prepare_state_serialization(&prio3, &1, &nonce).unwrap();
+        test_serialization(&prio3, &1, &nonce).unwrap();
 
         let prio3_extra_helper = Prio3::new_count(3).unwrap();
         assert_eq!(
@@ -1251,7 +1296,7 @@ mod tests {
         let result = run_vdaf_prepare(&prio3, &verify_key, &(), &nonce, public_share, input_shares);
         assert_matches!(result, Err(VdafError::Uncategorized(_)));
 
-        test_prepare_state_serialization(&prio3, &1, &nonce).unwrap();
+        test_serialization(&prio3, &1, &nonce).unwrap();
     }
 
     #[test]
@@ -1482,8 +1527,7 @@ mod tests {
                 run_vdaf_prepare(&prio3, &verify_key, &(), &nonce, public_share, input_shares);
             assert_matches!(result, Err(VdafError::Uncategorized(_)));
 
-            test_prepare_state_serialization(&prio3, &vec![fp_4_inv, fp_8_inv, fp_16_inv], &nonce)
-                .unwrap();
+            test_serialization(&prio3, &vec![fp_4_inv, fp_8_inv, fp_16_inv], &nonce).unwrap();
         }
     }
 
@@ -1501,7 +1545,7 @@ mod tests {
         assert_eq!(run_vdaf(&prio3, &(), [15]).unwrap(), vec![0, 0, 1, 0]);
         assert_eq!(run_vdaf(&prio3, &(), [20]).unwrap(), vec![0, 0, 1, 0]);
         assert_eq!(run_vdaf(&prio3, &(), [25]).unwrap(), vec![0, 0, 0, 1]);
-        test_prepare_state_serialization(&prio3, &23, &[0; 16]).unwrap();
+        test_serialization(&prio3, &23, &[0; 16]).unwrap();
     }
 
     #[test]
@@ -1544,7 +1588,7 @@ mod tests {
         }
     }
 
-    fn test_prepare_state_serialization<T, P, const SEED_SIZE: usize>(
+    fn test_serialization<T, P, const SEED_SIZE: usize>(
         prio3: &Prio3<T, P, SEED_SIZE>,
         measurement: &T::Measurement,
         nonce: &[u8; 16],
@@ -1556,14 +1600,73 @@ mod tests {
         let mut verify_key = [0; SEED_SIZE];
         thread_rng().fill(&mut verify_key[..]);
         let (public_share, input_shares) = prio3.shard(measurement, nonce)?;
+
+        let encoded_public_share = public_share.get_encoded();
+        let decoded_public_share =
+            Prio3PublicShare::get_decoded_with_param(prio3, &encoded_public_share)
+                .expect("failed to decode public share");
+        assert_eq!(decoded_public_share, public_share);
+        assert_eq!(
+            public_share.encoded_len().unwrap(),
+            encoded_public_share.len()
+        );
+
         for (agg_id, input_share) in input_shares.iter().enumerate() {
-            let (want, _msg) =
-                prio3.prepare_init(&verify_key, agg_id, &(), nonce, &public_share, input_share)?;
-            let got =
-                Prio3PrepareState::get_decoded_with_param(&(prio3, agg_id), &want.get_encoded())
-                    .expect("failed to decode prepare step");
-            assert_eq!(got, want);
+            let encoded_input_share = input_share.get_encoded();
+            let decoded_input_share =
+                Prio3InputShare::get_decoded_with_param(&(prio3, agg_id), &encoded_input_share)
+                    .expect("failed to decode input share");
+            assert_eq!(&decoded_input_share, input_share);
+            assert_eq!(
+                input_share.encoded_len().unwrap(),
+                encoded_input_share.len()
+            );
         }
+
+        let mut prepare_shares = Vec::new();
+        let mut last_prepare_state = None;
+        for (agg_id, input_share) in input_shares.iter().enumerate() {
+            let (prepare_state, prepare_share) =
+                prio3.prepare_init(&verify_key, agg_id, &(), nonce, &public_share, input_share)?;
+
+            let encoded_prepare_state = prepare_state.get_encoded();
+            let decoded_prepare_state =
+                Prio3PrepareState::get_decoded_with_param(&(prio3, agg_id), &encoded_prepare_state)
+                    .expect("failed to decode prepare state");
+            assert_eq!(decoded_prepare_state, prepare_state);
+            assert_eq!(
+                prepare_state.encoded_len().unwrap(),
+                encoded_prepare_state.len()
+            );
+
+            let encoded_prepare_share = prepare_share.get_encoded();
+            let decoded_prepare_share =
+                Prio3PrepareShare::get_decoded_with_param(&prepare_state, &encoded_prepare_share)
+                    .expect("failed to decode prepare share");
+            assert_eq!(decoded_prepare_share, prepare_share);
+            assert_eq!(
+                prepare_share.encoded_len().unwrap(),
+                encoded_prepare_share.len()
+            );
+
+            prepare_shares.push(prepare_share);
+            last_prepare_state = Some(prepare_state);
+        }
+
+        let prepare_message = prio3.prepare_preprocess(prepare_shares).unwrap();
+
+        let encoded_prepare_message = prepare_message.get_encoded();
+        let decoded_prepare_message = Prio3PrepareMessage::get_decoded_with_param(
+            &last_prepare_state.unwrap(),
+            &encoded_prepare_message,
+        )
+        .expect("failed to decode prepare message");
+        assert_eq!(decoded_prepare_message, prepare_message);
+        assert_eq!(
+            prepare_message.encoded_len().unwrap(),
+            encoded_prepare_message.len()
+        );
+
         Ok(())
     }
 


### PR DESCRIPTION
This adds new methods to the encoding traits that provide a size hint to speed up encoding, by right-sizing buffers. `encoded_len()` and `encoded_len_with_param()` are new provided methods that return `Option<usize>`, and their default implementations return `None`, so that the hints can be rolled out gracefully. All first-party types override this to provide accurate lengths. The `get_encoded_with_param()` method is changed to get a size hint first, and use `Vec::with_capacity()` if a size is available. This avoids subsequent reallocations and copies for larger messages. I added a benchmark for round-tripping a very small Poplar public share, and this shows a 3% improvement (albeit on a small number of total cycles). I expect that this should pay off more with bigger Poplar1 instances, and third-party DAP message types that reuse these traits.