### PR TITLE
Explicitly specify a trait to fix a Chalk issue

### DIFF
--- a/src/vdaf/prg.rs
+++ b/src/vdaf/prg.rs
@@ -166,7 +166,7 @@ pub struct SeedStreamAes128(Ctr64BE<Aes128>);
 #[cfg(feature = "crypto-dependencies")]
 impl SeedStreamAes128 {
     pub(crate) fn new(key: &[u8], iv: &[u8]) -> Self {
-        SeedStreamAes128(Ctr64BE::<Aes128>::new(key.into(), iv.into()))
+        SeedStreamAes128(<Ctr64BE<Aes128> as KeyIvInit>::new(key.into(), iv.into()))
     }
 }
 


### PR DESCRIPTION
Rust-analyzer was tripping over this line, presumably because Chalk incorrectly inferred this was `KeyInit::new()`, which takes one argument, instead of `KeyIvInit::new()`. We can explicitly specify the trait in this call to resolve it.