### PR TITLE
Deprecate Field96

### DIFF
--- a/src/fft.rs
+++ b/src/fft.rs
@@ -115,9 +115,7 @@ fn bitrev(d: usize, x: usize) -> usize {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::field::{
-        random_vector, split_vector, Field128, Field64, Field96, FieldElement, FieldPrio2,
-    };
+    use crate::field::{random_vector, split_vector, Field128, Field64, FieldElement, FieldPrio2};
     use crate::polynomial::{poly_fft, PolyAuxMemory};
 
     fn discrete_fourier_transform_then_inv_test<F: FftFriendlyFieldElement>() -> Result<(), FftError>
@@ -148,8 +146,10 @@ mod tests {
     }
 
     #[test]
+    #[allow(deprecated)]
     fn test_field96() {
-        discrete_fourier_transform_then_inv_test::<Field96>().expect("unexpected error");
+        discrete_fourier_transform_then_inv_test::<crate::field::Field96>()
+            .expect("unexpected error");
     }
 
     #[test]

--- a/src/field.rs
+++ b/src/field.rs
@@ -712,6 +712,10 @@ make_field!(
     8,
 );
 
+/// This nested module is an implementation detail to limit the scope of a module-wide
+/// `allow(deprecated)` attribute. [`Field96`] is marked as deprecated, and deprecation warnings
+/// must be silenced on multiple implementation blocks, and the macro invocation itself that
+/// defines the struct and its implementation.
 mod field96 {
     #![allow(deprecated)]
 

--- a/src/field.rs
+++ b/src/field.rs
@@ -7,13 +7,11 @@
 //! [`FftFriendlyFieldElement`], and have an associated element called the "generator" that
 //! generates a multiplicative subgroup of order `2^n` for some `n`.
 
-#![allow(deprecated)] // for Field96
-
 #[cfg(feature = "crypto-dependencies")]
 use crate::prng::{Prng, PrngError};
 use crate::{
     codec::{CodecError, Decode, Encode},
-    fp::{FP128, FP32, FP64, FP96},
+    fp::{FP128, FP32, FP64},
     vdaf::prg::{CoinToss, SeedStream},
 };
 use serde::{
@@ -714,16 +712,42 @@ make_field!(
     8,
 );
 
-make_field!(
-    #[deprecated]
-    /// `GF(79228148845226978974766202881)`, a 96-bit field.
-    ///
-    /// This is deprecated because it is not currently used by either Prio v2 or any VDAF.
-    Field96,
-    u128,
-    FP96,
-    12,
-);
+mod field96 {
+    #![allow(deprecated)]
+
+    use super::{
+        FftFriendlyFieldElement, FieldElement, FieldElementVisitor, FieldElementWithInteger,
+        FieldError,
+    };
+    use crate::{
+        codec::{CodecError, Decode, Encode},
+        fp::FP96,
+    };
+    use serde::{Deserialize, Deserializer, Serialize, Serializer};
+    use std::{
+        cmp::min,
+        fmt::{Debug, Display, Formatter},
+        hash::{Hash, Hasher},
+        io::{Cursor, Read},
+        marker::PhantomData,
+        ops::{Add, AddAssign, Div, DivAssign, Mul, MulAssign, Neg, Sub, SubAssign},
+    };
+    use subtle::{Choice, ConditionallySelectable, ConstantTimeEq};
+
+    make_field!(
+        #[deprecated]
+        /// `GF(79228148845226978974766202881)`, a 96-bit field.
+        ///
+        /// This is deprecated because it is not currently used by either Prio v2 or any VDAF.
+        Field96,
+        u128,
+        FP96,
+        12,
+    );
+}
+
+#[allow(deprecated)]
+pub use field96::Field96;
 
 make_field!(
     /// `GF(340282366920938462946865773367900766209)`, a 128-bit field.
@@ -1179,6 +1203,7 @@ mod tests {
 
     #[test]
     fn test_field96() {
+        #[allow(deprecated)]
         field_element_test::<Field96>();
     }
 

--- a/src/field.rs
+++ b/src/field.rs
@@ -7,6 +7,8 @@
 //! [`FftFriendlyFieldElement`], and have an associated element called the "generator" that
 //! generates a multiplicative subgroup of order `2^n` for some `n`.
 
+#![allow(deprecated)] // for Field96
+
 #[cfg(feature = "crypto-dependencies")]
 use crate::prng::{Prng, PrngError};
 use crate::{
@@ -713,6 +715,7 @@ make_field!(
 );
 
 make_field!(
+    #[deprecated]
     /// `GF(79228148845226978974766202881)`, a 96-bit field.
     Field96,
     u128,

--- a/src/field.rs
+++ b/src/field.rs
@@ -717,6 +717,8 @@ make_field!(
 make_field!(
     #[deprecated]
     /// `GF(79228148845226978974766202881)`, a 96-bit field.
+    ///
+    /// This is deprecated because it is not currently used by either Prio v2 or any VDAF.
     Field96,
     u128,
     FP96,

--- a/src/flp/gadgets.rs
+++ b/src/flp/gadgets.rs
@@ -585,7 +585,7 @@ mod tests {
 
     #[cfg(feature = "multithreaded")]
     use crate::field::FieldElement;
-    use crate::field::{random_vector, Field96 as TestField};
+    use crate::field::{random_vector, Field64 as TestField};
     use crate::prng::Prng;
 
     #[test]

--- a/src/prng.rs
+++ b/src/prng.rs
@@ -137,7 +137,7 @@ mod tests {
     use super::*;
     use crate::{
         codec::Decode,
-        field::{Field64, Field96, FieldPrio2},
+        field::{Field64, FieldPrio2},
         vdaf::prg::{CoinToss, Prg, PrgSha3, Seed, SeedStreamSha3},
     };
     #[cfg(feature = "prio2")]
@@ -247,11 +247,11 @@ mod tests {
     fn left_over_buffer_back_fill() {
         let seed = Seed::generate().unwrap();
 
-        let mut prng: Prng<Field96, SeedStreamSha3> =
+        let mut prng: Prng<Field64, SeedStreamSha3> =
             Prng::from_seed_stream(PrgSha3::seed_stream(&seed, b"", b""));
 
         // Construct a `Prng` with a longer-than-usual buffer.
-        let mut prng_weird_buffer_size: Prng<Field96, SeedStreamSha3> =
+        let mut prng_weird_buffer_size: Prng<Field64, SeedStreamSha3> =
             Prng::from_seed_stream(PrgSha3::seed_stream(&seed, b"", b""));
         let mut extra = [0; 7];
         prng_weird_buffer_size.seed_stream.fill(&mut extra);
@@ -268,7 +268,7 @@ mod tests {
     #[test]
     fn into_new_field() {
         let seed = Seed::generate().unwrap();
-        let want: Prng<Field96, SeedStreamSha3> =
+        let want: Prng<Field64, SeedStreamSha3> =
             Prng::from_seed_stream(PrgSha3::seed_stream(&seed, b"", b""));
         let want_buffer = want.buffer.clone();
 


### PR DESCRIPTION
This deprecates `Field96`, which is not used in any constructions so far. Closes #537.