### PR TITLE
Implement rand_core traits on SeedStreamSha3

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -902,6 +902,7 @@ dependencies = [
  "once_cell",
  "prio",
  "rand 0.8.5",
+ "rand_core 0.6.4",
  "rayon",
  "serde",
  "serde_json",
@@ -993,7 +994,7 @@ checksum = "34af8d1a0e25924bc5b7c43c079c942339d8f0a8b57c39049bef581b46327404"
 dependencies = [
  "libc",
  "rand_chacha 0.3.1",
- "rand_core 0.6.3",
+ "rand_core 0.6.4",
 ]
 
 [[package]]
@@ -1013,7 +1014,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e6c10a63a0fa32252be49d21e7709d4d4baf8d231c2dbce1eaa8141b9b127d88"
 dependencies = [
  "ppv-lite86",
- "rand_core 0.6.3",
+ "rand_core 0.6.4",
 ]
 
 [[package]]
@@ -1027,9 +1028,9 @@ dependencies = [
 
 [[package]]
 name = "rand_core"
-version = "0.6.3"
+version = "0.6.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d34f1408f55294453790c48b2f1ebbb1c5b4b7563eb1f418bcfcfdbb06ebb4e7"
+checksum = "ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c"
 dependencies = [
  "getrandom 0.2.10",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,6 +21,7 @@ fiat-crypto = { version = "0.1.20", optional = true }
 fixed = { version = "1.23", optional = true }
 getrandom = { version = "0.2.10", features = ["std"] }
 hmac = { version = "0.12.1", optional = true }
+rand_core = "0.6.4"
 rayon = { version = "1.7.0", optional = true }
 serde = { version = "1.0", features = ["derive"] }
 sha2 = { version = "0.10.7", optional = true }

--- a/src/vdaf/prg.rs
+++ b/src/vdaf/prg.rs
@@ -52,21 +52,9 @@ impl<const SEED_SIZE: usize> Seed<SEED_SIZE> {
     }
 }
 
-impl<const SEED_SIZE: usize> Default for Seed<SEED_SIZE> {
-    fn default() -> Self {
-        Self([0u8; SEED_SIZE])
-    }
-}
-
 impl<const SEED_SIZE: usize> AsRef<[u8; SEED_SIZE]> for Seed<SEED_SIZE> {
     fn as_ref(&self) -> &[u8; SEED_SIZE] {
         &self.0
-    }
-}
-
-impl<const SEED_SIZE: usize> AsMut<[u8]> for Seed<SEED_SIZE> {
-    fn as_mut(&mut self) -> &mut [u8] {
-        self.0.as_mut()
     }
 }
 
@@ -268,10 +256,10 @@ impl RngCore for SeedStreamSha3 {
 /// A `rand`-compatible interface to construct PrgSha3 seed streams, with the domain separation tag
 /// and binder string both fixed as the empty string.
 impl SeedableRng for SeedStreamSha3 {
-    type Seed = Seed<16>;
+    type Seed = [u8; 16];
 
     fn from_seed(seed: Self::Seed) -> Self {
-        PrgSha3::init(&seed.0, b"").into_seed_stream()
+        PrgSha3::init(&seed, b"").into_seed_stream()
     }
 }
 

--- a/supply-chain/audits.toml
+++ b/supply-chain/audits.toml
@@ -326,6 +326,11 @@ delta = "0.3.0 -> 0.2.2"
 
 [[audits.rand_core]]
 who = "David Cook <dcook@divviup.org>"
+criteria = "safe-to-deploy"
+version = "0.6.3"
+
+[[audits.rand_core]]
+who = "David Cook <dcook@divviup.org>"
 criteria = "safe-to-run"
 delta = "0.6.1 -> 0.5.1"
 

--- a/supply-chain/config.toml
+++ b/supply-chain/config.toml
@@ -207,10 +207,6 @@ criteria = "safe-to-run"
 version = "0.8.5"
 criteria = "safe-to-run"
 
-[[exemptions.rand_core]]
-version = "0.6.3"
-criteria = "safe-to-run"
-
 [[exemptions.rand_distr]]
 version = "0.2.2"
 criteria = "safe-to-run"

--- a/supply-chain/imports.lock
+++ b/supply-chain/imports.lock
@@ -460,6 +460,11 @@ criteria = "safe-to-deploy"
 version = "0.2.15"
 notes = "All code written or reviewed by Josh Stone."
 
+[[audits.firefox.audits.rand_core]]
+who = "Mike Hommey <mh+mozilla@glandium.org>"
+criteria = "safe-to-deploy"
+delta = "0.6.3 -> 0.6.4"
+
 [[audits.firefox.audits.rayon]]
 who = "Josh Stone <jistone@redhat.com>"
 criteria = "safe-to-deploy"


### PR DESCRIPTION
This implements `RngCore` and `SeedableRng` from `rand_core` on `SeedStreamSha3`. See previous discussion on #578; this partially addresses #644. I made the `Default for Seed<SEED_SIZE>` implementation return a zeroed array, as we expect users to call this, mutably dereference the new seed, and then fill it with random bytes.