### PR TITLE
CI: Replace features matrix with cargo-all-features

### DIFF
--- a/.github/workflows/ci-build.yml
+++ b/.github/workflows/ci-build.yml
@@ -46,26 +46,14 @@ jobs:
   build-crate:
     strategy:
       matrix:
-        features: [
-          "--no-default-features",
-          "--all-features",
-          "--features=default",
-          "--features=test-util",
-          "--features=multithreaded",
-          "--features=test-util,multithreaded",
-          "--features=prio2",
-          "--features=prio2,test-util",
-          "--features=prio2,multithreaded",
-          "--features=prio2,test-util,multithreaded",
-          "--features=experimental",
-          "--features=experimental,multithreaded",
-        ]
         rust-toolchain: [
           # MSRV from Cargo.toml
           "1.64",
           "stable",
         ]
     runs-on: ubuntu-latest
+    env:
+      CARGO_ALL_FEATURES_VERSION: 1.9.0
     steps:
     - uses: actions/checkout@v3
     - name: Install Rust toolchain
@@ -73,15 +61,34 @@ jobs:
       with:
         toolchain: ${{ matrix.rust-toolchain }}
         components: clippy, rustfmt
+    - name: Cache cargo-all-features
+      uses: actions/cache@v3
+      with:
+        key: cargo-all-features-bins-${{ env.CARGO_ALL_FEATURES_VERSION }}-rust-${{ matrix.rust-toolchain }}
+        path: |
+          ${{ runner.tool_cache }}/cargo-build-all-features
+          ${{ runner.tool_cache }}/cargo-check-all-features
+          ${{ runner.tool_cache }}/cargo-test-all-features
+    - name: Add the tool cache directory to the search path
+      run: echo "${{ runner.tool_cache }}/cargo-all-features/bin/" >> $GITHUB_PATH
+    - name: Ensure that the tool cache is populated with the cargo-all-features binaries
+      run: cargo install --root ${{ runner.tool_cache }}/cargo-all-features --version ${{ env.CARGO_ALL_FEATURES_VERSION }} cargo-all-features
+
     - name: Lint
       run: |
         cargo fmt --message-format human -- --check
         bash -c '! git grep "[I][P][D][F]"'
+    - name: Check
+      run: cargo check-all-features --workspace --all-targets
     - name: Clippy
-      run: cargo clippy --workspace --all-targets ${{ matrix.features }}
+      run: cargo clippy --workspace --all-targets
+    - name: Clippy (all features)
+      run: cargo clippy --workspace --all-targets --all-features
     - name: Build crate
-      run: cargo build --verbose --package prio ${{ matrix.features }}
+      run: cargo build-all-features --verbose --package prio
     - name: Run tests
-      run: cargo test --verbose ${{ matrix.features }}
+      run: cargo test-all-features --verbose
     - name: Build benchmarks
-      run: cargo bench --no-run ${{ matrix.features }} --profile=dev
+      run: cargo bench --no-run --profile=dev
+    - name: Build benchmarks (all features)
+      run: cargo bench --no-run --profile=dev --all-features


### PR DESCRIPTION
This replaces our features matrix at the GitHub Actions level with `cargo-all-features`.

Positives:

* Automatically computes power set of Cargo features, so we won't miss combinations or forget to update the matrix.
* Reduces GHA-level parallelism, to play nice with rate limits. (Fixes #617)
* Compilations with different feature sets reuse almost all compiled artifacts.

Negatives:

* `cargo-all-features` does not yet support `clippy` or `bench`. This is mitigated by running each with the default feature set and `--all-features`.
* CI runtime is more sensitive to the test suite's runtime, since executions happen serially. Fortunately, it's pretty fast as-is.