### PR TITLE
Add wildcard audit for divviup-github-automation

### DIFF
--- a/supply-chain/audits.toml
+++ b/supply-chain/audits.toml
@@ -8,6 +8,13 @@ user-id = 101233
 start = "2020-09-28"
 end = "2024-03-23"
 
+[[wildcard-audits.prio]]
+who = "David Cook <dcook@divviup.org>"
+criteria = "safe-to-deploy"
+user-id = 213776
+start = "2020-09-28"
+end = "2024-03-23"
+
 [[audits.aes-gcm]]
 who = "Tim Geoghegan <timg@letsencrypt.org>"
 criteria = "safe-to-deploy"


### PR DESCRIPTION
We are planning to switch which user releases this crate. This PR records an additional wildcard audit with the user ID for `divviup-github-automation`.