### PR TITLE
Update documentation for VDAF-05

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,14 +17,13 @@ This crate is used in the [Exposure Notifications Private Analytics][enpa] syste
 by the interfaces in modules `server` and `client` and is referred to in various places as Prio v2.
 See [`prio-server`][prio-server] or the [ENPA whitepaper][enpa-whitepaper] for more details.
 
-## Verifiable Distributed Aggregation Function (EXPERIMENTAL)
+## Verifiable Distributed Aggregation Function
 
 Crate `prio` also implements a [Verifiable Distributed Aggregation Function
 (VDAF)][vdaf] called "Prio3", implemented in the `vdaf` module, allowing Prio to
 be used in the [Distributed Aggregation Protocol][dap] protocol being developed
-in the PPM working group at the IETF. This support is still experimental, and is
-evolving along with the DAP and VDAF specifications. Formal security analysis is
-also forthcoming. Prio3 should not yet be used in production applications.
+in the PPM working group at the IETF. This support is still evolving along with
+the DAP and VDAF specifications.
 
 ### Draft versions and release branches
 
@@ -40,7 +39,7 @@ increases (e.g., 0.10 to 0.11).
 | 0.9 | `release/0.9` | [`draft-irtf-cfrg-vdaf-03`][vdaf-03] | [`draft-ietf-ppm-dap-02`][dap-02] and [`draft-ietf-ppm-dap-03`][dap-03] | Yes | Unmaintained as of September 22, 2022 |
 | 0.10 | `release/0.10` | [`draft-irtf-cfrg-vdaf-03`][vdaf-03] | [`draft-ietf-ppm-dap-02`][dap-02] and [`draft-ietf-ppm-dap-03`][dap-03] | Yes | Supported |
 | 0.11 | `release/0.11` | [`draft-irtf-cfrg-vdaf-04`][vdaf-04] | N/A | Yes | Unmaintained |
-| 0.12 | `main` | [`draft-irtf-cfrg-vdaf-05`][vdaf-05] | [`draft-ietf-ppm-dap-04`][dap-04] | No | Supported, unstable |
+| 0.12 | `main` | [`draft-irtf-cfrg-vdaf-05`][vdaf-05] | [`draft-ietf-ppm-dap-04`][dap-04] | Yes | Supported |
 
 [vdaf-01]: https://datatracker.ietf.org/doc/draft-irtf-cfrg-vdaf/01/
 [vdaf-03]: https://datatracker.ietf.org/doc/draft-irtf-cfrg-vdaf/03/

--- a/src/flp.rs
+++ b/src/flp.rs
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: MPL-2.0
 
 //! Implementation of the generic Fully Linear Proof (FLP) system specified in
-//! [[draft-irtf-cfrg-vdaf-04]]. This is the main building block of [`Prio3`](crate::vdaf::prio3).
+//! [[draft-irtf-cfrg-vdaf-05]]. This is the main building block of [`Prio3`](crate::vdaf::prio3).
 //!
 //! The FLP is derived for any implementation of the [`Type`] trait. Such an implementation
 //! specifies a validity circuit that defines the set of valid measurements, as well as the finite
@@ -44,7 +44,7 @@
 //! assert!(count.decide(&verifier).unwrap());
 //! ```
 //!
-//! [draft-irtf-cfrg-vdaf-04]: https://datatracker.ietf.org/doc/draft-irtf-cfrg-vdaf/04/
+//! [draft-irtf-cfrg-vdaf-05]: https://datatracker.ietf.org/doc/draft-irtf-cfrg-vdaf/05/
 
 use crate::fft::{discrete_fourier_transform, discrete_fourier_transform_inv_finish, FftError};
 use crate::field::{FftFriendlyFieldElement, FieldElement, FieldElementWithInteger, FieldError};

--- a/src/idpf.rs
+++ b/src/idpf.rs
@@ -1,7 +1,7 @@
 //! This module implements the incremental distributed point function (IDPF) described in
-//! [[draft-irtf-cfrg-vdaf-04]].
+//! [[draft-irtf-cfrg-vdaf-05]].
 //!
