### PR TITLE
Use fixed key AES PRG in IDPF

### DIFF
--- a/benches/cycle_counts.rs
+++ b/benches/cycle_counts.rs
@@ -9,10 +9,7 @@ use prio::{
     codec::{Decode, Encode, ParameterizedDecode},
     field::Field255,
     idpf::{self, IdpfInput, IdpfPublicShare, RingBufferCache},
-    vdaf::{
-        poplar1::Poplar1IdpfValue,
-        prg::{PrgSha3, Seed},
-    },
+    vdaf::{poplar1::Poplar1IdpfValue, prg::Seed},
 };
 #[cfg(feature = "prio2")]
 use prio::{field::FieldPrio2, server::VerificationMessage};
@@ -178,7 +175,7 @@ fn idpf_poplar_gen(
     inner_values: Vec<Poplar1IdpfValue<Field64>>,
     leaf_value: Poplar1IdpfValue<Field255>,
 ) {
-    idpf::gen::<_, _, _, PrgSha3, 16>(input, inner_values, leaf_value).unwrap();
+    idpf::gen(input, inner_values, leaf_value).unwrap();
 }
 
 #[cfg(feature = "experimental")]
@@ -217,11 +214,11 @@ fn idpf_poplar_gen_2048() {
 #[cfg(feature = "experimental")]
 fn idpf_poplar_eval(
     input: &IdpfInput,
-    public_share: &IdpfPublicShare<Poplar1IdpfValue<Field64>, Poplar1IdpfValue<Field255>, 16>,
+    public_share: &IdpfPublicShare<Poplar1IdpfValue<Field64>, Poplar1IdpfValue<Field255>>,
     key: &Seed<16>,
 ) {
     let mut cache = RingBufferCache::new(1);
-    idpf::eval::<_, _, PrgSha3, 16>(0, public_share, key, input, &mut cache).unwrap();
+    idpf::eval(0, public_share, key, input, &mut cache).unwrap();
 }
 
 #[cfg(feature = "experimental")]
@@ -261,7 +258,7 @@ fn idpf_codec() {
     ))
     .unwrap();
     let bits = 4;
-    let public_share = IdpfPublicShare::<Poplar1IdpfValue<Field64>,Poplar1IdpfValue<Field255>,16>::get_decoded_with_param(&bits, &data).unwrap();
+    let public_share = IdpfPublicShare::<Poplar1IdpfValue<Field64>, Poplar1IdpfValue<Field255>>::get_decoded_with_param(&bits, &data).unwrap();
     let encoded = public_share.get_encoded();
     let _ = black_box(encoded.len());
 }

--- a/benches/speed_tests.rs
+++ b/benches/speed_tests.rs
@@ -25,7 +25,6 @@ use prio::{
     idpf::{self, IdpfInput, RingBufferCache},
     vdaf::{
         poplar1::{Poplar1, Poplar1AggregationParam, Poplar1IdpfValue},
-        prg::PrgSha3,
         Aggregator,
     },
 };
@@ -272,8 +271,7 @@ pub fn idpf(c: &mut Criterion) {
             let leaf_value = Poplar1IdpfValue::new([Field255::one(), random_vector(1).unwrap()[0]]);
 
             b.iter(|| {
-                idpf::gen::<_, _, _, PrgSha3, 16>(&input, inner_values.clone(), leaf_value)
-                    .unwrap();
+                idpf::gen(&input, inner_values.clone(), leaf_value).unwrap();
             });
         });
     }
@@ -293,8 +291,7 @@ pub fn idpf(c: &mut Criterion) {
                 .collect::<Vec<_>>();
             let leaf_value = Poplar1IdpfValue::new([Field255::one(), random_vector(1).unwrap()[0]]);
 
-            let (public_share, keys) =
-                idpf::gen::<_, _, _, PrgSha3, 16>(&input, inner_values, leaf_value).unwrap();
+            let (public_share, keys) = idpf::gen(&input, inner_values, leaf_value).unwrap();
 
             b.iter(|| {
                 // This is an aggressively small cache, to minimize its impact on the benchmark.
@@ -305,14 +302,7 @@ pub fn idpf(c: &mut Criterion) {
 
                 for prefix_length in 1..=size {
                     let prefix = input[..prefix_length].to_owned().into();
-                    idpf::eval::<_, _, PrgSha3, 16>(
-                        0,
-                        &public_share,
-                        &keys[0],
-                        &prefix,
-                        &mut cache,
-                    )
-                    .unwrap();
+                    idpf::eval(0, &public_share, &keys[0], &prefix, &mut cache).unwrap();
                 }
             });
         });


### PR DESCRIPTION
This drops some type parameters from various functions in the IDPF module, and fixes it to use only `PrgFixedKeyAes128`. The IDPF is not parameterizable with other PRGs according to its definition in VDAF-05, plus we will need to go beyond the `Prg` trait in order to implement #511.