### PR TITLE
Conditional compilation fixes

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -85,3 +85,6 @@ rustdoc-args = ["--cfg", "docsrs"]
 name = "backward_compatibility"
 path = "tests/backward_compatibility.rs"
 required-features = ["prio2"]
+
+[package.metadata.cargo-all-features]
+skip_optional_dependencies = true

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -59,7 +59,7 @@ default = ["crypto-dependencies"]
 experimental = ["bitvec", "fiat-crypto", "fixed"]
 test-util = ["rand", "serde_json"]
 multithreaded = ["rayon"]
-prio2 = ["aes-gcm", "ring"]
+prio2 = ["crypto-dependencies", "aes-gcm", "ring"]
 crypto-dependencies = ["aes", "ctr", "cmac", "sha3"]
 
 [workspace]

--- a/src/field.rs
+++ b/src/field.rs
@@ -806,6 +806,7 @@ pub(crate) fn split_vector<F: FieldElement>(
 
 /// Generate a vector of uniformly distributed random field elements.
 #[cfg(feature = "crypto-dependencies")]
+#[cfg_attr(docsrs, doc(cfg(feature = "crypto-dependencies")))]
 pub fn random_vector<F: FieldElement>(len: usize) -> Result<Vec<F>, PrngError> {
     Ok(Prng::new()?.take(len).collect())
 }

--- a/src/field/field255.rs
+++ b/src/field/field255.rs
@@ -32,6 +32,7 @@ const MODULUS_LITTLE_ENDIAN: [u8; 32] = [
 
 /// `GF(2^255 - 19)`, a 255-bit field.
 #[derive(Clone, Copy)]
+#[cfg_attr(docsrs, doc(cfg(feature = "experimental")))]
 pub struct Field255(fiat_25519_tight_field_element);
 
 impl Field255 {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -20,10 +20,13 @@
 
 pub mod benchmarked;
 #[cfg(feature = "prio2")]
+#[cfg_attr(docsrs, doc(cfg(feature = "prio2")))]
 pub mod client;
 #[cfg(feature = "prio2")]
+#[cfg_attr(docsrs, doc(cfg(feature = "prio2")))]
 pub mod encrypt;
 #[cfg(feature = "prio2")]
+#[cfg_attr(docsrs, doc(cfg(feature = "prio2")))]
 pub mod server;
 
 pub mod codec;
@@ -32,13 +35,19 @@ pub mod field;
 pub mod flp;
 mod fp;
 #[cfg(all(feature = "crypto-dependencies", feature = "experimental"))]
+#[cfg_attr(
+    docsrs,
+    doc(cfg(all(feature = "crypto-dependencies", feature = "experimental")))
+)]
 pub mod idpf;
 mod polynomial;
 mod prng;
 // Module test_vector depends on crate `rand` so we make it an optional feature
 // to spare most clients the extra dependency.
 #[cfg(all(any(feature = "test-util", test), feature = "prio2"))]
+#[doc(hidden)]
 pub mod test_vector;
 #[cfg(feature = "prio2")]
+#[cfg_attr(docsrs, doc(cfg(feature = "prio2")))]
 pub mod util;
 pub mod vdaf;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -31,7 +31,7 @@ mod fft;
 pub mod field;
 pub mod flp;
 mod fp;
-#[cfg(feature = "experimental")]
+#[cfg(all(feature = "crypto-dependencies", feature = "experimental"))]
 pub mod idpf;
 mod polynomial;
 mod prng;

--- a/src/prng.rs
+++ b/src/prng.rs
@@ -109,7 +109,7 @@ where
     //
     // If we don't end up making this spec change, then add tests to ensure that changing field
     // types is done correctly.
-    #[cfg(feature = "experimental")]
+    #[cfg(all(feature = "crypto-dependencies", feature = "experimental"))]
     pub(crate) fn into_new_field<F1: FieldElement>(self) -> Prng<F1, S> {
         Prng {
             phantom: PhantomData,

--- a/src/vdaf.rs
+++ b/src/vdaf.rs
@@ -5,7 +5,7 @@
 //!
 //! [draft-irtf-cfrg-vdaf-05]: https://datatracker.ietf.org/doc/draft-irtf-cfrg-vdaf/05/
 
-#[cfg(feature = "experimental")]
+#[cfg(all(feature = "crypto-dependencies", feature = "experimental"))]
 use crate::idpf::IdpfError;
 use crate::{
     codec::{CodecError, Decode, Encode, ParameterizedDecode},
@@ -49,7 +49,7 @@ pub enum VdafError {
     GetRandom(#[from] getrandom::Error),
 
     /// IDPF error.
-    #[cfg(feature = "experimental")]
+    #[cfg(all(feature = "crypto-dependencies", feature = "experimental"))]
     #[error("idpf error: {0}")]
     Idpf(#[from] IdpfError),
 }

--- a/src/vdaf.rs
+++ b/src/vdaf.rs
@@ -532,10 +532,14 @@ where
 }
 
 #[cfg(all(feature = "crypto-dependencies", feature = "experimental"))]
-#[cfg_attr(docsrs, doc(cfg(feature = "experimental")))]
+#[cfg_attr(
+    docsrs,
+    doc(cfg(all(feature = "crypto-dependencies", feature = "experimental")))
+)]
 pub mod poplar1;
 pub mod prg;
 #[cfg(feature = "prio2")]
+#[cfg_attr(docsrs, doc(cfg(feature = "prio2")))]
 pub mod prio2;
 pub mod prio3;
 #[cfg(test)]

--- a/src/vdaf/prg.rs
+++ b/src/vdaf/prg.rs
@@ -5,7 +5,7 @@
 //! [draft-irtf-cfrg-vdaf-05]: https://datatracker.ietf.org/doc/draft-irtf-cfrg-vdaf/05/
 
 use crate::vdaf::{CodecError, Decode, Encode};
-#[cfg(feature = "experimental")]
+#[cfg(all(feature = "crypto-dependencies", feature = "experimental"))]
 use aes::{
     cipher::{generic_array::GenericArray, BlockEncrypt, KeyInit},
     Block,
@@ -236,12 +236,12 @@ impl SeedStream for SeedStreamSha3 {
 
 /// Factory to produce multiple [`PrgFixedKeyAes128`] instances with the same fixed key and
 /// different seeds.
-#[cfg(feature = "experimental")]
+#[cfg(all(feature = "crypto-dependencies", feature = "experimental"))]
 pub struct PrgFixedKeyAes128Key {
     cipher: Aes128,
 }
 
-#[cfg(feature = "experimental")]
+#[cfg(all(feature = "crypto-dependencies", feature = "experimental"))]
 impl PrgFixedKeyAes128Key {
     /// Derive a fixed key from the customization string and binder string.
     pub fn new(custom: &[u8], binder: &[u8]) -> Self {
@@ -274,13 +274,13 @@ impl PrgFixedKeyAes128Key {
 ///
 /// [draft-irtf-cfrg-vdaf-05]: https://datatracker.ietf.org/doc/draft-irtf-cfrg-vdaf/05/
 #[derive(Clone, Debug)]
-#[cfg(feature = "experimental")]
+#[cfg(all(feature = "crypto-dependencies", feature = "experimental"))]
 pub struct PrgFixedKeyAes128 {
     fixed_key_deriver: CShake128,
     base_block: Block,
 }
 
-#[cfg(feature = "experimental")]
+#[cfg(all(feature = "crypto-dependencies", feature = "experimental"))]
 impl Prg<16> for PrgFixedKeyAes128 {
     type SeedStream = SeedStreamFixedKeyAes128;
 
@@ -307,14 +307,14 @@ impl Prg<16> for PrgFixedKeyAes128 {
 }
 
 /// Seed stream for [`PrgFixedKeyAes128`].
-#[cfg(feature = "experimental")]
+#[cfg(all(feature = "crypto-dependencies", feature = "experimental"))]
 pub struct SeedStreamFixedKeyAes128 {
     cipher: Aes128,
     base_block: Block,
     length_consumed: u64,
 }
 
-#[cfg(feature = "experimental")]
+#[cfg(all(feature = "crypto-dependencies", feature = "experimental"))]
 impl SeedStream for SeedStreamFixedKeyAes128 {
     fn fill(&mut self, buf: &mut [u8]) {
         let next_length_consumed = self.length_consumed + u64::try_from(buf.len()).unwrap();
@@ -340,7 +340,7 @@ impl SeedStream for SeedStreamFixedKeyAes128 {
     }
 }
 
-#[cfg(feature = "experimental")]
+#[cfg(all(feature = "crypto-dependencies", feature = "experimental"))]
 impl SeedStreamFixedKeyAes128 {
     fn hash_block(&self, block: &mut Block) {
         let sigma = Block::from([

--- a/src/vdaf/prg.rs
+++ b/src/vdaf/prg.rs
@@ -133,6 +133,7 @@ pub trait Prg<const SEED_SIZE: usize>: Clone + Debug {
 /// [draft-irtf-cfrg-vdaf-04]: https://datatracker.ietf.org/doc/draft-irtf-cfrg-vdaf/04/
 #[derive(Clone, Debug)]
 #[cfg(feature = "crypto-dependencies")]
+#[cfg_attr(docsrs, doc(cfg(feature = "crypto-dependencies")))]
 #[deprecated(since = "0.11.0", note = "Superseded by PrgSha3")]
 pub struct PrgAes128(Cmac<Aes128>);
 
@@ -161,6 +162,7 @@ impl Prg<16> for PrgAes128 {
 
 /// The key stream produced by AES128 in CTR-mode.
 #[cfg(feature = "crypto-dependencies")]
+#[cfg_attr(docsrs, doc(cfg(feature = "crypto-dependencies")))]
 pub struct SeedStreamAes128(Ctr64BE<Aes128>);
 
 #[cfg(feature = "crypto-dependencies")]
@@ -195,6 +197,7 @@ impl Debug for SeedStreamAes128 {
 /// [draft-irtf-cfrg-vdaf-05]: https://datatracker.ietf.org/doc/draft-irtf-cfrg-vdaf/05/
 #[derive(Clone, Debug)]
 #[cfg(feature = "crypto-dependencies")]
+#[cfg_attr(docsrs, doc(cfg(feature = "crypto-dependencies")))]
 pub struct PrgSha3(CShake128);
 
 #[cfg(feature = "crypto-dependencies")]
@@ -218,6 +221,7 @@ impl Prg<16> for PrgSha3 {
 
 /// The key stream produced by the cSHAKE128 XOF.
 #[cfg(feature = "crypto-dependencies")]
+#[cfg_attr(docsrs, doc(cfg(feature = "crypto-dependencies")))]
 pub struct SeedStreamSha3(CShake128Reader);
 
 #[cfg(feature = "crypto-dependencies")]
@@ -237,6 +241,10 @@ impl SeedStream for SeedStreamSha3 {
 /// Factory to produce multiple [`PrgFixedKeyAes128`] instances with the same fixed key and
 /// different seeds.
 #[cfg(all(feature = "crypto-dependencies", feature = "experimental"))]
+#[cfg_attr(
+    docsrs,
+    doc(cfg(all(feature = "crypto-dependencies", feature = "experimental")))
+)]
 pub struct PrgFixedKeyAes128Key {
     cipher: Aes128,
 }
@@ -275,6 +283,10 @@ impl PrgFixedKeyAes128Key {
 /// [draft-irtf-cfrg-vdaf-05]: https://datatracker.ietf.org/doc/draft-irtf-cfrg-vdaf/05/
 #[derive(Clone, Debug)]
 #[cfg(all(feature = "crypto-dependencies", feature = "experimental"))]
+#[cfg_attr(
+    docsrs,
+    doc(cfg(all(feature = "crypto-dependencies", feature = "experimental")))
+)]
 pub struct PrgFixedKeyAes128 {
     fixed_key_deriver: CShake128,
     base_block: Block,
@@ -308,6 +320,10 @@ impl Prg<16> for PrgFixedKeyAes128 {
 
 /// Seed stream for [`PrgFixedKeyAes128`].
 #[cfg(all(feature = "crypto-dependencies", feature = "experimental"))]
+#[cfg_attr(
+    docsrs,
+    doc(cfg(all(feature = "crypto-dependencies", feature = "experimental")))
+)]
 pub struct SeedStreamFixedKeyAes128 {
     cipher: Aes128,
     base_block: Block,

--- a/src/vdaf/prio3.rs
+++ b/src/vdaf/prio3.rs
@@ -33,7 +33,7 @@ use crate::codec::{CodecError, Decode, Encode, ParameterizedDecode};
 use crate::field::{decode_fieldvec, FftFriendlyFieldElement, FieldElement};
 #[cfg(feature = "crypto-dependencies")]
 use crate::field::{Field128, Field64};
-#[cfg(feature = "multithreaded")]
+#[cfg(all(feature = "crypto-dependencies", feature = "multithreaded"))]
 use crate::flp::gadgets::ParallelSumMultithreaded;
 #[cfg(all(feature = "crypto-dependencies", feature = "experimental"))]
 use crate::flp::gadgets::PolyEval;

--- a/src/vdaf/prio3.rs
+++ b/src/vdaf/prio3.rs
@@ -70,6 +70,7 @@ const DST_JOINT_RAND_PART: u16 = 7;
 
 /// The count type. Each measurement is an integer in `[0,2)` and the aggregate result is the sum.
 #[cfg(feature = "crypto-dependencies")]
+#[cfg_attr(docsrs, doc(cfg(feature = "crypto-dependencies")))]
 pub type Prio3Count = Prio3<Count<Field64>, PrgSha3, 16>;
 
 #[cfg(feature = "crypto-dependencies")]
@@ -83,6 +84,7 @@ impl Prio3Count {
 /// The count-vector type. Each measurement is a vector of integers in `[0,2^bits)` and the
 /// aggregate is the element-wise sum.
 #[cfg(feature = "crypto-dependencies")]
+#[cfg_attr(docsrs, doc(cfg(feature = "crypto-dependencies")))]
 pub type Prio3SumVec =
     Prio3<SumVec<Field128, ParallelSum<Field128, BlindPolyEval<Field128>>>, PrgSha3, 16>;
 
@@ -99,18 +101,18 @@ impl Prio3SumVec {
 /// Like [`Prio3SumVec`] except this type uses multithreading to improve sharding and preparation
 /// time. Note that the improvement is only noticeable for very large input lengths, e.g., 201 and
 /// up. (Your system's mileage may vary.)
-#[cfg(feature = "multithreaded")]
-#[cfg(feature = "crypto-dependencies")]
-#[cfg_attr(docsrs, doc(cfg(feature = "multithreaded")))]
+#[cfg(all(feature = "multithreaded", feature = "crypto-dependencies"))]
+#[cfg_attr(
+    docsrs,
+    doc(cfg(all(feature = "multithreaded", feature = "crypto-dependencies")))
+)]
 pub type Prio3SumVecMultithreaded = Prio3<
     SumVec<Field128, ParallelSumMultithreaded<Field128, BlindPolyEval<Field128>>>,
     PrgSha3,
     16,
 >;
 
-#[cfg(feature = "multithreaded")]
-#[cfg(feature = "crypto-dependencies")]
-#[cfg_attr(docsrs, doc(cfg(feature = "multithreaded")))]
+#[cfg(all(feature = "multithreaded", feature = "crypto-dependencies"))]
 impl Prio3SumVecMultithreaded {
     /// Construct an instance of Prio3SumVecMultithreaded with the given number of
     /// aggregators. `bits` defines the bit width of each summand of the measurement; `len` defines
@@ -127,6 +129,7 @@ impl Prio3SumVecMultithreaded {
 /// The sum type. Each measurement is an integer in `[0,2^bits)` for some `0 < bits < 64` and the
 /// aggregate is the sum.
 #[cfg(feature = "crypto-dependencies")]
+#[cfg_attr(docsrs, doc(cfg(feature = "crypto-dependencies")))]
 pub type Prio3Sum = Prio3<Sum<Field128>, PrgSha3, 16>;
 
 #[cfg(feature = "crypto-dependencies")]
@@ -157,7 +160,10 @@ impl Prio3Sum {
 /// conversion to the client. The model itself will have floating point parameters, so the output
 /// sum has that type as well.
 #[cfg(all(feature = "crypto-dependencies", feature = "experimental"))]
-#[cfg_attr(docsrs, doc(cfg(feature = "experimental")))]
+#[cfg_attr(
+    docsrs,
+    doc(cfg(all(feature = "crypto-dependencies", feature = "experimental")))
+)]
 pub type Prio3FixedPointBoundedL2VecSum<Fx> = Prio3<
     FixedPointBoundedL2VecSum<
         Fx,
@@ -170,7 +176,6 @@ pub type Prio3FixedPointBoundedL2VecSum<Fx> = Prio3<
 >;
 
 #[cfg(all(feature = "crypto-dependencies", feature = "experimental"))]
-#[cfg_attr(docsrs, doc(cfg(feature = "experimental")))]
 impl<Fx: Fixed + CompatibleFloat<Field128>> Prio3FixedPointBoundedL2VecSum<Fx> {
     /// Construct an instance of this VDAF with the given number of aggregators and number of
     /// vector entries.
@@ -191,8 +196,14 @@ impl<Fx: Fixed + CompatibleFloat<Field128>> Prio3FixedPointBoundedL2VecSum<Fx> {
     feature = "experimental",
     feature = "multithreaded"
 ))]
-#[cfg_attr(docsrs, doc(cfg(feature = "experimental")))]
-#[cfg_attr(docsrs, doc(cfg(feature = "multithreaded")))]
+#[cfg_attr(
+    docsrs,
+    doc(cfg(all(
+        feature = "crypto-dependencies",
+        feature = "experimental",
+        feature = "multithreaded"
+    )))
+)]
 pub type Prio3FixedPointBoundedL2VecSumMultithreaded<Fx> = Prio3<
     FixedPointBoundedL2VecSum<
         Fx,
@@ -209,8 +220,6 @@ pub type Prio3FixedPointBoundedL2VecSumMultithreaded<Fx> = Prio3<
     feature = "experimental",
     feature = "multithreaded"
 ))]
-#[cfg_attr(docsrs, doc(cfg(feature = "experimental")))]
-#[cfg_attr(docsrs, doc(cfg(feature = "multithreaded")))]
 impl<Fx: Fixed + CompatibleFloat<Field128>> Prio3FixedPointBoundedL2VecSumMultithreaded<Fx> {
     /// Construct an instance of this VDAF with the given number of aggregators and number of
     /// vector entries.
@@ -226,6 +235,7 @@ impl<Fx: Fixed + CompatibleFloat<Field128>> Prio3FixedPointBoundedL2VecSumMultit
 /// The histogram type. Each measurement is an unsigned integer and the result is a histogram
 /// representation of the distribution. The bucket boundaries are fixed in advance.
 #[cfg(feature = "crypto-dependencies")]
+#[cfg_attr(docsrs, doc(cfg(feature = "crypto-dependencies")))]
 pub type Prio3Histogram = Prio3<Histogram<Field128>, PrgSha3, 16>;
 
 #[cfg(feature = "crypto-dependencies")]
@@ -242,6 +252,7 @@ impl Prio3Histogram {
 /// The average type. Each measurement is an integer in `[0,2^bits)` for some `0 < bits < 64` and
 /// the aggregate is the arithmetic average.
 #[cfg(feature = "crypto-dependencies")]
+#[cfg_attr(docsrs, doc(cfg(feature = "crypto-dependencies")))]
 pub type Prio3Average = Prio3<Average<Field128>, PrgSha3, 16>;
 
 #[cfg(feature = "crypto-dependencies")]
@@ -559,6 +570,7 @@ where
     /// Shard measurement with constant randomness of repeated bytes.
     /// This method is not secure. It is used for running test vectors for Prio3.
     #[cfg(feature = "test-util")]
+    #[doc(hidden)]
     #[allow(clippy::type_complexity)]
     pub fn test_vec_shard<const N: usize>(
         &self,


### PR DESCRIPTION
This makes some conditional compilation changes to fix building with unusual combinations of feature flags. I made `prio2` depend on `crypto-dependencies`, and fixed up some errors building with `experimental` but not `crypto-dependencies`, `multithreaded` but not `crypto-dependencies`, etc. I also updated `#[doc(cfg)]` attributes for public items that are conditionally available. With these changes, [`cargo check-all-features`](https://github.com/frewsxcv/cargo-all-features/) now passes.