### PR TITLE
Backport #497 and bump crate version to 0.11.1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -841,7 +841,7 @@ checksum = "eb9f9e6e233e5c4a35559a617bf40a4ec447db2e84c20b55a6f83167b7e57872"
 
 [[package]]
 name = "prio"
-version = "0.11.0"
+version = "0.11.1"
 dependencies = [
  "aes",
  "aes-gcm",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "prio"
-version = "0.11.0"
+version = "0.11.1"
 authors = ["Josh Aas <jaas@kflag.net>", "Tim Geoghegan <timg@letsencrypt.org>", "Christopher Patton <cpatton@cloudflare.com", "Karl Tarbe <tarbe@apple.com>"]
 edition = "2021"
 description = "Implementation of the Prio aggregation system core: https://crypto.stanford.edu/prio/"

--- a/src/vdaf.rs
+++ b/src/vdaf.rs
@@ -252,7 +252,7 @@ pub trait Collector: Vdaf {
 }
 
 /// A state transition of an Aggregator during the Prepare process.
-#[derive(Debug)]
+#[derive(Clone, Debug)]
 pub enum PrepareTransition<
     V: Aggregator<VERIFY_KEY_SIZE, NONCE_SIZE>,
     const VERIFY_KEY_SIZE: usize,


### PR DESCRIPTION
I'd like to release a `prio` with #497, because I'll need it soon for https://github.com/divviup/janus/issues/994.