### PR TITLE
Remove unused Copy bound in IdpfPublicShare

### DIFF
--- a/src/idpf.rs
+++ b/src/idpf.rs
@@ -620,8 +620,8 @@ where
 
 impl<VI, VL> ParameterizedDecode<usize> for IdpfPublicShare<VI, VL>
 where
-    VI: Decode + Copy,
-    VL: Decode + Copy,
+    VI: Decode,
+    VL: Decode,
 {
     fn decode_with_param(bits: &usize, bytes: &mut Cursor<&[u8]>) -> Result<Self, CodecError> {
         let packed_control_len = (bits + 3) / 4;


### PR DESCRIPTION
This removes an unused `Copy` bound on the `IdpfValue` types in one trait implementation block on `IdpfPublicShare`.

cc @cjpatton