### PR TITLE
Mark 0.8 branch as unmaintained

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -14,18 +14,6 @@ updates:
     directory: "/"
     schedule:
       interval: "weekly"
-    target-branch: release/0.8
-
-  - package-ecosystem: "github-actions"
-    directory: "/"
-    schedule:
-      interval: "weekly"
-    target-branch: release/0.8
-
-  - package-ecosystem: "cargo"
-    directory: "/"
-    schedule:
-      interval: "weekly"
     target-branch: release/0.10
 
   - package-ecosystem: "github-actions"

--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ increases (e.g., 0.10 to 0.11).
 
 | Crate version | Git branch | VDAF draft version | DAP draft version | Conforms to specification? | Status |
 | ----- | ---------- | ------------- | ------------- | --------------------- | ------ |
-| 0.8 | `release/0.8` | [`draft-irtf-cfrg-vdaf-01`][vdaf-01] | [`draft-ietf-ppm-dap-01`][dap-01] | Yes | Supported |
+| 0.8 | `release/0.8` | [`draft-irtf-cfrg-vdaf-01`][vdaf-01] | [`draft-ietf-ppm-dap-01`][dap-01] | Yes | Unmaintained as of March 28, 2023 |
 | 0.9 | `release/0.9` | [`draft-irtf-cfrg-vdaf-03`][vdaf-03] | [`draft-ietf-ppm-dap-02`][dap-02] and [`draft-ietf-ppm-dap-03`][dap-03] | Yes | Unmaintained as of September 22, 2022 |
 | 0.10 | `release/0.10` | [`draft-irtf-cfrg-vdaf-03`][vdaf-03] | [`draft-ietf-ppm-dap-02`][dap-02] and [`draft-ietf-ppm-dap-03`][dap-03] | Yes | Supported |
 | 0.11 | `release/0.11` | [`draft-irtf-cfrg-vdaf-04`][vdaf-04] | N/A | Yes | Unmaintained |


### PR DESCRIPTION
This updates the version table in the README to mark 0.8 as unmaintained, and removes it from the Dependabot configuration. (note that this will tickle Dependabot when merged, and may result in a few more version update PRs)