### PR TITLE
Performance optimizations for FLP

### DIFF
--- a/benches/speed_tests.rs
+++ b/benches/speed_tests.rs
@@ -62,7 +62,7 @@ fn poly_mul(c: &mut Criterion) {
             let m = (size + 1).next_power_of_two();
             let mut g: Mul<F> = Mul::new(*size);
             let mut outp = vec![F::zero(); 2 * m];
-            let inp = vec![random_vector(m).unwrap(); 2];
+            let inp = random_vector(2 * m).unwrap();
 
             b.iter(|| {
                 benchmarked_gadget_mul_call_poly_fft(&mut g, &mut outp, &inp).unwrap();
@@ -73,7 +73,7 @@ fn poly_mul(c: &mut Criterion) {
             let m = (size + 1).next_power_of_two();
             let mut g: Mul<F> = Mul::new(*size);
             let mut outp = vec![F::zero(); 2 * m];
-            let inp = vec![random_vector(m).unwrap(); 2];
+            let inp = random_vector(2 * m).unwrap();
 
             b.iter(|| {
                 benchmarked_gadget_mul_call_poly_direct(&mut g, &mut outp, &inp).unwrap();
@@ -176,8 +176,10 @@ fn prio3(c: &mut Criterion) {
     }
     group.finish();
 
+    let input_lens = [10, 100, 1_000, 10_000, 100_000];
+
     let mut group = c.benchmark_group("prio3sumvec_shard");
-    for input_len in [10, 100, 1_000] {
+    for input_len in input_lens {
         group.bench_with_input(
             BenchmarkId::new("serial", input_len),
             &input_len,
@@ -194,7 +196,7 @@ fn prio3(c: &mut Criterion) {
 
     #[cfg(feature = "multithreaded")]
     {
-        for input_len in [10, 100, 1_000] {
+        for input_len in input_lens {
             group.bench_with_input(
                 BenchmarkId::new("parallel", input_len),
                 &input_len,
@@ -212,7 +214,7 @@ fn prio3(c: &mut Criterion) {
     group.finish();
 
     let mut group = c.benchmark_group("prio3sumvec_prepare_init");
-    for input_len in [10, 100, 1_000] {
+    for input_len in input_lens {
         group.bench_with_input(
             BenchmarkId::new("serial", input_len),
             &input_len,
@@ -234,7 +236,7 @@ fn prio3(c: &mut Criterion) {
 
     #[cfg(feature = "multithreaded")]
     {
-        for input_len in [10, 100, 1_000] {
+        for input_len in input_lens {
             group.bench_with_input(
                 BenchmarkId::new("parallel", input_len),
                 &input_len,
@@ -264,7 +266,7 @@ fn prio3(c: &mut Criterion) {
     group.finish();
 
     let mut group = c.benchmark_group("prio3histogram_shard");
-    for input_len in [10, 100, 1_000, 10_000, 100_000] {
+    for input_len in input_lens {
         if input_len >= 100_000 {
             group.measurement_time(Duration::from_secs(15));
         }
@@ -282,7 +284,7 @@ fn prio3(c: &mut Criterion) {
     group.finish();
 
     let mut group = c.benchmark_group("prio3histogram_prepare_init");
-    for input_len in [10, 100, 1_000, 10_000, 100_000] {
+    for input_len in input_lens {
         if input_len >= 100_000 {
             group.measurement_time(Duration::from_secs(15));
         }

--- a/src/benchmarked.rs
+++ b/src/benchmarked.rs
@@ -34,7 +34,7 @@ pub fn benchmarked_recursive_fft<F: FftFriendlyFieldElement>(outp: &mut [F], inp
 pub fn benchmarked_gadget_mul_call_poly_fft<F: FftFriendlyFieldElement>(
     g: &mut Mul<F>,
     outp: &mut [F],
-    inp: &[Vec<F>],
+    inp: &[F],
 ) -> Result<(), FlpError> {
     g.call_poly_fft(outp, inp)
 }
@@ -44,7 +44,7 @@ pub fn benchmarked_gadget_mul_call_poly_fft<F: FftFriendlyFieldElement>(
 pub fn benchmarked_gadget_mul_call_poly_direct<F: FftFriendlyFieldElement>(
     g: &mut Mul<F>,
     outp: &mut [F],
-    inp: &[Vec<F>],
+    inp: &[F],
 ) -> Result<(), FlpError> {
     g.call_poly_direct(outp, inp)
 }

--- a/src/fft.rs
+++ b/src/fft.rs
@@ -33,7 +33,7 @@ pub fn discrete_fourier_transform<F: FftFriendlyFieldElement>(
     inp: &[F],
     size: usize,
 ) -> Result<(), FftError> {
-    multi_discrete_fourier_transform(&mut [outp], &[inp], size)
+    multi_discrete_fourier_transform(outp, &[inp], size)
 }
 
 /// For each `i in 0..inp.len()`, set `outp[i]` to the DFT of `inp[i]`.
@@ -45,12 +45,8 @@ pub fn discrete_fourier_transform<F: FftFriendlyFieldElement>(
 /// Assumpes that `outp.len() == inp.len()` and, for each `i in 0..inp.len()`, `outp[i].len() ==
 /// inp[i].len()`.
 #[allow(clippy::many_single_char_names)]
-pub fn multi_discrete_fourier_transform<
-    F: FftFriendlyFieldElement,
-    In: AsRef<[F]>,
-    Out: AsMut<[F]>,
->(
-    outp: &mut [Out],
+pub fn multi_discrete_fourier_transform<F: FftFriendlyFieldElement, In: AsRef<[F]>>(
+    outp: &mut [F],
     inp: &[In],
     size: usize,
 ) -> Result<(), FftError> {
@@ -70,7 +66,7 @@ pub fn multi_discrete_fourier_transform<
         for (inp, outp) in inp
             .iter()
             .map(AsRef::as_ref)
-            .zip(outp.iter_mut().map(AsMut::as_mut))
+            .zip(outp.chunks_exact_mut(size))
         {
             outp[i] = if j < inp.len() { inp[j] } else { F::zero() }
         }
@@ -84,7 +80,7 @@ pub fn multi_discrete_fourier_transform<
         for i in 0..y {
             for j in 0..(size / y) >> 1 {
                 let x = (1 << l) * j + i;
-                for outp in outp.iter_mut().map(AsMut::as_mut) {
+                for outp in outp.chunks_exact_mut(size) {
                     let u = outp[x];
                     let v = w * outp[x + y];
                     outp[x] = u + v;

--- a/src/flp/gadgets.rs
+++ b/src/flp/gadgets.rs
@@ -2,7 +2,10 @@
 
 //! A collection of gadgets.
 
-use crate::fft::{discrete_fourier_transform, discrete_fourier_transform_inv_finish};
+use crate::fft::{
+    discrete_fourier_transform, discrete_fourier_transform_inv_finish,
+    multi_discrete_fourier_transform,
+};
 use crate::field::FftFriendlyFieldElement;
 use crate::flp::{gadget_poly_len, wire_poly_len, FlpError, Gadget};
 use crate::polynomial::{poly_deg, poly_eval, poly_mul};
@@ -59,8 +62,7 @@ impl<F: FftFriendlyFieldElement> Mul<F> {
         let n = self.n;
         let mut buf = vec![F::zero(); n];
 
-        discrete_fourier_transform(&mut buf, &inp[0], n)?;
-        discrete_fourier_transform(outp, &inp[1], n)?;
+        multi_discrete_fourier_transform(&mut [buf.as_mut(), outp], &[&inp[0], &inp[1]], n)?;
 
         for i in 0..n {
             buf[i] *= outp[i];
@@ -266,10 +268,8 @@ impl<F: FftFriendlyFieldElement> BlindPolyEval<F> {
         let y = &inp[1];
 
         let mut x_vals = vec![F::zero(); n];
-        discrete_fourier_transform(&mut x_vals, x, n)?;
-
         let mut z_vals = vec![F::zero(); n];
-        discrete_fourier_transform(&mut z_vals, y, n)?;
+        multi_discrete_fourier_transform(&mut [&mut x_vals, &mut z_vals], &[x, y], n)?;
 
         let mut z = vec![F::zero(); n];
         let mut z_len = y.len();


### PR DESCRIPTION
There are a few features of the implementation I have felt for a while could be improved:
1. When constructing the "wire polynomials", we perform an identical FFT operation on each of the wires. Some of the logic in this operation is identical across all invocations.
2. We construct `Vec<Vec<F>>` to store the wire polynomials, where the length of the outer `Vec<_>` is equal to the arity of the gadget. This results in a lot of allocations for high-arity gadgets, like `ParallelSum`.
3. We allocate storage for the wire polynomials separately for each gadget. Since the underlying type is the same (`F`), it would be possible to reuse the same buffer.

This PR implements the following changes:
1. Add a SIMD-style FFT algorithm and deduplicate some of the arithmetic in proof/query generation
2. Modify the `prove()` / `query()` to operate on a flat buffer that is allocated once
3. **API-breaking**: Have `Gadget::call_poly()` operate on a flat buffer rather than a slice of `Vec<F>`'s

These changes result in marked performance improvement for the verifier (up to 20% for long inputs). However the prover did not improve very much, and in some cases regressed slightly (no more than 3%). Before merging this, I think we need to spend more time understanding how this changes the code that's generated. Specifically, are we *actually* reducing the number of allocations? Can valgrind tell us?