### PR TITLE
API changes for Aggregator-side differential privacy

### DIFF
--- a/src/dp.rs
+++ b/src/dp.rs
@@ -1,0 +1,68 @@
+// SPDX-License-Identifier: MPL-2.0
+
+//! Differential privacy (DP) primitives.
+use std::fmt::Debug;
+
+/// Positive rational number to represent DP and noise distribution parameters in protocol messages
+/// and manipulate them without rounding errors.
+#[derive(Clone, Debug)]
+pub struct Rational {
+    /// Numerator.
+    pub numerator: u32,
+    /// Denominator.
+    pub denominator: u32,
+}
+
+/// Marker trait for differential privacy budgets (regardless of the specific accounting method).
+pub trait DifferentialPrivacyBudget {}
+
+/// Marker trait for differential privacy scalar noise distributions.
+pub trait DifferentialPrivacyDistribution {}
+
+/// Zero-concentrated differential privacy (zCDP) budget as defined in [[BS16]].
+///
+/// [BS16]: https://arxiv.org/pdf/1605.02065.pdf
+pub struct ZeroConcentratedDifferentialPrivacyBudget {
+    /// Parameter `epsilon`, using the notation from [[CKS20]] where `rho = (epsilon**2)/2`
+    /// for a `rho`-zCDP budget.
+    ///
+    /// [CKS20]: https://arxiv.org/pdf/2004.00010.pdf
+    pub epsilon: Rational,
+}
+
+impl DifferentialPrivacyBudget for ZeroConcentratedDifferentialPrivacyBudget {}
+
+/// Zero-mean Discrete Gaussian noise distribution.
+///
+/// The distribution is defined over the integers, represented by arbitrary-precision integers.
+#[derive(Clone, Debug)]
+pub struct DiscreteGaussian {
+    /// Standard deviation of the distribution.
+    pub sigma: Rational,
+}
+
+impl DifferentialPrivacyDistribution for DiscreteGaussian {}
+
+/// Strategy to make aggregate shares differentially private, e.g. by adding noise from a specific
+/// type of distribution instantiated with a given DP budget
+pub trait DifferentialPrivacyStrategy {}
+
+/// A zCDP budget used to create a Discrete Gaussian distribution
+pub struct ZCdpDiscreteGaussian {
+    budget: ZeroConcentratedDifferentialPrivacyBudget,
+}
+
+impl DifferentialPrivacyStrategy for ZCdpDiscreteGaussian {}
+
+impl ZCdpDiscreteGaussian {
+    /// Creates a new Discrete Gaussian by following Theorem 4 from [[CKS20]]
+    ///
+    /// [CKS20]: https://arxiv.org/pdf/2004.00010.pdf
+    pub fn create_distribution(&self, sensitivity: Rational) -> DiscreteGaussian {
+        let sigma = Rational {
+            numerator: self.budget.epsilon.denominator * sensitivity.numerator,
+            denominator: self.budget.epsilon.numerator * sensitivity.denominator,
+        };
+        DiscreteGaussian { sigma }
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -51,3 +51,6 @@ pub mod test_vector;
 #[cfg_attr(docsrs, doc(cfg(feature = "prio2")))]
 pub mod util;
 pub mod vdaf;
+
+#[cfg(feature = "experimental")]
+pub mod dp;

--- a/src/vdaf.rs
+++ b/src/vdaf.rs
@@ -5,6 +5,8 @@
 //!
 //! [draft-irtf-cfrg-vdaf-06]: https://datatracker.ietf.org/doc/draft-irtf-cfrg-vdaf/06/
 
+#[cfg(feature = "experimental")]
+use crate::dp::DifferentialPrivacyStrategy;
 #[cfg(all(feature = "crypto-dependencies", feature = "experimental"))]
 use crate::idpf::IdpfError;
 use crate::{
@@ -248,6 +250,25 @@ pub trait Aggregator<const VERIFY_KEY_SIZE: usize, const NONCE_SIZE: usize>: Vda
         agg_param: &Self::AggregationParam,
         output_shares: M,
     ) -> Result<Self::AggregateShare, VdafError>;
+}
+
+/// Aggregator that implements differential privacy with Aggregator-side noise addition.
+#[cfg(feature = "experimental")]
+pub trait AggregatorWithNoise<
+    const VERIFY_KEY_SIZE: usize,
+    const NONCE_SIZE: usize,
+    DPStrategy: DifferentialPrivacyStrategy,
+>: Aggregator<VERIFY_KEY_SIZE, NONCE_SIZE>
+{
+    /// Adds noise to an aggregate share such that the aggregate result is differentially private
+    /// as long as one Aggregator is honest.
+    fn add_noise_to_agg_share(
+        &self,
+        dp_strategy: &DPStrategy,
+        agg_param: &Self::AggregationParam,
+        agg_share: &mut Self::AggregateShare,
+        num_measurements: usize,
+    ) -> Result<(), VdafError>;
 }
 
 /// The Collector's role in the execution of a VDAF.


### PR DESCRIPTION
As discussed yesterday, this PR makes some API changes required to add DP on aggregated shares (aka Server-DP, following the terminology from DPrio (https://petsymposium.org/popets/2023/popets-2023-0086.php). Once we settle on an API we can tackle DP implementations for specific VDAFs, such as https://github.com/divviup/libprio-rs/pull/578.

cc/ @cjpatton 