-//! [draft-irtf-cfrg-vdaf-04]: https://datatracker.ietf.org/doc/draft-irtf-cfrg-vdaf/04/
+//! [draft-irtf-cfrg-vdaf-05]: https://datatracker.ietf.org/doc/draft-irtf-cfrg-vdaf/05/
 
 use crate::{
     codec::{CodecError, Decode, Encode, ParameterizedDecode},

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -16,7 +16,7 @@
 //! Aggregation Functions][vdaf], along with an experimental implementation of Poplar1.
 //!
 //! [enpa]: https://www.abetterinternet.org/post/prio-services-for-covid-en/
-//! [vdaf]: https://datatracker.ietf.org/doc/draft-irtf-cfrg-vdaf/04/
+//! [vdaf]: https://datatracker.ietf.org/doc/draft-irtf-cfrg-vdaf/05/
 
 pub mod benchmarked;
 #[cfg(feature = "prio2")]

--- a/src/vdaf.rs
+++ b/src/vdaf.rs
@@ -1,9 +1,9 @@
 // SPDX-License-Identifier: MPL-2.0
 
 //! Verifiable Distributed Aggregation Functions (VDAFs) as described in
-//! [[draft-irtf-cfrg-vdaf-04]].
+//! [[draft-irtf-cfrg-vdaf-05]].
 //!
-//! [draft-irtf-cfrg-vdaf-04]: https://datatracker.ietf.org/doc/draft-irtf-cfrg-vdaf/04/
+//! [draft-irtf-cfrg-vdaf-05]: https://datatracker.ietf.org/doc/draft-irtf-cfrg-vdaf/05/
 
 #[cfg(feature = "experimental")]
 use crate::idpf::IdpfError;

--- a/src/vdaf/poplar1.rs
+++ b/src/vdaf/poplar1.rs
@@ -1,8 +1,8 @@
 // SPDX-License-Identifier: MPL-2.0
 
-//! Work-in-progress implementation of Poplar1 as specified in [[draft-irtf-cfrg-vdaf-04]].
+//! Implementation of Poplar1 as specified in [[draft-irtf-cfrg-vdaf-05]].
 //!
-//! [draft-irtf-cfrg-vdaf-04]: https://datatracker.ietf.org/doc/draft-irtf-cfrg-vdaf/04/
+//! [draft-irtf-cfrg-vdaf-05]: https://datatracker.ietf.org/doc/draft-irtf-cfrg-vdaf/05/
 
 use crate::{
     codec::{CodecError, Decode, Encode, ParameterizedDecode},
@@ -31,9 +31,9 @@ const DST_VERIFY_RANDOMNESS: u16 = 4;
 
 impl<P, const SEED_SIZE: usize> Poplar1<P, SEED_SIZE> {
     /// Create an instance of [`Poplar1`]. The caller provides the bit length of each
-    /// measurement (`BITS` as defined in the [[draft-irtf-cfrg-vdaf-04]]).
+    /// measurement (`BITS` as defined in the [[draft-irtf-cfrg-vdaf-05]]).
     ///
-    /// [draft-irtf-cfrg-vdaf-04]: https://datatracker.ietf.org/doc/draft-irtf-cfrg-vdaf/04/
+    /// [draft-irtf-cfrg-vdaf-05]: https://datatracker.ietf.org/doc/draft-irtf-cfrg-vdaf/05/
     pub fn new(bits: usize) -> Self {
         Self {
             bits,
@@ -44,9 +44,9 @@ impl<P, const SEED_SIZE: usize> Poplar1<P, SEED_SIZE> {
 
 impl Poplar1<PrgSha3, 16> {
     /// Create an instance of [`Poplar1`] using [`PrgSha3`]. The caller provides the bit length of
-    /// each measurement (`BITS` as defined in the [[draft-irtf-cfrg-vdaf-04]]).
+    /// each measurement (`BITS` as defined in the [[draft-irtf-cfrg-vdaf-05]]).
     ///
-    /// [draft-irtf-cfrg-vdaf-04]: https://datatracker.ietf.org/doc/draft-irtf-cfrg-vdaf/04/
+    /// [draft-irtf-cfrg-vdaf-05]: https://datatracker.ietf.org/doc/draft-irtf-cfrg-vdaf/05/
     pub fn new_sha3(bits: usize) -> Self {
         Poplar1::new(bits)
     }

--- a/src/vdaf/prg.rs
+++ b/src/vdaf/prg.rs
@@ -1,8 +1,8 @@
 // SPDX-License-Identifier: MPL-2.0
 
-//! Implementations of PRGs specified in [[draft-irtf-cfrg-vdaf-04]].
+//! Implementations of PRGs specified in [[draft-irtf-cfrg-vdaf-05]].
 //!
-//! [draft-irtf-cfrg-vdaf-04]: https://datatracker.ietf.org/doc/draft-irtf-cfrg-vdaf/04/
+//! [draft-irtf-cfrg-vdaf-05]: https://datatracker.ietf.org/doc/draft-irtf-cfrg-vdaf/05/
 
 use crate::vdaf::{CodecError, Decode, Encode};
 #[cfg(feature = "experimental")]
@@ -91,9 +91,9 @@ pub trait SeedStream {
     fn fill(&mut self, buf: &mut [u8]);
 }
 
-/// A pseudorandom generator (PRG) with the interface specified in [[draft-irtf-cfrg-vdaf-04]].
+/// A pseudorandom generator (PRG) with the interface specified in [[draft-irtf-cfrg-vdaf-05]].
 ///
-/// [draft-irtf-cfrg-vdaf-04]: https://datatracker.ietf.org/doc/draft-irtf-cfrg-vdaf/04/
+/// [draft-irtf-cfrg-vdaf-05]: https://datatracker.ietf.org/doc/draft-irtf-cfrg-vdaf/05/
 pub trait Prg<const SEED_SIZE: usize>: Clone + Debug {
     /// The type of stream produced by this PRG.
     type SeedStream: SeedStream;
@@ -190,9 +190,9 @@ impl Debug for SeedStreamAes128 {
     }
 }
 
-/// The PRG based on SHA-3 as specified in [[draft-irtf-cfrg-vdaf-04]].
+/// The PRG based on SHA-3 as specified in [[draft-irtf-cfrg-vdaf-05]].
 ///
-/// [draft-irtf-cfrg-vdaf-04]: https://datatracker.ietf.org/doc/draft-irtf-cfrg-vdaf/04/
+/// [draft-irtf-cfrg-vdaf-05]: https://datatracker.ietf.org/doc/draft-irtf-cfrg-vdaf/05/
 #[derive(Clone, Debug)]
 #[cfg(feature = "crypto-dependencies")]
 pub struct PrgSha3(CShake128);

--- a/src/vdaf/prio3.rs
+++ b/src/vdaf/prio3.rs
@@ -1,16 +1,15 @@
 // SPDX-License-Identifier: MPL-2.0
 
-//! Implementation of the Prio3 VDAF [[draft-irtf-cfrg-vdaf-04]].
+//! Implementation of the Prio3 VDAF [[draft-irtf-cfrg-vdaf-05]].
 //!
-//! **WARNING:** Neither this code nor the cryptographic construction it implements has undergone
-//! significant security analysis. Use at your own risk.
+//! **WARNING:** This code has not undergone significant security analysis. Use at your own risk.
 //!
 //! Prio3 is based on the Prio system desigend by Dan Boneh and Henry Corrigan-Gibbs and presented
 //! at NSDI 2017 [[CGB17]]. However, it incorporates a few techniques from Boneh et al., CRYPTO
 //! 2019 [[BBCG+19]], that lead to substantial improvements in terms of run time and communication
-//! cost.
+//! cost. The security of the construction was analyzed in [[DPRS23]].
 //!
-//! Prio3 is a transformation of a Fully Linear Proof (FLP) system [[draft-irtf-cfrg-vdaf-04]] into
+//! Prio3 is a transformation of a Fully Linear Proof (FLP) system [[draft-irtf-cfrg-vdaf-05]] into
 //! a VDAF. The base type, [`Prio3`], supports a wide variety of aggregation functions, some of
 //! which are instantiated here:
 //!
@@ -21,11 +20,12 @@
 //!
 //! Additional types can be constructed from [`Prio3`] as needed.
 //!
-//! (*) denotes that the type is specified in [[draft-irtf-cfrg-vdaf-04]].
+//! (*) denotes that the type is specified in [[draft-irtf-cfrg-vdaf-05]].
 //!
 //! [BBCG+19]: https://ia.cr/2019/188
 //! [CGB17]: https://crypto.stanford.edu/prio/
-//! [draft-irtf-cfrg-vdaf-04]: https://datatracker.ietf.org/doc/draft-irtf-cfrg-vdaf/04/
+//! [DPRS23]: https://ia.cr/2023/130
+//! [draft-irtf-cfrg-vdaf-05]: https://datatracker.ietf.org/doc/draft-irtf-cfrg-vdaf/05/
 
 #[cfg(feature = "crypto-dependencies")]
 use super::prg::PrgSha3;


### PR DESCRIPTION
Stacked on #522.

This updates document references for the new draft as appropriate, updates the version table in the README, and adds a reference to DPRS23 to the top-level docs.