### PR TITLE
Import cargo-vet audits from main branch on release/0.12

### DIFF
--- a/supply-chain/config.toml
+++ b/supply-chain/config.toml
@@ -7,6 +7,9 @@ version = "0.7"
 [imports.bytecode-alliance]
 url = "https://raw.githubusercontent.com/bytecodealliance/wasmtime/main/supply-chain/audits.toml"
 
+[imports.divviup]
+url = "https://raw.githubusercontent.com/divviup/libprio-rs/main/supply-chain/audits.toml"
+
 [imports.embark-studios]
 url = "https://raw.githubusercontent.com/EmbarkStudios/rust-ecosystem/main/audits.toml"
 

--- a/supply-chain/imports.lock
+++ b/supply-chain/imports.lock
@@ -335,6 +335,8 @@ criteria = "safe-to-deploy"
 version = "0.48.0"
 notes = "This is a Windows API bindings library maintained by Microsoft themselves."
 
+[audits.divviup.audits]
+
 [[audits.embark-studios.audits.epaint]]
 who = "Johan Andersson <opensource@embark-studios.com>"
 criteria = "safe-to-deploy"


### PR DESCRIPTION
This allows importing new audits on the main branch onto this new release branch, going forward.