### PR TITLE
CI: Build benchmarks without optimization

### DIFF
--- a/.github/workflows/ci-build.yml
+++ b/.github/workflows/ci-build.yml
@@ -84,4 +84,4 @@ jobs:
     - name: Run tests
       run: cargo test --verbose ${{ matrix.features }}
     - name: Build benchmarks
-      run: cargo bench --no-run ${{ matrix.features }}
+      run: cargo bench --no-run ${{ matrix.features }} --profile=dev


### PR DESCRIPTION
Building benchmarks is currently one of the slower steps in our CI. We can speed this up by building them with the dev profile, instead of release.