### PR TITLE
`Prio2`: Remove proof validation state

### DIFF
--- a/benches/cycle_counts.rs
+++ b/benches/cycle_counts.rs
@@ -77,10 +77,8 @@ fn prio2_prove_1000() -> Vec<FieldPrio2> {
 #[cfg(feature = "prio2")]
 fn prio2_prove_and_verify(size: usize) -> VerificationMessage<FieldPrio2> {
     use prio::{
-        benchmarked::benchmarked_v2_prove,
-        client::Client,
-        encrypt::PublicKey,
-        server::{generate_verification_message, ValidationMemory},
+        benchmarked::benchmarked_v2_prove, client::Client, encrypt::PublicKey,
+        server::generate_verification_message,
     };
 
     let input = vec![FieldPrio2::zero(); size];
@@ -88,16 +86,8 @@ fn prio2_prove_and_verify(size: usize) -> VerificationMessage<FieldPrio2> {
     let pk2 = PublicKey::from_base64(PRIO2_PUBKEY2).unwrap();
     let mut client: Client<FieldPrio2> = Client::new(input.len(), pk1, pk2).unwrap();
     let input_and_proof = benchmarked_v2_prove(&input, &mut client);
-    let mut validator = ValidationMemory::new(input.len());
     let eval_at = random_vector(1).unwrap()[0];
-    generate_verification_message(
-        input.len(),
-        eval_at,
-        &black_box(input_and_proof),
-        true,
-        &mut validator,
-    )
-    .unwrap()
+    generate_verification_message(input.len(), eval_at, &black_box(input_and_proof), true).unwrap()
 }
 
 #[cfg(feature = "prio2")]

--- a/src/polynomial.rs
+++ b/src/polynomial.rs
@@ -3,6 +3,8 @@
 
 //! Functions for polynomial interpolation and evaluation
 
+#[cfg(feature = "prio2")]
+use crate::fft::{discrete_fourier_transform, discrete_fourier_transform_inv_finish};
 use crate::field::FftFriendlyFieldElement;
 
 use std::convert::TryFrom;
@@ -204,14 +206,15 @@ pub fn poly_mul<F: FftFriendlyFieldElement>(p: &[F], q: &[F]) -> Vec<F> {
 }
 
 #[cfg(feature = "prio2")]
+#[inline]
 pub fn poly_interpret_eval<F: FftFriendlyFieldElement>(
     points: &[F],
-    roots: &[F],
     eval_at: F,
     tmp_coeffs: &mut [F],
-    fft_memory: &mut PolyFFTTempMemory<F>,
 ) -> F {
-    poly_fft(tmp_coeffs, points, roots, points.len(), true, fft_memory);
+    let size_inv = F::from(F::Integer::try_from(points.len()).unwrap()).inv();
+    discrete_fourier_transform(tmp_coeffs, points, points.len()).unwrap();
+    discrete_fourier_transform_inv_finish(tmp_coeffs, points.len(), size_inv);
     poly_eval(&tmp_coeffs[..points.len()], eval_at)
 }
 

--- a/src/vdaf/prio2.rs
+++ b/src/vdaf/prio2.rs
@@ -74,13 +74,11 @@ impl Prio2 {
             Share::Helper(_) => expanded_data.as_ref().unwrap(),
         };
 
-        let mut mem = v2_server::ValidationMemory::new(self.input_len);
         let verifier_share = v2_server::generate_verification_message(
             self.input_len,
             query_rand,
             data, // Combined input and proof shares
             is_leader,
-            &mut mem,
         )
         .map_err(|e| VdafError::Uncategorized(e.to_string()))?;
 


### PR DESCRIPTION
The current implementation of `Prio2` constructs an object called `ValidationMemory` that includes the memory for the recursive FFT algorithm and pre-computed roots of unity used for FFT and rejecting query randomnesses `eval_at`. (It's not secure to query the proof at a root of unity.) This memory can be removed by making the following changes:

* Use the iterative FFT algorithm
* To do the root-of-unity check, check if `eval_at`, when raised to the power of the proof polynomial length, is equal to `1`. If not, then `eval_at` is not a root of unity.

According to the microbenchmarks, removing this memory and making these changes results in a 20% speed up for dimension = 1,000, 16% for 10,000, and 10% for 100,000. Smaller inputs fair even better.