### PR TITLE
Clean up debug formatting of Prio3 - 0.10 backport

### DIFF
--- a/src/flp/types.rs
+++ b/src/flp/types.rs
@@ -7,13 +7,20 @@ use crate::flp::gadgets::{BlindPolyEval, Mul, ParallelSumGadget, PolyEval};
 use crate::flp::{FlpError, Gadget, Type};
 use crate::polynomial::poly_range_check;
 use std::convert::TryInto;
+use std::fmt::{self, Debug};
 use std::marker::PhantomData;
 
 /// The counter data type. Each measurement is `0` or `1` and the aggregate result is the sum of
 /// the measurements (i.e., the total number of `1s`).
-#[derive(Clone, Debug, PartialEq, Eq)]
+#[derive(Clone, PartialEq, Eq)]
 pub struct Count<F> {
     range_checker: Vec<F>,
+}
+
+impl<F> Debug for Count<F> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("Count").finish()
+    }
 }
 
 impl<F: FieldElement> Count<F> {
@@ -105,10 +112,16 @@ impl<F: FieldElement> Type for Count<F> {
 /// The validity circuit is based on the SIMD circuit construction of [[BBCG+19], Theorem 5.3].
 ///
 /// [BBCG+19]: https://ia.cr/2019/188
-#[derive(Clone, Debug, PartialEq, Eq)]
+#[derive(Clone, PartialEq, Eq)]
 pub struct Sum<F: FieldElement> {
     bits: usize,
     range_checker: Vec<F>,
+}
+
+impl<F: FieldElement> Debug for Sum<F> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("Sum").field("bits", &self.bits).finish()
+    }
 }
 
 impl<F: FieldElement> Sum<F> {
@@ -198,10 +211,16 @@ impl<F: FieldElement> Type for Sum<F> {
 
 /// The average type. Each measurement is an integer in `[0,2^bits)` for some `0 < bits < 64` and the
 /// aggregate is the arithmetic average.
-#[derive(Clone, Debug, PartialEq, Eq)]
+#[derive(Clone, PartialEq, Eq)]
 pub struct Average<F: FieldElement> {
     bits: usize,
     range_checker: Vec<F>,
+}
+
+impl<F: FieldElement> Debug for Average<F> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("Average").field("bits", &self.bits).finish()
+    }
 }
 
 impl<F: FieldElement> Average<F> {
@@ -297,10 +316,21 @@ impl<F: FieldElement> Type for Average<F> {
 
 /// The histogram type. Each measurement is a non-negative integer and the aggregate is a histogram
 /// approximating the distribution of the measurements.
-#[derive(Clone, Debug, PartialEq, Eq)]
+#[derive(Clone, PartialEq, Eq)]
 pub struct Histogram<F: FieldElement> {
     buckets: Vec<F::Integer>,
     range_checker: Vec<F>,
+}
+
+impl<F: FieldElement> Debug for Histogram<F> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("Histogram")
+            .field(
+                "buckets",
+                &format_args!("[{} buckets]", self.buckets.len() + 1),
+            )
+            .finish()
+    }
 }
 
 impl<F: FieldElement> Histogram<F> {
@@ -423,13 +453,19 @@ impl<F: FieldElement> Type for Histogram<F> {
 /// the proof size to roughly the square root of the input size.
 ///
 /// [BBCG+19]: https://eprint.iacr.org/2019/188
-#[derive(Debug, PartialEq, Eq)]
+#[derive(PartialEq, Eq)]
 pub struct CountVec<F, S> {
     range_checker: Vec<F>,
     len: usize,
     chunk_len: usize,
     gadget_calls: usize,
     phantom: PhantomData<S>,
+}
+
+impl<F: FieldElement, S> Debug for CountVec<F, S> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("CountVec").field("len", &self.len).finish()
+    }
 }
 
 impl<F: FieldElement, S: ParallelSumGadget<F, BlindPolyEval<F>>> CountVec<F, S> {

--- a/src/flp/types/fixedpoint_l2.rs
+++ b/src/flp/types/fixedpoint_l2.rs
@@ -176,7 +176,7 @@ use std::{convert::TryFrom, convert::TryInto, fmt::Debug, marker::PhantomData};
 /// to be chosen for `F`. For a `n`-bit fixed point type and a `d`-dimensional vector, the field
 /// modulus needs to be larger than `d * 2^(2n-2)` so there are no overflows during norm validity
 /// computation.
-#[derive(Clone, Debug, PartialEq, Eq)]
+#[derive(Clone, PartialEq, Eq)]
 pub struct FixedPointBoundedL2VecSum<
     T: Fixed,
     F: FieldElement,
@@ -200,6 +200,21 @@ pub struct FixedPointBoundedL2VecSum<
     gadget0_chunk_len: usize,
     gadget1_calls: usize,
     gadget1_chunk_len: usize,
+}
+
+impl<T, F, SPoly, SBlindPoly> Debug for FixedPointBoundedL2VecSum<T, F, SPoly, SBlindPoly>
+where
+    T: Fixed,
+    F: FieldElement,
+    SPoly: ParallelSumGadget<F, PolyEval<F>> + Clone,
+    SBlindPoly: ParallelSumGadget<F, BlindPolyEval<F>> + Clone,
+{
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("FixedPointBoundedL2VecSum")
+            .field("bits_per_entry", &self.bits_per_entry)
+            .field("entries", &self.entries)
+            .finish()
+    }
 }
 
 impl<T, F, SPoly, SBlindPoly> FixedPointBoundedL2VecSum<T, F, SPoly, SBlindPoly>


### PR DESCRIPTION
This backports #595 onto the release branch for 0.10. It simplifies the `Debug` implementation for Prio3 instances, by excluding precomputed fields inside the respective `Type` structs, and for `Histogram`, it replaces the list of bucket boundaries with just the number of buckets.