### PR TITLE
Exclude the supply-chain directory from the published package

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,6 +3,7 @@ name = "prio"
 version = "0.12.0"
 authors = ["Josh Aas <jaas@kflag.net>", "Tim Geoghegan <timg@letsencrypt.org>", "Christopher Patton <cpatton@cloudflare.com", "Karl Tarbe <tarbe@apple.com>"]
 edition = "2021"
+exclude = ["/supply-chain"]
 description = "Implementation of the Prio aggregation system core: https://crypto.stanford.edu/prio/"
 license = "MPL-2.0"
 repository = "https://github.com/divviup/libprio-rs"


### PR DESCRIPTION
At present, vendoring libprio into Firefox causes us to end up with a duplicated copy of certain Firefox audits (via `imports.lock`) which is harmless but a little confusing.