### PR TITLE
Add DAP draft references to version table

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,17 +34,22 @@ Crate `prio` version `x.y.z` is released from a corresponding `release/x.y` bran
 maintain [Rust SemVer][semver] compatibility, meaning that API breaks only happen on minor version
 increases (e.g., 0.10 to 0.11).
 
-| Git branch | Draft version | Conforms to specification? | Status |
-| ---------- | ------------- | --------------------- | ------ |
-| `release/0.8` | [`draft-irtf-cfrg-vdaf-01`][vdaf-01] | Yes | Supported |
-| `release/0.9` | [`draft-irtf-cfrg-vdaf-03`][vdaf-03] | Yes | Unmaintained as of September 22, 2022 |
-| `release/0.10` | [`draft-irtf-cfrg-vdaf-03`][vdaf-03] | Yes | Supported |
-| `release/0.11` | [`draft-irtf-cfrg-vdaf-04`][vdaf-04] | Yes | Unmaintained |
-| `main` | draft-irtf-cfrg-vdaf-05 (forthcoming) | No | Supported, unstable |
+| Crate version | Git branch | VDAF draft version | DAP draft version | Conforms to specification? | Status |
+| ----- | ---------- | ------------- | ------------- | --------------------- | ------ |
+| 0.8 | `release/0.8` | [`draft-irtf-cfrg-vdaf-01`][vdaf-01] | [`draft-ietf-ppm-dap-01`][dap-01] | Yes | Supported |
+| 0.9 | `release/0.9` | [`draft-irtf-cfrg-vdaf-03`][vdaf-03] | [`draft-ietf-ppm-dap-02`][dap-02] and [`draft-ietf-ppm-dap-03`][dap-03] | Yes | Unmaintained as of September 22, 2022 |
+| 0.10 | `release/0.10` | [`draft-irtf-cfrg-vdaf-03`][vdaf-03] | [`draft-ietf-ppm-dap-02`][dap-02] and [`draft-ietf-ppm-dap-03`][dap-03] | Yes | Supported |
+| 0.11 | `release/0.11` | [`draft-irtf-cfrg-vdaf-04`][vdaf-04] | N/A | Yes | Unmaintained |
+| 0.12 | `main` | [`draft-irtf-cfrg-vdaf-05`][vdaf-05] | [`draft-ietf-ppm-dap-04`][dap-04] | No | Supported, unstable |
 
 [vdaf-01]: https://datatracker.ietf.org/doc/draft-irtf-cfrg-vdaf/01/
 [vdaf-03]: https://datatracker.ietf.org/doc/draft-irtf-cfrg-vdaf/03/
 [vdaf-04]: https://datatracker.ietf.org/doc/draft-irtf-cfrg-vdaf/04/
+[vdaf-05]: https://datatracker.ietf.org/doc/draft-irtf-cfrg-vdaf/05/
+[dap-01]: https://datatracker.ietf.org/doc/draft-ietf-ppm-dap/01/
+[dap-02]: https://datatracker.ietf.org/doc/draft-ietf-ppm-dap/02/
+[dap-03]: https://datatracker.ietf.org/doc/draft-ietf-ppm-dap/03/
+[dap-04]: https://datatracker.ietf.org/doc/draft-ietf-ppm-dap/04/
 [enpa]: https://www.abetterinternet.org/post/prio-services-for-covid-en/
 [enpa-whitepaper]: https://covid19-static.cdn-apple.com/applications/covid19/current/static/contact-tracing/pdf/ENPA_White_Paper.pdf
 [prio-server]: https://github.com/divviup/prio-server


### PR DESCRIPTION
This adds reverse cross references from DAP drafts for each VDAF draft in the version table, and updates the main branch's row with recently published documents. I also added a column for the crate version, in the interest of being explicit.

cc @simon-friedberger