### PR TITLE
Bind IDPF generation/evaluation to a nonce

### DIFF
--- a/benches/cycle_counts.rs
+++ b/benches/cycle_counts.rs
@@ -175,7 +175,7 @@ fn idpf_poplar_gen(
     inner_values: Vec<Poplar1IdpfValue<Field64>>,
     leaf_value: Poplar1IdpfValue<Field255>,
 ) {
-    idpf::gen(input, inner_values, leaf_value).unwrap();
+    idpf::gen(input, inner_values, leaf_value, &[0; 16]).unwrap();
 }
 
 #[cfg(feature = "experimental")]
@@ -218,7 +218,7 @@ fn idpf_poplar_eval(
     key: &Seed<16>,
 ) {
     let mut cache = RingBufferCache::new(1);
-    idpf::eval(0, public_share, key, input, &mut cache).unwrap();
+    idpf::eval(0, public_share, key, input, &[0; 16], &mut cache).unwrap();
 }
 
 #[cfg(feature = "experimental")]

--- a/benches/speed_tests.rs
+++ b/benches/speed_tests.rs
@@ -271,7 +271,7 @@ pub fn idpf(c: &mut Criterion) {
             let leaf_value = Poplar1IdpfValue::new([Field255::one(), random_vector(1).unwrap()[0]]);
 
             b.iter(|| {
-                idpf::gen(&input, inner_values.clone(), leaf_value).unwrap();
+                idpf::gen(&input, inner_values.clone(), leaf_value, &[0; 16]).unwrap();
             });
         });
     }
@@ -291,7 +291,8 @@ pub fn idpf(c: &mut Criterion) {
                 .collect::<Vec<_>>();
             let leaf_value = Poplar1IdpfValue::new([Field255::one(), random_vector(1).unwrap()[0]]);
 
-            let (public_share, keys) = idpf::gen(&input, inner_values, leaf_value).unwrap();
+            let (public_share, keys) =
+                idpf::gen(&input, inner_values, leaf_value, &[0; 16]).unwrap();
 
             b.iter(|| {
                 // This is an aggressively small cache, to minimize its impact on the benchmark.
@@ -302,7 +303,7 @@ pub fn idpf(c: &mut Criterion) {
 
                 for prefix_length in 1..=size {
                     let prefix = input[..prefix_length].to_owned().into();
-                    idpf::eval(0, &public_share, &keys[0], &prefix, &mut cache).unwrap();
+                    idpf::eval(0, &public_share, &keys[0], &prefix, &[0; 16], &mut cache).unwrap();
                 }
             });
         });

--- a/src/vdaf/poplar1.rs
+++ b/src/vdaf/poplar1.rs
@@ -580,6 +580,7 @@ impl<P: Prg<SEED_SIZE>, const SEED_SIZE: usize> Client<16> for Poplar1<P, SEED_S
                 .iter()
                 .map(|auth| Poplar1IdpfValue([Field64::one(), *auth])),
             Poplar1IdpfValue([Field255::one(), auth_leaf]),
+            nonce,
         )?;
 
         // Generate the correlated randomness for the inner nodes. This includes additive shares of
@@ -968,6 +969,7 @@ where
             public_share,
             idpf_key,
             prefix,
+            nonce,
             &mut idpf_eval_cache,
         )?);
 


### PR DESCRIPTION
This adds a binder input to IDPF key generation and evaluation functions, and updates Poplar1 to pass the nonce as this binder string. Stacked on top of #519, since it's editing all the same function calls.