### PR TITLE
Finish Poplar1 codec implementations

### DIFF
--- a/src/idpf.rs
+++ b/src/idpf.rs
@@ -39,7 +39,7 @@ pub enum IdpfError {
 }
 
 /// An index used as the input to an IDPF evaluation.
-#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+#[derive(Debug, Clone, PartialEq, Eq, Hash, PartialOrd, Ord)]
 pub struct IdpfInput {
     /// The index as a boxed bit slice.
     index: BitBox,

--- a/src/idpf.rs
+++ b/src/idpf.rs
@@ -10,7 +10,14 @@ use crate::{
         VdafError, VERSION,
     },
 };
-use bitvec::{bitvec, boxed::BitBox, prelude::Lsb0, slice::BitSlice, vec::BitVec, view::BitView};
+use bitvec::{
+    bitvec,
+    boxed::BitBox,
+    prelude::{Lsb0, Msb0},
+    slice::BitSlice,
+    vec::BitVec,
+    view::BitView,
+};
 use std::{
     collections::{HashMap, VecDeque},
     fmt::Debug,
@@ -40,9 +47,9 @@ pub struct IdpfInput {
 
 impl IdpfInput {
     /// Convert a slice of bytes into an IDPF input, where the bits of each byte are processed in
-    /// LSB-to-MSB order. (Subsequent bytes are processed in their natural order.)
+    /// MSB-to-LSB order. (Subsequent bytes are processed in their natural order.)
     pub fn from_bytes(bytes: &[u8]) -> IdpfInput {
-        let bit_slice_u8_storage = bytes.view_bits::<Lsb0>();
+        let bit_slice_u8_storage = bytes.view_bits::<Msb0>();
         let mut bit_vec_usize_storage = bitvec![0; bit_slice_u8_storage.len()];
         bit_vec_usize_storage.clone_from_bitslice(bit_slice_u8_storage);
         IdpfInput {
@@ -84,9 +91,9 @@ impl IdpfInput {
     }
 
     /// Convert the IDPF into a byte slice. If the length of the underlying bit vector is not a
-    /// multiple of `8`, then the last byte is `0`-padded.
+    /// multiple of `8`, then the least significant bits of the last byte are `0`-padded.
     pub fn to_bytes(&self) -> Vec<u8> {
-        let mut vec = BitVec::<u8, Lsb0>::with_capacity(self.index.len());
+        let mut vec = BitVec::<u8, Msb0>::with_capacity(self.index.len());
         vec.extend_from_bitslice(&self.index);
         vec.set_uninitialized(false);
         vec.into_vec()
@@ -881,12 +888,12 @@ mod tests {
     #[test]
     fn idpf_input_conversion() {
         let input_1 = IdpfInput::from_bools(&[
-            true, false, false, false, false, false, true, false, false, true, false, false, false,
+            false, true, false, false, false, false, false, true, false, true, false, false, false,
             false, true, false,
         ]);
         let input_2 = IdpfInput::from_bytes(b"AB");
         assert_eq!(input_1, input_2);
-        let bits = bitbox![1, 0, 0, 0, 0, 0, 1, 0, 0, 1, 0, 0, 0, 0, 1, 0];
+        let bits = bitbox![0, 1, 0, 0, 0, 0, 0, 1, 0, 1, 0, 0, 0, 0, 1, 0];
         assert_eq!(input_1[..], bits);
     }
 
@@ -1874,8 +1881,8 @@ mod tests {
     #[test]
     fn idpf_input_from_bools_to_bytes() {
         let input = IdpfInput::from_bools(&[true; 7]);
-        assert_eq!(input.to_bytes(), &[127]);
+        assert_eq!(input.to_bytes(), &[254]);
         let input = IdpfInput::from_bools(&[true; 9]);
-        assert_eq!(input.to_bytes(), &[255, 1]);
+        assert_eq!(input.to_bytes(), &[255, 128]);
     }
 }

--- a/src/idpf.rs
+++ b/src/idpf.rs
@@ -79,7 +79,7 @@ impl IdpfInput {
     }
 
     /// Get an iterator over the bits that make up this input.
-    pub fn iter(&self) -> impl Iterator<Item = bool> + '_ {
+    pub fn iter(&self) -> impl DoubleEndedIterator<Item = bool> + '_ {
         self.index.iter().by_vals()
     }
 

--- a/src/vdaf/poplar1.rs
+++ b/src/vdaf/poplar1.rs
@@ -98,10 +98,10 @@ impl<P, const SEED_SIZE: usize> ParameterizedDecode<Poplar1<P, SEED_SIZE>>
     for Poplar1PublicShare<SEED_SIZE>
 {
     fn decode_with_param(
-        _poplar1: &Poplar1<P, SEED_SIZE>,
-        _bytes: &mut Cursor<&[u8]>,
+        poplar1: &Poplar1<P, SEED_SIZE>,
+        bytes: &mut Cursor<&[u8]>,
     ) -> Result<Self, CodecError> {
-        todo!()
+        Self::decode_with_param(&poplar1.bits, bytes)
     }
 }
 

--- a/src/vdaf/poplar1.rs
+++ b/src/vdaf/poplar1.rs
@@ -476,7 +476,7 @@ impl Encode for Poplar1AggregationParam {
         // byte, not necessarily aligned to a byte boundary. If the highest bits in the first byte
         // are unused, they will be set to zero.
 
-        // When an IPDF index is treated as an integer, the first bit is the integer's most
+        // When an IDPF index is treated as an integer, the first bit is the integer's most
         // significant bit, and bits are subsequently processed in order of decreasing significance.
         // Thus, setting aside the order of bytes, bits within each byte are ordered with the
         // [`Msb0`](bitvec::prelude::Msb0) convention, not [`Lsb0`](bitvec::prelude::Msb0). Yet,

--- a/src/vdaf/poplar1.rs
+++ b/src/vdaf/poplar1.rs
@@ -6,7 +6,7 @@
 
 use crate::{
     codec::{CodecError, Decode, Encode, ParameterizedDecode},
-    field::{merge_vector, Field255, Field64, FieldElement},
+    field::{decode_fieldvec, merge_vector, Field255, Field64, FieldElement},
     idpf::{self, IdpfInput, IdpfOutputShare, IdpfPublicShare, IdpfValue, RingBufferCache},
     prng::Prng,
     vdaf::{
@@ -340,10 +340,14 @@ impl<'a, P: Prg<SEED_SIZE>, const SEED_SIZE: usize>
     for Poplar1FieldVec
 {
     fn decode_with_param(
-        (_poplar1, _agg_param): &(&'a Poplar1<P, SEED_SIZE>, &'a Poplar1AggregationParam),
-        _bytes: &mut Cursor<&[u8]>,
+        (poplar1, agg_param): &(&'a Poplar1<P, SEED_SIZE>, &'a Poplar1AggregationParam),
+        bytes: &mut Cursor<&[u8]>,
     ) -> Result<Self, CodecError> {
-        todo!()
+        if agg_param.level() == poplar1.bits - 1 {
+            decode_fieldvec(agg_param.prefixes().len(), bytes).map(Poplar1FieldVec::Leaf)
+        } else {
+            decode_fieldvec(agg_param.prefixes().len(), bytes).map(Poplar1FieldVec::Inner)
+        }
     }
 }
 

--- a/src/vdaf/poplar1.rs
+++ b/src/vdaf/poplar1.rs
@@ -1488,6 +1488,11 @@ mod tests {
                 ]),
                 [0, 9, 0, 0, 0, 2, 0x0b, 0x69, 0xb2].as_slice(),
             ),
+            // poplar.encode_agg_param(15, [0xcafe])
+            (
+                Vec::from([IdpfInput::from_bytes(b"\xca\xfe")]),
+                [0, 15, 0, 0, 0, 1, 0xca, 0xfe].as_slice(),
+            ),
         ] {
             let agg_param = Poplar1AggregationParam::try_from_prefixes(prefixes).unwrap();
             let encoded = agg_param.get_encoded();


### PR DESCRIPTION
This finishes up Encode/Decode/ParameterizedDecode implementations for Poplar1, particularly output shares, aggregate shares, public input shares, and aggregation parameters. The aggregation parameter serialization is somewhat complicated, (it reverses bits, then reverses bytes, to get the ordering and justification of packed prefixes right) so we may want to revisit the implementation and specification in the future to enable simplifications. I also changed the semantics of `IdpfInput::from_bytes()` and `IdpfInput::to_bytes()`, as I think I got this wrong the first time around. They now align with how candidate prefixes get encoded in the aggregation parameter (assuming they're byte-aligned to begin with).