### PR TITLE
Explicltly pass random bytes to Prio3 and IDPF

### DIFF
--- a/src/idpf.rs
+++ b/src/idpf.rs
@@ -328,7 +328,7 @@ where
     }
     let initial_keys: [Seed<SEED_SIZE>; 2] = [
         Seed::from_bytes(random[..SEED_SIZE].try_into().unwrap()),
-        Seed::from_bytes(random[SEED_SIZE..SEED_SIZE * 2].try_into().unwrap()),
+        Seed::from_bytes(random[SEED_SIZE..].try_into().unwrap()),
     ];
 
     let mut keys = [initial_keys[0].0, initial_keys[1].0];

--- a/src/vdaf/prg.rs
+++ b/src/vdaf/prg.rs
@@ -26,11 +26,6 @@ use std::{
     io::{Cursor, Read},
 };
 
-/// Function pointer to fill a buffer with random bytes. Under normal operation,
-/// `getrandom::getrandom()` will be used, but other implementations can be used to control
-/// randomness when generating or verifying test vectors.
-pub(crate) type RandSource = fn(&mut [u8]) -> Result<(), getrandom::Error>;
-
 /// Input of [`Prg`].
 #[derive(Clone, Debug, Eq)]
 pub struct Seed<const SEED_SIZE: usize>(pub(crate) [u8; SEED_SIZE]);
@@ -38,13 +33,13 @@ pub struct Seed<const SEED_SIZE: usize>(pub(crate) [u8; SEED_SIZE]);
 impl<const SEED_SIZE: usize> Seed<SEED_SIZE> {
     /// Generate a uniform random seed.
     pub fn generate() -> Result<Self, getrandom::Error> {
-        Self::from_rand_source(getrandom::getrandom)
+        let mut seed = [0; SEED_SIZE];
+        getrandom::getrandom(&mut seed)?;
+        Ok(Self::from_bytes(seed))
     }
 
-    pub(crate) fn from_rand_source(rand_source: RandSource) -> Result<Self, getrandom::Error> {
-        let mut seed = [0; SEED_SIZE];
-        rand_source(&mut seed)?;
-        Ok(Self(seed))
+    pub(crate) fn from_bytes(seed: [u8; SEED_SIZE]) -> Self {
+        Self(seed)
     }
 }
 

--- a/src/vdaf/prio3.rs
+++ b/src/vdaf/prio3.rs
@@ -379,11 +379,16 @@ where
         if self.typ.joint_rand_len() == 0 {
             // Two seeds per helper for measurement and proof shares, plus one seed for proving
             // randomness.
-            (usize::from(self.num_aggregators) * 2 - 1) * SEED_SIZE
+            (usize::from(self.num_aggregators - 1) * 2 + 1) * SEED_SIZE
         } else {
-            // Two seeds per helper for measurement and proof shares, plus one seed for proving
-            // randomness, plus one seed per aggregator for joint randomness blinds.
-            (usize::from(self.num_aggregators) * 3 - 1) * SEED_SIZE
+            (
+                // Two seeds per helper for measurement and proof shares
+                usize::from(self.num_aggregators - 1) * 2
+                // One seed for proving randomness
+                + 1
+                // One seed per aggregator for joint randomness blinds
+                + usize::from(self.num_aggregators)
+            ) * SEED_SIZE
         }
     }
 

--- a/src/vdaf/prio3.rs
+++ b/src/vdaf/prio3.rs
@@ -423,6 +423,10 @@ where
         };
         let mut leader_measurement_share = encoded_measurement.clone();
         for agg_id in 1..num_aggregators {
+            // The Option from the ChunksExact iterator is okay to unwrap because we checked that
+            // the randomness slice is long enough for this VDAF. The slice-to-array conversion
+            // Result is okay to unwrap because the ChunksExact iterator always returns slices of
+            // the correct length.
             let measurement_share_seed = random_seeds.next().unwrap().try_into().unwrap();
             let proof_share_seed = random_seeds.next().unwrap().try_into().unwrap();
             let measurement_share_prng: Prng<T::Field, _> = Prng::from_seed_stream(P::seed_stream(


### PR DESCRIPTION
This adopts an internal API change in VDAF-05, explicitly passing random bytes to sharding and key generation functions. The `RandSource` type alias is removed. The Prio3 sharding method and the IDPF key generation function were updated; the Poplar1 sharding method doesn't support test vectors yet, so I left it for now. I had to rearrange Prio3 sharding to skip joint randomness computations when they aren't needed, since the new API doesn't let us get extra random bytes, so this closes #466 as well.