### PR TITLE
Fix build on 32-bit targets

### DIFF
--- a/src/flp/types/fixedpoint_l2.rs
+++ b/src/flp/types/fixedpoint_l2.rs
@@ -778,7 +778,7 @@ mod tests {
             Field128,
             ParallelSum<Field128, PolyEval<Field128>>,
             ParallelSum<Field128, BlindPolyEval<Field128>>,
-        >>::new(30000000000)
+        >>::new(3000000000)
         .unwrap_err();
         // fixed point type has more than one int bit
         <FixedPointBoundedL2VecSum<


### PR DESCRIPTION
I was running tests with Miri, emulating an i686-unknown-linux-gnu host for something else, and I came across the following error.

```
error: literal out of range for `usize`
   --> src/flp/types/fixedpoint_l2.rs:781:17
    |
781 |         >>::new(30000000000)
    |                 ^^^^^^^^^^^
    |
    = note: the literal `30000000000` does not fit into the type `usize` whose range is `0..=4294967295`
    = note: `#[deny(overflowing_literals)]` on by default
```

This PR fixes test compilation by dropping a zero from this length, so that it can be represented by a 32-bit `usize`, while still being sufficiently large that fixed point norm calculations may wrap the field.