### PR TITLE
VDAF-06+ ping-pong topology

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -46,7 +46,7 @@ itertools = "0.11.0"
 modinverse = "0.1.0"
 num-bigint = "0.4.4"
 once_cell = "1.18.0"
-prio = { path = ".", features = ["crypto-dependencies"] }
+prio = { path = ".", features = ["crypto-dependencies", "test-util"] }
 rand = "0.8"
 serde_json = "1.0"
 statrs = "0.16.0"
@@ -58,6 +58,7 @@ experimental = ["bitvec", "fiat-crypto", "fixed", "num-bigint", "num-rational", 
 multithreaded = ["rayon"]
 prio2 = ["crypto-dependencies", "hmac", "sha2"]
 crypto-dependencies = ["aes", "ctr"]
+test-util = ["dep:rand"]
 
 [workspace]
 members = [".", "binaries"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -58,7 +58,7 @@ experimental = ["bitvec", "fiat-crypto", "fixed", "num-bigint", "num-rational", 
 multithreaded = ["rayon"]
 prio2 = ["crypto-dependencies", "hmac", "sha2"]
 crypto-dependencies = ["aes", "ctr"]
-test-util = ["dep:rand"]
+test-util = ["rand"]
 
 [workspace]
 members = [".", "binaries"]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -30,4 +30,5 @@ mod fp;
 pub mod idpf;
 mod polynomial;
 mod prng;
+pub mod topology;
 pub mod vdaf;

--- a/src/topology/mod.rs
+++ b/src/topology/mod.rs
@@ -1,0 +1,7 @@
+// SPDX-License-Identifier: MPL-2.0
+
+//! Implementations of the aggregator communication topologies specified in [VDAF].
+//!
+//! [VDAF]: https://datatracker.ietf.org/doc/html/draft-irtf-cfrg-vdaf-06#section-5.7
+
+pub mod ping_pong;

--- a/src/topology/mod.rs
+++ b/src/topology/mod.rs
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: MPL-2.0
 
-//! Implementations of the aggregator communication topologies specified in [VDAF].
+//! Implementations of some aggregator communication topologies specified in [VDAF].
 //!
 //! [VDAF]: https://datatracker.ietf.org/doc/html/draft-irtf-cfrg-vdaf-06#section-5.7
 

--- a/src/topology/ping_pong.rs
+++ b/src/topology/ping_pong.rs
@@ -237,23 +237,6 @@ impl<
     }
 }
 
-impl<
-        const VERIFY_KEY_SIZE: usize,
-        const NONCE_SIZE: usize,
-        A: Aggregator<VERIFY_KEY_SIZE, NONCE_SIZE>,
-    > Default for PingPongTransition<VERIFY_KEY_SIZE, NONCE_SIZE, A>
-where
-    A::PrepareState: Default,
-    A::PrepareMessage: Default,
-{
-    fn default() -> Self {
-        Self {
-            previous_prepare_state: A::PrepareState::default(),
-            current_prepare_message: A::PrepareMessage::default(),
-        }
-    }
-}
-
 impl<const VERIFY_KEY_SIZE: usize, const NONCE_SIZE: usize, A> Encode
     for PingPongTransition<VERIFY_KEY_SIZE, NONCE_SIZE, A>
 where

--- a/src/topology/ping_pong.rs
+++ b/src/topology/ping_pong.rs
@@ -598,7 +598,7 @@ where
         } else {
             return Err(PingPongError::HostStateMismatch {
                 found: "finished",
-                expected: "continued",
+                expected: "continue",
             });
         };
 
@@ -606,7 +606,7 @@ where
             PingPongMessage::Initialize { .. } => {
                 return Err(PingPongError::PeerMessageMismatch {
                     found: inbound.variant(),
-                    expected: "continued",
+                    expected: "continue",
                 });
             }
             PingPongMessage::Continue {

--- a/src/topology/ping_pong.rs
+++ b/src/topology/ping_pong.rs
@@ -1,0 +1,682 @@
+// SPDX-License-Identifier: MPL-2.0
+
+//! Implements the Ping-Pong Topology described in [VDAF]. This topology assumes there are exactly
+//! two aggregators, designated "Leader" and "Helper". Note that while this implementation is
+//! compatible with VDAF-06, it actually implements the ping-pong wrappers specified in VDAF-07
+//! (forthcoming) since those line up better with the VDAF implementation in this crate.
+//!
+//! [VDAF]: https://datatracker.ietf.org/doc/html/draft-irtf-cfrg-vdaf-06#section-5.8
+
+use crate::{
+    codec::{decode_u32_items, encode_u32_items, CodecError, Decode, Encode, ParameterizedDecode},
+    vdaf::{Aggregator, PrepareTransition, VdafError},
+};
+use std::fmt::Debug;
+
+/// Errors emitted by this module.
+#[derive(Debug, thiserror::Error)]
+pub enum PingPongError {
+    /// Error running prepare_init
+    #[error("vdaf.prepare_init: {0}")]
+    VdafPrepareInit(VdafError),
+
+    /// Error running prepare_preprocess
+    #[error("vdaf.prepare_preprocess {0}")]
+    VdafPreparePreprocess(VdafError),
+
+    /// Error running prepare_step
+    #[error("vdaf.prepare_step {0}")]
+    VdafPrepareStep(VdafError),
+
+    /// Error decoding a prepare share
+    #[error("decode prep share {0}")]
+    CodecPrepShare(CodecError),
+
+    /// Error decoding a prepare message
+    #[error("decode prep message {0}")]
+    CodecPrepMessage(CodecError),
+
+    /// State machine mismatch between peer and host.
+    #[error("state mismatch: host state {0} peer state {0}")]
+    StateMismatch(&'static str, &'static str),
+
+    /// Internal error
+    #[error("internal error: {0}")]
+    InternalError(&'static str),
+}
+
+/// Distinguished aggregator roles.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum Role {
+    /// The Leader aggregator.
+    Leader,
+    /// The Helper aggregator.
+    Helper,
+}
+
+/// Corresponds to `struct Message` in [VDAF's Ping-Pong Topology][VDAF]. All of the fields of the
+/// variants are opaque byte buffers. This is because the ping-pong routines take responsibility for
+/// decoding preparation shares and messages, which usually requires having the preparation state.
+///
+/// [VDAF]: https://datatracker.ietf.org/doc/html/draft-irtf-cfrg-vdaf-06#section-5.8
+#[derive(Clone, PartialEq, Eq)]
+pub enum Message {
+    /// Corresponds to MessageType.initialize.
+    Initialize {
+        /// The leader's initial preparation share.
+        prep_share: Vec<u8>,
+    },
+    /// Corresponds to MessageType.continue.
+    Continue {
+        /// The current round's preparation message.
+        prep_msg: Vec<u8>,
+        /// The next round's preparation share.
+        prep_share: Vec<u8>,
+    },
+    /// Corresponds to MessageType.finish.
+    Finish {
+        /// The current round's preparation message.
+        prep_msg: Vec<u8>,
+    },
+}
+
+impl Message {
+    fn state_name(&self) -> &'static str {
+        match self {
+            Self::Initialize { .. } => "Initialize",
+            Self::Continue { .. } => "Continue",
+            Self::Finish { .. } => "Finish",
+        }
+    }
+}
+
+impl Debug for Message {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "Message::{}", self.state_name())
+    }
+}
+
+impl Encode for Message {
+    fn encode(&self, bytes: &mut Vec<u8>) {
+        // The encoding includes an implicit discriminator byte, called MessageType in the VDAF
+        // spec.
+        match self {
+            Self::Initialize { prep_share } => {
+                0u8.encode(bytes);
+                encode_u32_items(bytes, &(), prep_share);
+            }
+            Self::Continue {
+                prep_msg,
+                prep_share,
+            } => {
+                1u8.encode(bytes);
+                encode_u32_items(bytes, &(), prep_msg);
+                encode_u32_items(bytes, &(), prep_share);
+            }
+            Self::Finish { prep_msg } => {
+                2u8.encode(bytes);
+                encode_u32_items(bytes, &(), prep_msg);
+            }
+        }
+    }
+
+    fn encoded_len(&self) -> Option<usize> {
+        match self {
+            Self::Initialize { prep_share } => Some(1 + 4 + prep_share.len()),
+            Self::Continue {
+                prep_msg,
+                prep_share,
+            } => Some(1 + 4 + prep_msg.len() + 4 + prep_share.len()),
+            Self::Finish { prep_msg } => Some(1 + 4 + prep_msg.len()),
+        }
+    }
+}
+
+impl Decode for Message {
+    fn decode(bytes: &mut std::io::Cursor<&[u8]>) -> Result<Self, CodecError> {
+        let message_type = u8::decode(bytes)?;
+        Ok(match message_type {
+            0 => {
+                let prep_share = decode_u32_items(&(), bytes)?;
+                Self::Initialize { prep_share }
+            }
+            1 => {
+                let prep_msg = decode_u32_items(&(), bytes)?;
+                let prep_share = decode_u32_items(&(), bytes)?;
+                Self::Continue {
+                    prep_msg,
+                    prep_share,
+                }
+            }
+            2 => {
+                let prep_msg = decode_u32_items(&(), bytes)?;
+                Self::Finish { prep_msg }
+            }
+            _ => return Err(CodecError::UnexpectedValue),
+        })
+    }
+}
+
+/// Corresponds to the `State` enumeration implicitly defined in [VDAF's Ping-Pong Topology][VDAF].
+/// VDAF describes `Start` and `Rejected` states, but the `Start` state is never instantiated in
+/// code, and the `Rejected` state is represented as `std::result::Result::Error`, so this enum does
+/// not include those variants.
+///
+/// [VDAF]: https://datatracker.ietf.org/doc/html/draft-irtf-cfrg-vdaf-06#section-5.8
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub enum State<PrepState, OutputShare> {
+    /// Preparation of the report will continue with the enclosed state.
+    Continued(PrepState),
+    /// Preparation of the report is finished and has yielded the enclosed output share.
+    Finished(OutputShare),
+}
+
+impl<PrepState: Encode, OutputShare: Encode> Encode for State<PrepState, OutputShare> {
+    fn encode(&self, bytes: &mut Vec<u8>) {
+        match self {
+            Self::Continued(prep_state) => {
+                0u8.encode(bytes);
+                prep_state.encode(bytes);
+            }
+            Self::Finished(output_share) => {
+                1u8.encode(bytes);
+                output_share.encode(bytes);
+            }
+        }
+    }
+
+    fn encoded_len(&self) -> Option<usize> {
+        Some(
+            1 + match self {
+                Self::Continued(prep_state) => prep_state.encoded_len()?,
+                Self::Finished(output_share) => output_share.encoded_len()?,
+            },
+        )
+    }
+}
+
+/// Decoding parameter for [`State`].
+pub struct StateDecodingParam<'a, PrepStateDecode, OutputShareDecode> {
+    /// The decoding parameter for the preparation state.
+    pub prep_state: &'a PrepStateDecode,
+    /// The decoding parameter for the output share.
+    pub output_share: &'a OutputShareDecode,
+}
+
+impl<
+        'a,
+        PrepStateDecode,
+        OutputShareDecode,
+        PrepState: ParameterizedDecode<PrepStateDecode>,
+        OutputShare: ParameterizedDecode<OutputShareDecode>,
+    > ParameterizedDecode<StateDecodingParam<'a, PrepStateDecode, OutputShareDecode>>
+    for State<PrepState, OutputShare>
+{
+    fn decode_with_param(
+        decoding_param: &StateDecodingParam<PrepStateDecode, OutputShareDecode>,
+        bytes: &mut std::io::Cursor<&[u8]>,
+    ) -> Result<Self, CodecError> {
+        let variant = u8::decode(bytes)?;
+        match variant {
+            0 => Ok(Self::Continued(PrepState::decode_with_param(
+                decoding_param.prep_state,
+                bytes,
+            )?)),
+            1 => Ok(Self::Finished(OutputShare::decode_with_param(
+                decoding_param.output_share,
+                bytes,
+            )?)),
+            _ => Err(CodecError::UnexpectedValue),
+        }
+    }
+}
+
+/// Values returned by [`PingPongTopology::continued`].
+///
+/// Corresponds to the `State` enumeration implicitly defined in [VDAF's Ping-Pong Topology][VDAF],
+/// but combined with the components of [`Message`] so that no impossible states may be represented.
+/// For example, it's impossible to be in the `Continued` state but to send an outgoing `Message` of
+/// type `Finished`.
+///
+/// VDAF describes `Start` and `Rejected` states, but the `Start` state is never instantiated in
+/// code, and the `Rejected` state is represented as `std::result::Result::Error`, so this enum does
+/// not include those variants.
+///
+/// [VDAF]: https://datatracker.ietf.org/doc/html/draft-irtf-cfrg-vdaf-06#section-5.8
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub enum StateAndMessage<PrepareState, OutputShare> {
+    /// The operation resulted in a new state and a message to transmit to the peer.
+    WithMessage {
+        /// The [`State`] to which we just advanced.
+        state: State<PrepareState, OutputShare>,
+        /// The [`Message`] which should now be transmitted to the peer.
+        message: Message,
+    },
+    /// The operation caused the host to finish preparation of the input share, yielding an output
+    /// share and no message for the peer.
+    FinishedNoMessage {
+        /// The output share which may now be accumulated.
+        output_share: OutputShare,
+    },
+}
+
+/// Extension trait on [`crate::vdaf::Aggregator`] which adds the [VDAF Ping-Pong Topology][VDAF].
+///
+/// [VDAF]: https://datatracker.ietf.org/doc/html/draft-irtf-cfrg-vdaf-06#section-5.8
+pub trait PingPongTopology<const VERIFY_KEY_SIZE: usize, const NONCE_SIZE: usize>:
+    Aggregator<VERIFY_KEY_SIZE, NONCE_SIZE>
+{
+    /// Specialization of [`State`] for this VDAF.
+    type State;
+    /// Specialization of [`StateAndMessage`] for this VDAF.
+    type StateAndMessage;
+
+    /// Initialize leader state using the leader's input share. Corresponds to
+    /// `ping_pong_leader_init` in the forthcoming `draft-irtf-cfrg-vdaf-07`.
+    ///
+    /// If successful, the returned [`State`] (which will always be `State::Continued`) should be
+    /// stored by the leader for use in the next round, and the returned [`Message`] (which will
+    /// always be `Message::Initialize`) should be transmitted to the helper.
+    fn leader_initialize(
+        &self,
+        verify_key: &[u8; VERIFY_KEY_SIZE],
+        agg_param: &Self::AggregationParam,
+        nonce: &[u8; NONCE_SIZE],
+        public_share: &Self::PublicShare,
+        input_share: &Self::InputShare,
+    ) -> Result<(Self::State, Message), PingPongError>;
+
+    /// Initialize helper state using the helper's input share and the leader's first prepare share.
+    /// Corresponds to `ping_pong_helper_init` in the forthcoming `draft-irtf-cfrg-vdaf-07`.
+    ///
+    /// If successful, the returned [`State`] will either be `State::Continued` and should be stored
+    /// by the helper for use in the next round or `State::Finished`, in which case preparation is
+    /// finished and the output share may be accumulated by the helper.
+    ///
+    /// Regardless of state, the returned [`Message`] should be transmitted to the leader.
+    ///
+    /// # Errors
+    ///
+    /// `inbound` must be `Message::Initialize` or the function will fail.
+    fn helper_initialize(
+        &self,
+        verify_key: &[u8; VERIFY_KEY_SIZE],
+        agg_param: &Self::AggregationParam,
+        nonce: &[u8; NONCE_SIZE],
+        public_share: &Self::PublicShare,
+        input_share: &Self::InputShare,
+        inbound: &Message,
+    ) -> Result<(Self::State, Message), PingPongError>;
+
+    /// Continue preparation based on the host's current state and an incoming [`Message`] from the
+    /// peer. `role` is the host's [`Role`]. Corresponds to `ping_pong_contnued` in the forthcoming
+    /// `draft-irtf-cfrg-vdaf-07`.
+    ///
+    /// If successful, the returned [`StateAndMessage`] will either be:
+    ///
+    /// - `StateAndMessage::WithMessage { state, message }`: the `state` will be either
+    ///   `State::Continued` and should be stored by the host for use in the next round or
+    ///   `State::Finished`, in which case preparation is finished and the output share may be
+    ///   accumulated. Regardless of state, `message` should be transmitted to the peer.
+    /// - `StateAndMessage::FinishedNoMessage`: preparation is finished and the output share may be
+    ///   accumulated. No message needs to be send to the peer.
+    ///
+    /// # Errors
+    ///
+    /// `host_state` must be `State::Continued` or the function will fail.
+    ///
+    /// `inbound` must not be `Message::Initialize` or the function will fail.
+    fn continued(
+        &self,
+        role: Role,
+        host_state: Self::State,
+        inbound: &Message,
+    ) -> Result<StateAndMessage<Self::PrepareState, Self::OutputShare>, PingPongError>;
+}
+
+/// Private interfaces for VDAF Ping-Pong topology.
+trait PingPongTopologyPrivate<const VERIFY_KEY_SIZE: usize, const NONCE_SIZE: usize>:
+    PingPongTopology<VERIFY_KEY_SIZE, NONCE_SIZE>
+{
+    /// Corresponds to `ping_pong_transition` in the forthcoming `draft-irtf-cfrg-vdaf-07`.
+    fn transition(
+        &self,
+        prep_shares: [Self::PrepareShare; 2],
+        host_prep_state: Self::PrepareState,
+    ) -> Result<(Self::State, Message), PingPongError>;
+}
+
+impl<const VERIFY_KEY_SIZE: usize, const NONCE_SIZE: usize, A>
+    PingPongTopology<VERIFY_KEY_SIZE, NONCE_SIZE> for A
+where
+    A: Aggregator<VERIFY_KEY_SIZE, NONCE_SIZE>,
+{
+    type State = State<A::PrepareState, A::OutputShare>;
+    type StateAndMessage = StateAndMessage<A::PrepareState, A::OutputShare>;
+
+    fn leader_initialize(
+        &self,
+        verify_key: &[u8; VERIFY_KEY_SIZE],
+        agg_param: &Self::AggregationParam,
+        nonce: &[u8; NONCE_SIZE],
+        public_share: &Self::PublicShare,
+        input_share: &Self::InputShare,
+    ) -> Result<(Self::State, Message), PingPongError> {
+        self.prepare_init(
+            verify_key,
+            /* Leader */ 0,
+            agg_param,
+            nonce,
+            public_share,
+            input_share,
+        )
+        .map(|(prep_state, prep_share)| {
+            (
+                State::Continued(prep_state),
+                Message::Initialize {
+                    prep_share: prep_share.get_encoded(),
+                },
+            )
+        })
+        .map_err(PingPongError::VdafPrepareInit)
+    }
+
+    fn helper_initialize(
+        &self,
+        verify_key: &[u8; VERIFY_KEY_SIZE],
+        agg_param: &Self::AggregationParam,
+        nonce: &[u8; NONCE_SIZE],
+        public_share: &Self::PublicShare,
+        input_share: &Self::InputShare,
+        inbound: &Message,
+    ) -> Result<(Self::State, Message), PingPongError> {
+        let (prep_state, prep_share) = self
+            .prepare_init(
+                verify_key,
+                /* Helper */ 1,
+                agg_param,
+                nonce,
+                public_share,
+                input_share,
+            )
+            .map_err(PingPongError::VdafPrepareInit)?;
+
+        let inbound_prep_share = if let Message::Initialize { prep_share } = inbound {
+            Self::PrepareShare::get_decoded_with_param(&prep_state, prep_share)
+                .map_err(PingPongError::CodecPrepShare)?
+        } else {
+            return Err(PingPongError::StateMismatch(
+                "initialize",
+                inbound.state_name(),
+            ));
+        };
+
+        self.transition([inbound_prep_share, prep_share], prep_state)
+    }
+
+    fn continued(
+        &self,
+        role: Role,
+        host_state: Self::State,
+        inbound: &Message,
+    ) -> Result<Self::StateAndMessage, PingPongError> {
+        let host_prep_state = if let State::Continued(state) = host_state {
+            state
+        } else {
+            return Err(PingPongError::StateMismatch("finished", "continue"));
+        };
+
+        let (prep_msg, next_peer_prep_share) = match inbound {
+            Message::Initialize { .. } => {
+                return Err(PingPongError::StateMismatch(
+                    "continue",
+                    inbound.state_name(),
+                ));
+            }
+            Message::Continue {
+                prep_msg,
+                prep_share,
+            } => (prep_msg, Some(prep_share)),
+            Message::Finish { prep_msg } => (prep_msg, None),
+        };
+
+        let prep_msg = Self::PrepareMessage::get_decoded_with_param(&host_prep_state, prep_msg)
+            .map_err(PingPongError::CodecPrepMessage)?;
+        let host_prep_transition = self
+            .prepare_step(host_prep_state, prep_msg)
+            .map_err(PingPongError::VdafPrepareStep)?;
+
+        match (host_prep_transition, next_peer_prep_share) {
+            (
+                PrepareTransition::Continue(next_prep_state, next_host_prep_share),
+                Some(next_peer_prep_share),
+            ) => {
+                let next_peer_prep_share = Self::PrepareShare::get_decoded_with_param(
+                    &next_prep_state,
+                    next_peer_prep_share,
+                )
+                .map_err(PingPongError::CodecPrepShare)?;
+                let mut prep_shares = [next_host_prep_share, next_peer_prep_share];
+                if role == Role::Helper {
+                    prep_shares.reverse();
+                }
+                self.transition(prep_shares, next_prep_state)
+                    .map(|(state, message)| StateAndMessage::WithMessage { state, message })
+            }
+            (PrepareTransition::Finish(output_share), None) => {
+                Ok(StateAndMessage::FinishedNoMessage { output_share })
+            }
+            (transition, _) => {
+                return Err(PingPongError::StateMismatch(
+                    inbound.state_name(),
+                    match transition {
+                        PrepareTransition::Continue(_, _) => "continue",
+                        PrepareTransition::Finish(_) => "finished",
+                    },
+                ))
+            }
+        }
+    }
+}
+
+impl<const VERIFY_KEY_SIZE: usize, const NONCE_SIZE: usize, A>
+    PingPongTopologyPrivate<VERIFY_KEY_SIZE, NONCE_SIZE> for A
+where
+    A: Aggregator<VERIFY_KEY_SIZE, NONCE_SIZE>,
+{
+    fn transition(
+        &self,
+        prep_shares: [Self::PrepareShare; 2],
+        host_prep_state: Self::PrepareState,
+    ) -> Result<(Self::State, Message), PingPongError> {
+        let prep_message = self
+            .prepare_preprocess(prep_shares)
+            .map_err(PingPongError::VdafPreparePreprocess)?;
+
+        self.prepare_step(host_prep_state, prep_message.clone())
+            .map(|transition| match transition {
+                PrepareTransition::Continue(prep_state, prep_share) => (
+                    State::Continued(prep_state),
+                    Message::Continue {
+                        prep_msg: prep_message.get_encoded(),
+                        prep_share: prep_share.get_encoded(),
+                    },
+                ),
+                PrepareTransition::Finish(output_share) => (
+                    State::Finished(output_share),
+                    Message::Finish {
+                        prep_msg: prep_message.get_encoded(),
+                    },
+                ),
+            })
+            .map_err(PingPongError::VdafPrepareStep)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use assert_matches::assert_matches;
+
+    use super::*;
+
+    use crate::vdaf::dummy;
+
+    #[test]
+    fn ping_pong_one_round() {
+        let verify_key = [];
+        let aggregation_param = dummy::AggregationParam(0);
+        let nonce = [0; 16];
+        #[allow(clippy::let_unit_value)]
+        let public_share = ();
+        let input_share = dummy::InputShare(0);
+
+        let leader = dummy::Vdaf::new(1);
+        let helper = dummy::Vdaf::new(1);
+
+        // Leader inits into round 0
+        let (leader_state, leader_message) = leader
+            .leader_initialize(
+                &verify_key,
+                &aggregation_param,
+                &nonce,
+                &public_share,
+                &input_share,
+            )
+            .unwrap();
+
+        // Helper inits into round 1
+        let (helper_state, helper_message) = helper
+            .helper_initialize(
+                &verify_key,
+                &aggregation_param,
+                &nonce,
+                &public_share,
+                &input_share,
+                &leader_message,
+            )
+            .unwrap();
+
+        // 1 round VDAF: helper should finish immediately.
+        assert_matches!(helper_state, State::Finished(_));
+
+        let leader_state = leader
+            .continued(Role::Leader, leader_state, &helper_message)
+            .unwrap();
+        // 1 round VDAF: leader should finish when it gets helper message and emit no message.
+        assert_matches!(leader_state, StateAndMessage::FinishedNoMessage { .. });
+    }
+
+    #[test]
+    fn ping_pong_two_rounds() {
+        let verify_key = [];
+        let aggregation_param = dummy::AggregationParam(0);
+        let nonce = [0; 16];
+        #[allow(clippy::let_unit_value)]
+        let public_share = ();
+        let input_share = dummy::InputShare(0);
+
+        let leader = dummy::Vdaf::new(2);
+        let helper = dummy::Vdaf::new(2);
+
+        // Leader inits into round 0
+        let (leader_state, leader_message) = leader
+            .leader_initialize(
+                &verify_key,
+                &aggregation_param,
+                &nonce,
+                &public_share,
+                &input_share,
+            )
+            .unwrap();
+
+        // Helper inits into round 1
+        let (helper_state, helper_message) = helper
+            .helper_initialize(
+                &verify_key,
+                &aggregation_param,
+                &nonce,
+                &public_share,
+                &input_share,
+                &leader_message,
+            )
+            .unwrap();
+
+        // 2 round VDAF, round 1: helper should continue.
+        assert_matches!(helper_state, State::Continued(_));
+
+        let leader_state = leader
+            .continued(Role::Leader, leader_state, &helper_message)
+            .unwrap();
+        // 2 round VDAF, round 1: leader should finish and emit a finish message.
+        let leader_message = assert_matches!(
+            leader_state, StateAndMessage::WithMessage { state: State::Finished(_), message } => message
+        );
+
+        let helper_state = helper
+            .continued(Role::Helper, helper_state, &leader_message)
+            .unwrap();
+        // 2 round vdaf, round 1: helper should finish and emit no message.
+        assert_matches!(helper_state, StateAndMessage::FinishedNoMessage { .. });
+    }
+
+    #[test]
+    fn ping_pong_three_rounds() {
+        let verify_key = [];
+        let aggregation_param = dummy::AggregationParam(0);
+        let nonce = [0; 16];
+        #[allow(clippy::let_unit_value)]
+        let public_share = ();
+        let input_share = dummy::InputShare(0);
+
+        let leader = dummy::Vdaf::new(3);
+        let helper = dummy::Vdaf::new(3);
+
+        // Leader inits into round 0
+        let (leader_state, leader_message) = leader
+            .leader_initialize(
+                &verify_key,
+                &aggregation_param,
+                &nonce,
+                &public_share,
+                &input_share,
+            )
+            .unwrap();
+
+        // Helper inits into round 1
+        let (helper_state, helper_message) = helper
+            .helper_initialize(
+                &verify_key,
+                &aggregation_param,
+                &nonce,
+                &public_share,
+                &input_share,
+                &leader_message,
+            )
+            .unwrap();
+
+        // 3 round VDAF, round 1: helper should continue.
+        assert_matches!(helper_state, State::Continued(_));
+
+        let leader_state = leader
+            .continued(Role::Leader, leader_state, &helper_message)
+            .unwrap();
+        // 3 round VDAF, round 1: leader should continue and emit a continue message.
+        let (leader_state, leader_message) = assert_matches!(
+            leader_state, StateAndMessage::WithMessage { ref message, state } => (state, message)
+        );
+
+        let helper_state = helper
+            .continued(Role::Helper, helper_state, leader_message)
+            .unwrap();
+        // 3 round vdaf, round 2: helper should finish and emit a finish message.
+        let helper_message = assert_matches!(
+            helper_state, StateAndMessage::WithMessage { message, state: State::Finished(_) } => message
+        );
+
+        let leader_state = leader
+            .continued(Role::Leader, leader_state, &helper_message)
+            .unwrap();
+        // 3 round VDAF, round 2: leader should finish and emit no message.
+        assert_matches!(leader_state, StateAndMessage::FinishedNoMessage { .. });
+    }
+}

--- a/src/topology/ping_pong.rs
+++ b/src/topology/ping_pong.rs
@@ -24,9 +24,9 @@ pub enum PingPongError {
     #[error("vdaf.prepare_shares_to_prepare_message {0}")]
     VdafPrepareSharesToPrepareMessage(VdafError),
 
-    /// Error running prepare_step
-    #[error("vdaf.prepare_step {0}")]
-    VdafPrepareStep(VdafError),
+    /// Error running prepare_next
+    #[error("vdaf.prepare_next {0}")]
+    VdafPrepareNext(VdafError),
 
     /// Error decoding a prepare share
     #[error("decode prep share {0}")]
@@ -231,7 +231,7 @@ impl<
                 PingPongMessage::Finish { prep_msg },
             ),
         })
-        .map_err(PingPongError::VdafPrepareStep)
+        .map_err(PingPongError::VdafPrepareNext)
     }
 }
 
@@ -622,7 +622,7 @@ where
             .map_err(PingPongError::CodecPrepMessage)?;
         let host_prep_transition = self
             .prepare_next(host_prep_state, prep_msg)
-            .map_err(PingPongError::VdafPrepareStep)?;
+            .map_err(PingPongError::VdafPrepareNext)?;
 
         match (host_prep_transition, next_peer_prep_share) {
             (

--- a/src/topology/ping_pong.rs
+++ b/src/topology/ping_pong.rs
@@ -157,6 +157,137 @@ impl Decode for Message {
     }
 }
 
+/// A transition in the pong-pong topology. This represents the `ping_pong_transition` function
+/// defined in [VDAF].
+///
+/// # Discussion
+///
+/// The obvious implementation would of `ping_pong_transition` would be a method on trait
+/// [`PingPongTopology`] that returns `(State, Message)`, and then `StateAndMessage::WithMessage`
+/// would contain those values. But then DAP implementations would have to store relatively large
+/// VDAF prepare shares between rounds of input preparation.
+///
+/// Instead, this structure stores just the previous round's prepare state and the current round's
+/// preprocessed prepare message. Their encoding is much smaller than the `(State, Message)` tuple,
+/// which can always be recomputed with [`Self::evaluate`].
+///
+/// [VDAF]: https://datatracker.ietf.org/doc/html/draft-irtf-cfrg-vdaf-06#section-5.8
+#[derive(Clone, Debug, Eq)]
+pub struct Transition<
+    const VERIFY_KEY_SIZE: usize,
+    const NONCE_SIZE: usize,
+    A: Aggregator<VERIFY_KEY_SIZE, NONCE_SIZE>,
+> {
+    previous_prepare_state: A::PrepareState,
+    current_prepare_message: A::PrepareMessage,
+}
+
+impl<
+        const VERIFY_KEY_SIZE: usize,
+        const NONCE_SIZE: usize,
+        A: Aggregator<VERIFY_KEY_SIZE, NONCE_SIZE>,
+    > Transition<VERIFY_KEY_SIZE, NONCE_SIZE, A>
+{
+    /// Evaluate this transition to obtain a new [`State`] and a [`Message`] which should be
+    /// transmitted to the peer.
+    #[allow(clippy::type_complexity)]
+    pub fn evaluate(
+        &self,
+        vdaf: &A,
+    ) -> Result<(State<VERIFY_KEY_SIZE, NONCE_SIZE, A>, Message), PingPongError> {
+        vdaf.prepare_step(
+            self.previous_prepare_state.clone(),
+            self.current_prepare_message.clone(),
+        )
+        .map(|transition| match transition {
+            PrepareTransition::Continue(prep_state, prep_share) => (
+                State::Continued(prep_state),
+                Message::Continue {
+                    prep_msg: self.current_prepare_message.get_encoded(),
+                    prep_share: prep_share.get_encoded(),
+                },
+            ),
+            PrepareTransition::Finish(output_share) => (
+                State::Finished(output_share),
+                Message::Finish {
+                    prep_msg: self.current_prepare_message.get_encoded(),
+                },
+            ),
+        })
+        .map_err(PingPongError::VdafPrepareStep)
+    }
+}
+
+impl<
+        const VERIFY_KEY_SIZE: usize,
+        const NONCE_SIZE: usize,
+        A: Aggregator<VERIFY_KEY_SIZE, NONCE_SIZE>,
+    > PartialEq for Transition<VERIFY_KEY_SIZE, NONCE_SIZE, A>
+{
+    fn eq(&self, other: &Self) -> bool {
+        self.previous_prepare_state == other.previous_prepare_state
+            && self.current_prepare_message == other.current_prepare_message
+    }
+}
+
+impl<
+        const VERIFY_KEY_SIZE: usize,
+        const NONCE_SIZE: usize,
+        A: Aggregator<VERIFY_KEY_SIZE, NONCE_SIZE>,
+    > Default for Transition<VERIFY_KEY_SIZE, NONCE_SIZE, A>
+where
+    A::PrepareState: Default,
+    A::PrepareMessage: Default,
+{
+    fn default() -> Self {
+        Self {
+            previous_prepare_state: A::PrepareState::default(),
+            current_prepare_message: A::PrepareMessage::default(),
+        }
+    }
+}
+
+impl<const VERIFY_KEY_SIZE: usize, const NONCE_SIZE: usize, A> Encode
+    for Transition<VERIFY_KEY_SIZE, NONCE_SIZE, A>
+where
+    A: Aggregator<VERIFY_KEY_SIZE, NONCE_SIZE>,
+    A::PrepareState: Encode,
+{
+    fn encode(&self, bytes: &mut Vec<u8>) {
+        self.previous_prepare_state.encode(bytes);
+        self.current_prepare_message.encode(bytes);
+    }
+
+    fn encoded_len(&self) -> Option<usize> {
+        Some(
+            self.previous_prepare_state.encoded_len()?
+                + self.current_prepare_message.encoded_len()?,
+        )
+    }
+}
+
+impl<const VERIFY_KEY_SIZE: usize, const NONCE_SIZE: usize, A, PrepareStateDecode>
+    ParameterizedDecode<PrepareStateDecode> for Transition<VERIFY_KEY_SIZE, NONCE_SIZE, A>
+where
+    A: Aggregator<VERIFY_KEY_SIZE, NONCE_SIZE>,
+    A::PrepareState: ParameterizedDecode<PrepareStateDecode> + PartialEq,
+    A::PrepareMessage: PartialEq,
+{
+    fn decode_with_param(
+        decoding_param: &PrepareStateDecode,
+        bytes: &mut std::io::Cursor<&[u8]>,
+    ) -> Result<Self, CodecError> {
+        let previous_prepare_state = A::PrepareState::decode_with_param(decoding_param, bytes)?;
+        let current_prepare_message =
+            A::PrepareMessage::decode_with_param(&previous_prepare_state, bytes)?;
+
+        Ok(Self {
+            previous_prepare_state,
+            current_prepare_message,
+        })
+    }
+}
+
 /// Corresponds to the `State` enumeration implicitly defined in [VDAF's Ping-Pong Topology][VDAF].
 /// VDAF describes `Start` and `Rejected` states, but the `Start` state is never instantiated in
 /// code, and the `Rejected` state is represented as `std::result::Result::Error`, so this enum does
@@ -164,71 +295,15 @@ impl Decode for Message {
 ///
 /// [VDAF]: https://datatracker.ietf.org/doc/html/draft-irtf-cfrg-vdaf-06#section-5.8
 #[derive(Clone, Debug, PartialEq, Eq)]
-pub enum State<PrepState, OutputShare> {
+pub enum State<
+    const VERIFY_KEY_SIZE: usize,
+    const NONCE_SIZE: usize,
+    A: Aggregator<VERIFY_KEY_SIZE, NONCE_SIZE>,
+> {
     /// Preparation of the report will continue with the enclosed state.
-    Continued(PrepState),
+    Continued(A::PrepareState),
     /// Preparation of the report is finished and has yielded the enclosed output share.
-    Finished(OutputShare),
-}
-
-impl<PrepState: Encode, OutputShare: Encode> Encode for State<PrepState, OutputShare> {
-    fn encode(&self, bytes: &mut Vec<u8>) {
-        match self {
-            Self::Continued(prep_state) => {
-                0u8.encode(bytes);
-                prep_state.encode(bytes);
-            }
-            Self::Finished(output_share) => {
-                1u8.encode(bytes);
-                output_share.encode(bytes);
-            }
-        }
-    }
-
-    fn encoded_len(&self) -> Option<usize> {
-        Some(
-            1 + match self {
-                Self::Continued(prep_state) => prep_state.encoded_len()?,
-                Self::Finished(output_share) => output_share.encoded_len()?,
-            },
-        )
-    }
-}
-
-/// Decoding parameter for [`State`].
-pub struct StateDecodingParam<'a, PrepStateDecode, OutputShareDecode> {
-    /// The decoding parameter for the preparation state.
-    pub prep_state: &'a PrepStateDecode,
-    /// The decoding parameter for the output share.
-    pub output_share: &'a OutputShareDecode,
-}
-
-impl<
-        'a,
-        PrepStateDecode,
-        OutputShareDecode,
-        PrepState: ParameterizedDecode<PrepStateDecode>,
-        OutputShare: ParameterizedDecode<OutputShareDecode>,
-    > ParameterizedDecode<StateDecodingParam<'a, PrepStateDecode, OutputShareDecode>>
-    for State<PrepState, OutputShare>
-{
-    fn decode_with_param(
-        decoding_param: &StateDecodingParam<PrepStateDecode, OutputShareDecode>,
-        bytes: &mut std::io::Cursor<&[u8]>,
-    ) -> Result<Self, CodecError> {
-        let variant = u8::decode(bytes)?;
-        match variant {
-            0 => Ok(Self::Continued(PrepState::decode_with_param(
-                decoding_param.prep_state,
-                bytes,
-            )?)),
-            1 => Ok(Self::Finished(OutputShare::decode_with_param(
-                decoding_param.output_share,
-                bytes,
-            )?)),
-            _ => Err(CodecError::UnexpectedValue),
-        }
-    }
+    Finished(A::OutputShare),
 }
 
 /// Values returned by [`PingPongTopology::continued`].
@@ -239,24 +314,27 @@ impl<
 /// type `Finished`.
 ///
 /// VDAF describes `Start` and `Rejected` states, but the `Start` state is never instantiated in
-/// code, and the `Rejected` state is represented as `std::result::Result::Error`, so this enum does
+/// code, and the `Rejected` state is represented as [`std::result::Result::Error`], so this enum does
 /// not include those variants.
 ///
 /// [VDAF]: https://datatracker.ietf.org/doc/html/draft-irtf-cfrg-vdaf-06#section-5.8
-#[derive(Clone, Debug, PartialEq, Eq)]
-pub enum StateAndMessage<PrepareState, OutputShare> {
+#[derive(Clone, Debug)]
+pub enum StateAndMessage<
+    const VERIFY_KEY_SIZE: usize,
+    const NONCE_SIZE: usize,
+    A: Aggregator<VERIFY_KEY_SIZE, NONCE_SIZE>,
+> {
     /// The operation resulted in a new state and a message to transmit to the peer.
     WithMessage {
-        /// The [`State`] to which we just advanced.
-        state: State<PrepareState, OutputShare>,
-        /// The [`Message`] which should now be transmitted to the peer.
-        message: Message,
+        /// The transition that will be executed. Call `Transition::evaluate` to obtain the next
+        /// [`State`] and a [`Message`] to transmit to the peer.
+        transition: Transition<VERIFY_KEY_SIZE, NONCE_SIZE, A>,
     },
     /// The operation caused the host to finish preparation of the input share, yielding an output
     /// share and no message for the peer.
     FinishedNoMessage {
         /// The output share which may now be accumulated.
-        output_share: OutputShare,
+        output_share: A::OutputShare,
     },
 }
 
@@ -274,9 +352,10 @@ pub trait PingPongTopology<const VERIFY_KEY_SIZE: usize, const NONCE_SIZE: usize
     /// Initialize leader state using the leader's input share. Corresponds to
     /// `ping_pong_leader_init` in the forthcoming `draft-irtf-cfrg-vdaf-07`.
     ///
-    /// If successful, the returned [`State`] (which will always be `State::Continued`) should be
-    /// stored by the leader for use in the next round, and the returned [`Message`] (which will
-    /// always be `Message::Initialize`) should be transmitted to the helper.
+    /// If successful, the returned [`Message`] (which will always be `Message::Initialize`) should
+    /// be transmitted to the helper. The returned [`State`] (which will always be
+    /// `State::Continued`) should be used by the leader along with the next [`Message`] received
+    /// from the helper as input to [`Self::continued`] to advance to the next round.
     fn leader_initialize(
         &self,
         verify_key: &[u8; VERIFY_KEY_SIZE],
@@ -289,11 +368,16 @@ pub trait PingPongTopology<const VERIFY_KEY_SIZE: usize, const NONCE_SIZE: usize
     /// Initialize helper state using the helper's input share and the leader's first prepare share.
     /// Corresponds to `ping_pong_helper_init` in the forthcoming `draft-irtf-cfrg-vdaf-07`.
     ///
-    /// If successful, the returned [`State`] will either be `State::Continued` and should be stored
-    /// by the helper for use in the next round or `State::Finished`, in which case preparation is
-    /// finished and the output share may be accumulated by the helper.
+    /// If successful, the returned [`Transition`] should be evaluated, yielding a [`Message`], which
+    /// should be transmitted to the leader, and a [`State`].
     ///
-    /// Regardless of state, the returned [`Message`] should be transmitted to the leader.
+    /// If the state is `State::Continued`, then it should be used by the helper along with the next
+    /// `Message` received from the leader as input to [`Self::continued`] to advance to the next
+    /// round. The helper may store the `Transition` between rounds of preparation instead of the
+    /// `State` and `Message`.
+    ///
+    /// If the state is `State::Finished`, then preparation is finished and the output share may be
+    /// accumulated.
     ///
     /// # Errors
     ///
@@ -306,7 +390,7 @@ pub trait PingPongTopology<const VERIFY_KEY_SIZE: usize, const NONCE_SIZE: usize
         public_share: &Self::PublicShare,
         input_share: &Self::InputShare,
         inbound: &Message,
-    ) -> Result<(Self::State, Message), PingPongError>;
+    ) -> Result<Transition<VERIFY_KEY_SIZE, NONCE_SIZE, Self>, PingPongError>;
 
     /// Continue preparation based on the host's current state and an incoming [`Message`] from the
     /// peer. `role` is the host's [`Role`]. Corresponds to `ping_pong_contnued` in the forthcoming
@@ -314,12 +398,19 @@ pub trait PingPongTopology<const VERIFY_KEY_SIZE: usize, const NONCE_SIZE: usize
     ///
     /// If successful, the returned [`StateAndMessage`] will either be:
     ///
-    /// - `StateAndMessage::WithMessage { state, message }`: the `state` will be either
-    ///   `State::Continued` and should be stored by the host for use in the next round or
-    ///   `State::Finished`, in which case preparation is finished and the output share may be
-    ///   accumulated. Regardless of state, `message` should be transmitted to the peer.
+    /// - `StateAndMessage::WithMessage { transition }`: `transition` should be evaluated, yielding
+    ///   a [`Message`], which should be transmitted to the peer, and a [`State`].
+    ///
+    ///   If the state is `State::Continued`, then it should be used by this aggregator along with
+    ///   the next `Message` received from the peer as input to [`Self::continued`] to advance to
+    ///   the next round. The aggregator may store the `Transition` between rounds of preparation
+    ///   instead of the `State` and `Message`.
+    ///
+    ///   If the state is `State::Finished`, then preparation is finished and the output share may be
+    ///   accumulated.
+    ///
     /// - `StateAndMessage::FinishedNoMessage`: preparation is finished and the output share may be
-    ///   accumulated. No message needs to be send to the peer.
+    ///   accumulated. No message needs to be sent to the peer.
     ///
     /// # Errors
     ///
@@ -339,29 +430,7 @@ pub trait PingPongTopology<const VERIFY_KEY_SIZE: usize, const NONCE_SIZE: usize
         role: Role,
         host_state: Self::State,
         inbound: &Message,
-    ) -> Result<StateAndMessage<Self::PrepareState, Self::OutputShare>, PingPongError>;
-}
-
-/// Private interfaces for VDAF Ping-Pong topology.
-trait PingPongTopologyPrivate<const VERIFY_KEY_SIZE: usize, const NONCE_SIZE: usize>:
-    PingPongTopology<VERIFY_KEY_SIZE, NONCE_SIZE>
-{
-    /// Corresponds to `ping_pong_transition` in the forthcoming `draft-irtf-cfrg-vdaf-07`.
-    /// `prep_shares` must be ordered so that the leader's prepare share is first.
-    ///
-    /// # Notes
-    ///
-    /// The specification of this function in [VDAF] takes the aggregation parameter. This version
-    /// does not, because [`vdaf::Vdaf::prepare_preprocess`] does not take the aggregation
-    /// parameter. This may change in the future if/when [#670][issue] is addressed.
-    ///
-    /// [VDAF]: https://datatracker.ietf.org/doc/html/draft-irtf-cfrg-vdaf-06#section-5.8
-    /// [issue]: https://github.com/divviup/libprio-rs/issues/670
-    fn transition(
-        &self,
-        prep_shares: [Self::PrepareShare; 2],
-        host_prep_state: Self::PrepareState,
-    ) -> Result<(Self::State, Message), PingPongError>;
+    ) -> Result<StateAndMessage<VERIFY_KEY_SIZE, NONCE_SIZE, Self>, PingPongError>;
 }
 
 impl<const VERIFY_KEY_SIZE: usize, const NONCE_SIZE: usize, A>
@@ -369,8 +438,8 @@ impl<const VERIFY_KEY_SIZE: usize, const NONCE_SIZE: usize, A>
 where
     A: Aggregator<VERIFY_KEY_SIZE, NONCE_SIZE>,
 {
-    type State = State<A::PrepareState, A::OutputShare>;
-    type StateAndMessage = StateAndMessage<A::PrepareState, A::OutputShare>;
+    type State = State<VERIFY_KEY_SIZE, NONCE_SIZE, Self>;
+    type StateAndMessage = StateAndMessage<VERIFY_KEY_SIZE, NONCE_SIZE, Self>;
 
     fn leader_initialize(
         &self,
@@ -407,7 +476,7 @@ where
         public_share: &Self::PublicShare,
         input_share: &Self::InputShare,
         inbound: &Message,
-    ) -> Result<(Self::State, Message), PingPongError> {
+    ) -> Result<Transition<VERIFY_KEY_SIZE, NONCE_SIZE, Self>, PingPongError> {
         let (prep_state, prep_share) = self
             .prepare_init(
                 verify_key,
@@ -429,7 +498,14 @@ where
             ));
         };
 
-        self.transition([inbound_prep_share, prep_share], prep_state)
+        let current_prepare_message = self
+            .prepare_preprocess([inbound_prep_share, prep_share])
+            .map_err(PingPongError::VdafPreparePreprocess)?;
+
+        Ok(Transition {
+            previous_prepare_state: prep_state,
+            current_prepare_message,
+        })
     }
 
     fn continued(
@@ -478,8 +554,16 @@ where
                 if role == Role::Leader {
                     prep_shares.reverse();
                 }
-                self.transition(prep_shares, next_prep_state)
-                    .map(|(state, message)| StateAndMessage::WithMessage { state, message })
+                let current_prepare_message = self
+                    .prepare_preprocess(prep_shares)
+                    .map_err(PingPongError::VdafPreparePreprocess)?;
+
+                Ok(StateAndMessage::WithMessage {
+                    transition: Transition {
+                        previous_prepare_state: next_prep_state,
+                        current_prepare_message,
+                    },
+                })
             }
             (PrepareTransition::Finish(output_share), None) => {
                 Ok(StateAndMessage::FinishedNoMessage { output_share })
@@ -494,40 +578,6 @@ where
                 ))
             }
         }
-    }
-}
-
-impl<const VERIFY_KEY_SIZE: usize, const NONCE_SIZE: usize, A>
-    PingPongTopologyPrivate<VERIFY_KEY_SIZE, NONCE_SIZE> for A
-where
-    A: Aggregator<VERIFY_KEY_SIZE, NONCE_SIZE>,
-{
-    fn transition(
-        &self,
-        prep_shares: [Self::PrepareShare; 2],
-        host_prep_state: Self::PrepareState,
-    ) -> Result<(Self::State, Message), PingPongError> {
-        let prep_message = self
-            .prepare_preprocess(prep_shares)
-            .map_err(PingPongError::VdafPreparePreprocess)?;
-
-        self.prepare_step(host_prep_state, prep_message.clone())
-            .map(|transition| match transition {
-                PrepareTransition::Continue(prep_state, prep_share) => (
-                    State::Continued(prep_state),
-                    Message::Continue {
-                        prep_msg: prep_message.get_encoded(),
-                        prep_share: prep_share.get_encoded(),
-                    },
-                ),
-                PrepareTransition::Finish(output_share) => (
-                    State::Finished(output_share),
-                    Message::Finish {
-                        prep_msg: prep_message.get_encoded(),
-                    },
-                ),
-            })
-            .map_err(PingPongError::VdafPrepareStep)
     }
 }
 
@@ -572,6 +622,8 @@ mod tests {
                 &input_share,
                 &leader_message,
             )
+            .unwrap()
+            .evaluate(&helper)
             .unwrap();
 
         // 1 round VDAF: helper should finish immediately.
@@ -617,6 +669,8 @@ mod tests {
                 &input_share,
                 &leader_message,
             )
+            .unwrap()
+            .evaluate(&helper)
             .unwrap();
 
         // 2 round VDAF, round 1: helper should continue.
@@ -627,7 +681,11 @@ mod tests {
             .unwrap();
         // 2 round VDAF, round 1: leader should finish and emit a finish message.
         let leader_message = assert_matches!(
-            leader_state, StateAndMessage::WithMessage { state: State::Finished(_), message } => message
+            leader_state, StateAndMessage::WithMessage { transition } => {
+                let (state, message) = transition.evaluate(&leader).unwrap();
+                assert_matches!(state, State::Finished(_));
+                message
+            }
         );
 
         let helper_state = helper
@@ -670,6 +728,8 @@ mod tests {
                 &input_share,
                 &leader_message,
             )
+            .unwrap()
+            .evaluate(&helper)
             .unwrap();
 
         // 3 round VDAF, round 1: helper should continue.
@@ -680,15 +740,23 @@ mod tests {
             .unwrap();
         // 3 round VDAF, round 1: leader should continue and emit a continue message.
         let (leader_state, leader_message) = assert_matches!(
-            leader_state, StateAndMessage::WithMessage { ref message, state } => (state, message)
+            leader_state, StateAndMessage::WithMessage { transition } => {
+                let (state, message) = transition.evaluate(&leader).unwrap();
+                assert_matches!(state, State::Continued(_));
+                (state, message)
+            }
         );
 
         let helper_state = helper
-            .continued(Role::Helper, helper_state, leader_message)
+            .continued(Role::Helper, helper_state, &leader_message)
             .unwrap();
         // 3 round vdaf, round 2: helper should finish and emit a finish message.
         let helper_message = assert_matches!(
-            helper_state, StateAndMessage::WithMessage { message, state: State::Finished(_) } => message
+            helper_state, StateAndMessage::WithMessage { transition } => {
+                let (state, message) = transition.evaluate(&helper).unwrap();
+                assert_matches!(state, State::Finished(_));
+                message
+            }
         );
 
         let leader_state = leader

--- a/src/topology/ping_pong.rs
+++ b/src/topology/ping_pong.rs
@@ -1,11 +1,15 @@
 // SPDX-License-Identifier: MPL-2.0
 
 //! Implements the Ping-Pong Topology described in [VDAF]. This topology assumes there are exactly
-//! two aggregators, designated "Leader" and "Helper". Note that while this implementation is
-//! compatible with VDAF-06, it actually implements the ping-pong wrappers specified in VDAF-07
-//! (forthcoming) since those line up better with the VDAF implementation in this crate.
+//! two aggregators, designated "Leader" and "Helper". This topology is required for implementing
+//! the [Distributed Aggregation Protocol][DAP].
+//!
+//! Note that while this implementation is compatible with VDAF-06, it actually implements the
+//! ping-pong wrappers specified in VDAF-07 (forthcoming) since those line up better with the VDAF
+//! implementation in this crate.
 //!
 //! [VDAF]: https://datatracker.ietf.org/doc/html/draft-irtf-cfrg-vdaf-06#section-5.8
+//! [DAP]: https://datatracker.ietf.org/doc/html/draft-ietf-ppm-dap
 
 use crate::{
     codec::{decode_u32_items, encode_u32_items, CodecError, Decode, Encode, ParameterizedDecode},
@@ -45,22 +49,13 @@ pub enum PingPongError {
     InternalError(&'static str),
 }
 
-/// Distinguished aggregator roles.
-#[derive(Clone, Copy, Debug, PartialEq, Eq)]
-pub enum Role {
-    /// The Leader aggregator.
-    Leader,
-    /// The Helper aggregator.
-    Helper,
-}
-
 /// Corresponds to `struct Message` in [VDAF's Ping-Pong Topology][VDAF]. All of the fields of the
 /// variants are opaque byte buffers. This is because the ping-pong routines take responsibility for
 /// decoding preparation shares and messages, which usually requires having the preparation state.
 ///
 /// [VDAF]: https://datatracker.ietf.org/doc/html/draft-irtf-cfrg-vdaf-06#section-5.8
 #[derive(Clone, PartialEq, Eq)]
-pub enum Message {
+pub enum PingPongMessage {
     /// Corresponds to MessageType.initialize.
     Initialize {
         /// The leader's initial preparation share.
@@ -80,7 +75,7 @@ pub enum Message {
     },
 }
 
-impl Message {
+impl PingPongMessage {
     fn state_name(&self) -> &'static str {
         match self {
             Self::Initialize { .. } => "Initialize",
@@ -90,13 +85,19 @@ impl Message {
     }
 }
 
-impl Debug for Message {
+impl Debug for PingPongMessage {
+    // We want `PingPongMessage` to implement `Debug`, but we don't want that impl to print out
+    // prepare shares or messages, because (1) their contents are sensitive and (2) their contents
+    // are long and not intelligible to humans. For both reasons they generally shouldn't get
+    // logged. Normally, we'd use the `derivative` crate to customize a derived `Debug`, but that
+    // crate has not been audited (in the `cargo vet` sense) so we can't use it here unless we audit
+    // 8,000+ lines of proc macros.
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         f.debug_tuple(self.state_name()).finish()
     }
 }
 
-impl Encode for Message {
+impl Encode for PingPongMessage {
     fn encode(&self, bytes: &mut Vec<u8>) {
         // The encoding includes an implicit discriminator byte, called MessageType in the VDAF
         // spec.
@@ -132,7 +133,7 @@ impl Encode for Message {
     }
 }
 
-impl Decode for Message {
+impl Decode for PingPongMessage {
     fn decode(bytes: &mut std::io::Cursor<&[u8]>) -> Result<Self, CodecError> {
         let message_type = u8::decode(bytes)?;
         Ok(match message_type {
@@ -162,7 +163,7 @@ impl Decode for Message {
 ///
 /// # Discussion
 ///
-/// The obvious implementation would of `ping_pong_transition` would be a method on trait
+/// The obvious implementation of `ping_pong_transition` would be a method on trait
 /// [`PingPongTopology`] that returns `(State, Message)`, and then `ContinuedValue::WithMessage`
 /// would contain those values. But then DAP implementations would have to store relatively large
 /// VDAF prepare shares between rounds of input preparation.
@@ -173,7 +174,7 @@ impl Decode for Message {
 ///
 /// [VDAF]: https://datatracker.ietf.org/doc/html/draft-irtf-cfrg-vdaf-06#section-5.8
 #[derive(Clone, Debug, Eq)]
-pub struct Transition<
+pub struct PingPongTransition<
     const VERIFY_KEY_SIZE: usize,
     const NONCE_SIZE: usize,
     A: Aggregator<VERIFY_KEY_SIZE, NONCE_SIZE>,
@@ -186,15 +187,21 @@ impl<
         const VERIFY_KEY_SIZE: usize,
         const NONCE_SIZE: usize,
         A: Aggregator<VERIFY_KEY_SIZE, NONCE_SIZE>,
-    > Transition<VERIFY_KEY_SIZE, NONCE_SIZE, A>
+    > PingPongTransition<VERIFY_KEY_SIZE, NONCE_SIZE, A>
 {
-    /// Evaluate this transition to obtain a new [`State`] and a [`Message`] which should be
-    /// transmitted to the peer.
+    /// Evaluate this transition to obtain a new [`PingPongState`] and a [`PingPongMessage`] which
+    /// should be transmitted to the peer.
     #[allow(clippy::type_complexity)]
     pub fn evaluate(
         &self,
         vdaf: &A,
-    ) -> Result<(State<VERIFY_KEY_SIZE, NONCE_SIZE, A>, Message), PingPongError> {
+    ) -> Result<
+        (
+            PingPongState<VERIFY_KEY_SIZE, NONCE_SIZE, A>,
+            PingPongMessage,
+        ),
+        PingPongError,
+    > {
         let prep_msg = self.current_prepare_message.get_encoded();
 
         vdaf.prepare_step(
@@ -203,15 +210,16 @@ impl<
         )
         .map(|transition| match transition {
             PrepareTransition::Continue(prep_state, prep_share) => (
-                State::Continued(prep_state),
-                Message::Continue {
+                PingPongState::Continued(prep_state),
+                PingPongMessage::Continue {
                     prep_msg,
                     prep_share: prep_share.get_encoded(),
                 },
             ),
-            PrepareTransition::Finish(output_share) => {
-                (State::Finished(output_share), Message::Finish { prep_msg })
-            }
+            PrepareTransition::Finish(output_share) => (
+                PingPongState::Finished(output_share),
+                PingPongMessage::Finish { prep_msg },
+            ),
         })
         .map_err(PingPongError::VdafPrepareStep)
     }
@@ -221,7 +229,7 @@ impl<
         const VERIFY_KEY_SIZE: usize,
         const NONCE_SIZE: usize,
         A: Aggregator<VERIFY_KEY_SIZE, NONCE_SIZE>,
-    > PartialEq for Transition<VERIFY_KEY_SIZE, NONCE_SIZE, A>
+    > PartialEq for PingPongTransition<VERIFY_KEY_SIZE, NONCE_SIZE, A>
 {
     fn eq(&self, other: &Self) -> bool {
         self.previous_prepare_state == other.previous_prepare_state
@@ -233,7 +241,7 @@ impl<
         const VERIFY_KEY_SIZE: usize,
         const NONCE_SIZE: usize,
         A: Aggregator<VERIFY_KEY_SIZE, NONCE_SIZE>,
-    > Default for Transition<VERIFY_KEY_SIZE, NONCE_SIZE, A>
+    > Default for PingPongTransition<VERIFY_KEY_SIZE, NONCE_SIZE, A>
 where
     A::PrepareState: Default,
     A::PrepareMessage: Default,
@@ -247,7 +255,7 @@ where
 }
 
 impl<const VERIFY_KEY_SIZE: usize, const NONCE_SIZE: usize, A> Encode
-    for Transition<VERIFY_KEY_SIZE, NONCE_SIZE, A>
+    for PingPongTransition<VERIFY_KEY_SIZE, NONCE_SIZE, A>
 where
     A: Aggregator<VERIFY_KEY_SIZE, NONCE_SIZE>,
     A::PrepareState: Encode,
@@ -266,7 +274,7 @@ where
 }
 
 impl<const VERIFY_KEY_SIZE: usize, const NONCE_SIZE: usize, A, PrepareStateDecode>
-    ParameterizedDecode<PrepareStateDecode> for Transition<VERIFY_KEY_SIZE, NONCE_SIZE, A>
+    ParameterizedDecode<PrepareStateDecode> for PingPongTransition<VERIFY_KEY_SIZE, NONCE_SIZE, A>
 where
     A: Aggregator<VERIFY_KEY_SIZE, NONCE_SIZE>,
     A::PrepareState: ParameterizedDecode<PrepareStateDecode> + PartialEq,
@@ -294,7 +302,7 @@ where
 ///
 /// [VDAF]: https://datatracker.ietf.org/doc/html/draft-irtf-cfrg-vdaf-06#section-5.8
 #[derive(Clone, Debug, PartialEq, Eq)]
-pub enum State<
+pub enum PingPongState<
     const VERIFY_KEY_SIZE: usize,
     const NONCE_SIZE: usize,
     A: Aggregator<VERIFY_KEY_SIZE, NONCE_SIZE>,
@@ -305,18 +313,20 @@ pub enum State<
     Finished(A::OutputShare),
 }
 
-/// Values returned by [`PingPongTopology::continued`].
+/// Values returned by [`PingPongTopology::leader_continued`] or
+/// [`PingPongTopology::helper_continued`].
 #[derive(Clone, Debug)]
-pub enum ContinuedValue<
+pub enum PingPongContinuedValue<
     const VERIFY_KEY_SIZE: usize,
     const NONCE_SIZE: usize,
     A: Aggregator<VERIFY_KEY_SIZE, NONCE_SIZE>,
 > {
     /// The operation resulted in a new state and a message to transmit to the peer.
     WithMessage {
-        /// The transition that will be executed. Call `Transition::evaluate` to obtain the next
-        /// [`State`] and a [`Message`] to transmit to the peer.
-        transition: Transition<VERIFY_KEY_SIZE, NONCE_SIZE, A>,
+        /// The transition that will be executed. Call `PingPongTransition::evaluate` to obtain the
+        /// next
+        /// [`PingPongState`] and a [`PingPongMessage`] to transmit to the peer.
+        transition: PingPongTransition<VERIFY_KEY_SIZE, NONCE_SIZE, A>,
     },
     /// The operation caused the host to finish preparation of the input share, yielding an output
     /// share and no message for the peer.
@@ -332,81 +342,85 @@ pub enum ContinuedValue<
 pub trait PingPongTopology<const VERIFY_KEY_SIZE: usize, const NONCE_SIZE: usize>:
     Aggregator<VERIFY_KEY_SIZE, NONCE_SIZE>
 {
-    /// Specialization of [`State`] for this VDAF.
+    /// Specialization of [`PingPongState`] for this VDAF.
     type State;
-    /// Specialization of [`ContinuedValue`] for this VDAF.
+    /// Specialization of [`PingPongContinuedValue`] for this VDAF.
     type ContinuedValue;
-    /// Specializaton of [`Transition`] for this VDAF.
+    /// Specializaton of [`PingPongTransition`] for this VDAF.
     type Transition;
 
     /// Initialize leader state using the leader's input share. Corresponds to
-    /// `ping_pong_leader_init` in the forthcoming `draft-irtf-cfrg-vdaf-07`.
+    /// `ping_pong_leader_init` in [VDAF].
     ///
-    /// If successful, the returned [`Message`] (which will always be `Message::Initialize`) should
-    /// be transmitted to the helper. The returned [`State`] (which will always be
-    /// `State::Continued`) should be used by the leader along with the next [`Message`] received
-    /// from the helper as input to [`Self::continued`] to advance to the next round.
-    fn leader_initialize(
+    /// If successful, the returned [`PingPongMessage`] (which will always be
+    /// `PingPongMessage::Initialize`) should be transmitted to the helper. The returned
+    /// [`PingPongState`] (which will always be `PingPongState::Continued`) should be used by the
+    /// leader along with the next [`PingPongMessage`] received from the helper as input to
+    /// [`Self::leader_continued`] to advance to the next round.
+    ///
+    /// [VDAF]: https://datatracker.ietf.org/doc/html/draft-irtf-cfrg-vdaf-06#section-5.8
+    fn leader_initialized(
         &self,
         verify_key: &[u8; VERIFY_KEY_SIZE],
         agg_param: &Self::AggregationParam,
         nonce: &[u8; NONCE_SIZE],
         public_share: &Self::PublicShare,
         input_share: &Self::InputShare,
-    ) -> Result<(Self::State, Message), PingPongError>;
+    ) -> Result<(Self::State, PingPongMessage), PingPongError>;
 
     /// Initialize helper state using the helper's input share and the leader's first prepare share.
     /// Corresponds to `ping_pong_helper_init` in the forthcoming `draft-irtf-cfrg-vdaf-07`.
     ///
-    /// If successful, the returned [`Transition`] should be evaluated, yielding a [`Message`],
-    /// which should be transmitted to the leader, and a [`State`].
+    /// If successful, the returned [`PingPongTransition`] should be evaluated, yielding a
+    /// [`PingPongMessage`], which should be transmitted to the leader, and a [`PingPongState`].
     ///
-    /// If the state is `State::Continued`, then it should be used by the helper along with the next
-    /// `Message` received from the leader as input to [`Self::continued`] to advance to the next
-    /// round. The helper may store the `Transition` between rounds of preparation instead of the
-    /// `State` and `Message`.
+    /// If the state is `PingPongState::Continued`, then it should be used by the helper along with
+    /// the next `PingPongMessage` received from the leader as input to [`Self::helper_continued`]
+    /// to advance to the next round. The helper may store the `PingPongTransition` between rounds
+    /// of preparation instead of the `PingPongState` and `PingPongMessage`.
     ///
-    /// If the state is `State::Finished`, then preparation is finished and the output share may be
-    /// accumulated.
+    /// If the state is `PingPongState::Finished`, then preparation is finished and the output share
+    /// may be accumulated.
     ///
     /// # Errors
     ///
-    /// `inbound` must be `Message::Initialize` or the function will fail.
-    fn helper_initialize(
+    /// `inbound` must be `PingPongMessage::Initialize` or the function will fail.
+    fn helper_initialized(
         &self,
         verify_key: &[u8; VERIFY_KEY_SIZE],
         agg_param: &Self::AggregationParam,
         nonce: &[u8; NONCE_SIZE],
         public_share: &Self::PublicShare,
         input_share: &Self::InputShare,
-        inbound: &Message,
-    ) -> Result<Transition<VERIFY_KEY_SIZE, NONCE_SIZE, Self>, PingPongError>;
+        inbound: &PingPongMessage,
+    ) -> Result<PingPongTransition<VERIFY_KEY_SIZE, NONCE_SIZE, Self>, PingPongError>;
 
-    /// Continue preparation based on the host's current state and an incoming [`Message`] from the
-    /// peer. `role` is the host's [`Role`]. Corresponds to `ping_pong_contnued` in the forthcoming
-    /// `draft-irtf-cfrg-vdaf-07`.
+    /// Continue preparation based on the leader's current state and an incoming [`PingPongMessage`]
+    /// from the helper. Corresponds to `ping_pong_leader_continued` in [VDAF].
     ///
-    /// If successful, the returned [`ContinuedValue`] will either be:
+    /// If successful, the returned [`PingPongContinuedValue`] will either be:
     ///
-    /// - `ContinuedValue::WithMessage { transition }`: `transition` should be evaluated, yielding a
-    ///   [`Message`], which should be transmitted to the peer, and a [`State`].
+    /// - `PingPongContinuedValue::WithMessage { transition }`: `transition` should be evaluated,
+    ///   yielding a [`PingPongMessage`], which should be transmitted to the helper, and a
+    ///   [`PingPongState`].
     ///
-    ///   If the state is `State::Continued`, then it should be used by this aggregator along with
-    ///   the next `Message` received from the peer as input to [`Self::continued`] to advance to
-    ///   the next round. The aggregator may store the `Transition` between rounds of preparation
-    ///   instead of the `State` and `Message`.
+    ///   If the state is `PingPongState::Continued`, then it should be used by the leader along
+    ///   with the next `PingPongMessage` received from the helper as input to
+    ///   [`Self::leader_continued`] to advance to the next round. The leader may store the
+    ///   `PingPongTransition` between rounds of preparation instead of of the `PingPongState` and
+    ///   `PingPongMessage`.
     ///
-    ///   If the state is `State::Finished`, then preparation is finished and the output share may
-    ///   be accumulated.
+    ///   If the state is `PingPongState::Finished`, then preparation is finished and the output
+    ///   share may be accumulated.
     ///
-    /// - `ContinuedValue::FinishedNoMessage`: preparation is finished and the output share may be
-    ///   accumulated. No message needs to be sent to the peer.
+    /// - `PingPongContinuedValue::FinishedNoMessage`: preparation is finished and the output share
+    ///    may be accumulated. No message needs to be sent to the helper.
     ///
     /// # Errors
     ///
-    /// `host_state` must be `State::Continued` or the function will fail.
+    /// `leader_state` must be `PingPongState::Continued` or the function will fail.
     ///
-    /// `inbound` must not be `Message::Initialize` or the function will fail.
+    /// `inbound` must not be `PingPongMessage::Initialize` or the function will fail.
     ///
     /// # Notes
     ///
@@ -417,11 +431,64 @@ pub trait PingPongTopology<const VERIFY_KEY_SIZE: usize, const NONCE_SIZE: usize
     ///
     /// [VDAF]: https://datatracker.ietf.org/doc/html/draft-irtf-cfrg-vdaf-06#section-5.8
     /// [issue]: https://github.com/divviup/libprio-rs/issues/670
+    fn leader_continued(
+        &self,
+        leader_state: Self::State,
+        inbound: &PingPongMessage,
+    ) -> Result<Self::ContinuedValue, PingPongError>;
+
+    /// PingPongContinue preparation based on the helper's current state and an incoming
+    /// [`PingPongMessage`] from the leader. Corresponds to `ping_pong_helper_contnued` in [VDAF].
+    ///
+    /// If successful, the returned [`PingPongContinuedValue`] will either be:
+    ///
+    /// - `PingPongContinuedValue::WithMessage { transition }`: `transition` should be evaluated,
+    ///   yielding a [`PingPongMessage`], which should be transmitted to the leader, and a
+    ///   [`PingPongState`].
+    ///
+    ///   If the state is `PingPongState::Continued`, then it should be used by the helper along
+    ///   with the next `PingPongMessage` received from the leader as input to
+    ///   [`Self::helper_continued`] to advance to the next round. The helper may store the
+    ///   `PingPongTransition` between rounds of preparation instead of the `PingPongState` and
+    ///   `PingPongMessage`.
+    ///
+    ///   If the state is `PingPongState::Finished`, then preparation is finished and the output
+    ///   share may be accumulated.
+    ///
+    /// - `PingPongContinuedValue::FinishedNoMessage`: preparation is finished and the output share
+    ///   may be accumulated. No message needs to be sent to the leader.
+    ///
+    /// # Errors
+    ///
+    /// `helper_state` must be `PingPongState::Continued` or the function will fail.
+    ///
+    /// `inbound` must not be `PingPongMessage::Initialize` or the function will fail.
+    ///
+    /// # Notes
+    ///
+    /// The specification of this function in [VDAF] takes the aggregation parameter. This version
+    /// does not, because [`crate::vdaf::Aggregator::prepare_preprocess`] does not take the
+    /// aggregation parameter. This may change in the future if/when [#670][issue] is addressed.
+    ///
+    ///
+    /// [VDAF]: https://datatracker.ietf.org/doc/html/draft-irtf-cfrg-vdaf-06#section-5.8
+    /// [issue]: https://github.com/divviup/libprio-rs/issues/670
+    fn helper_continued(
+        &self,
+        helper_state: Self::State,
+        inbound: &PingPongMessage,
+    ) -> Result<Self::ContinuedValue, PingPongError>;
+}
+
+/// Private interfaces for implementing ping-pong
+trait PingPongTopologyPrivate<const VERIFY_KEY_SIZE: usize, const NONCE_SIZE: usize>:
+    PingPongTopology<VERIFY_KEY_SIZE, NONCE_SIZE>
+{
     fn continued(
         &self,
-        role: Role,
-        host_state: Self::State,
-        inbound: &Message,
+        is_leader: bool,
+        helper_state: Self::State,
+        inbound: &PingPongMessage,
     ) -> Result<Self::ContinuedValue, PingPongError>;
 }
 
@@ -430,18 +497,18 @@ impl<const VERIFY_KEY_SIZE: usize, const NONCE_SIZE: usize, A>
 where
     A: Aggregator<VERIFY_KEY_SIZE, NONCE_SIZE>,
 {
-    type State = State<VERIFY_KEY_SIZE, NONCE_SIZE, Self>;
-    type ContinuedValue = ContinuedValue<VERIFY_KEY_SIZE, NONCE_SIZE, Self>;
-    type Transition = Transition<VERIFY_KEY_SIZE, NONCE_SIZE, Self>;
+    type State = PingPongState<VERIFY_KEY_SIZE, NONCE_SIZE, Self>;
+    type ContinuedValue = PingPongContinuedValue<VERIFY_KEY_SIZE, NONCE_SIZE, Self>;
+    type Transition = PingPongTransition<VERIFY_KEY_SIZE, NONCE_SIZE, Self>;
 
-    fn leader_initialize(
+    fn leader_initialized(
         &self,
         verify_key: &[u8; VERIFY_KEY_SIZE],
         agg_param: &Self::AggregationParam,
         nonce: &[u8; NONCE_SIZE],
         public_share: &Self::PublicShare,
         input_share: &Self::InputShare,
-    ) -> Result<(Self::State, Message), PingPongError> {
+    ) -> Result<(Self::State, PingPongMessage), PingPongError> {
         self.prepare_init(
             verify_key,
             /* Leader */ 0,
@@ -452,8 +519,8 @@ where
         )
         .map(|(prep_state, prep_share)| {
             (
-                State::Continued(prep_state),
-                Message::Initialize {
+                PingPongState::Continued(prep_state),
+                PingPongMessage::Initialize {
                     prep_share: prep_share.get_encoded(),
                 },
             )
@@ -461,14 +528,14 @@ where
         .map_err(PingPongError::VdafPrepareInit)
     }
 
-    fn helper_initialize(
+    fn helper_initialized(
         &self,
         verify_key: &[u8; VERIFY_KEY_SIZE],
         agg_param: &Self::AggregationParam,
         nonce: &[u8; NONCE_SIZE],
         public_share: &Self::PublicShare,
         input_share: &Self::InputShare,
-        inbound: &Message,
+        inbound: &PingPongMessage,
     ) -> Result<Self::Transition, PingPongError> {
         let (prep_state, prep_share) = self
             .prepare_init(
@@ -481,7 +548,7 @@ where
             )
             .map_err(PingPongError::VdafPrepareInit)?;
 
-        let inbound_prep_share = if let Message::Initialize { prep_share } = inbound {
+        let inbound_prep_share = if let PingPongMessage::Initialize { prep_share } = inbound {
             Self::PrepareShare::get_decoded_with_param(&prep_state, prep_share)
                 .map_err(PingPongError::CodecPrepShare)?
         } else {
@@ -495,36 +562,58 @@ where
             .prepare_preprocess([inbound_prep_share, prep_share])
             .map_err(PingPongError::VdafPreparePreprocess)?;
 
-        Ok(Transition {
+        Ok(PingPongTransition {
             previous_prepare_state: prep_state,
             current_prepare_message,
         })
     }
 
+    fn leader_continued(
+        &self,
+        leader_state: Self::State,
+        inbound: &PingPongMessage,
+    ) -> Result<Self::ContinuedValue, PingPongError> {
+        self.continued(true, leader_state, inbound)
+    }
+
+    fn helper_continued(
+        &self,
+        helper_state: Self::State,
+        inbound: &PingPongMessage,
+    ) -> Result<Self::ContinuedValue, PingPongError> {
+        self.continued(false, helper_state, inbound)
+    }
+}
+
+impl<const VERIFY_KEY_SIZE: usize, const NONCE_SIZE: usize, A>
+    PingPongTopologyPrivate<VERIFY_KEY_SIZE, NONCE_SIZE> for A
+where
+    A: Aggregator<VERIFY_KEY_SIZE, NONCE_SIZE>,
+{
     fn continued(
         &self,
-        role: Role,
+        is_leader: bool,
         host_state: Self::State,
-        inbound: &Message,
+        inbound: &PingPongMessage,
     ) -> Result<Self::ContinuedValue, PingPongError> {
-        let host_prep_state = if let State::Continued(state) = host_state {
+        let host_prep_state = if let PingPongState::Continued(state) = host_state {
             state
         } else {
             return Err(PingPongError::StateMismatch("finished", "continue"));
         };
 
         let (prep_msg, next_peer_prep_share) = match inbound {
-            Message::Initialize { .. } => {
+            PingPongMessage::Initialize { .. } => {
                 return Err(PingPongError::StateMismatch(
                     "continue",
                     inbound.state_name(),
                 ));
             }
-            Message::Continue {
+            PingPongMessage::Continue {
                 prep_msg,
                 prep_share,
             } => (prep_msg, Some(prep_share)),
-            Message::Finish { prep_msg } => (prep_msg, None),
+            PingPongMessage::Finish { prep_msg } => (prep_msg, None),
         };
 
         let prep_msg = Self::PrepareMessage::get_decoded_with_param(&host_prep_state, prep_msg)
@@ -544,22 +633,22 @@ where
                 )
                 .map_err(PingPongError::CodecPrepShare)?;
                 let mut prep_shares = [next_peer_prep_share, next_host_prep_share];
-                if role == Role::Leader {
+                if is_leader {
                     prep_shares.reverse();
                 }
                 let current_prepare_message = self
                     .prepare_preprocess(prep_shares)
                     .map_err(PingPongError::VdafPreparePreprocess)?;
 
-                Ok(ContinuedValue::WithMessage {
-                    transition: Transition {
+                Ok(PingPongContinuedValue::WithMessage {
+                    transition: PingPongTransition {
                         previous_prepare_state: next_prep_state,
                         current_prepare_message,
                     },
                 })
             }
             (PrepareTransition::Finish(output_share), None) => {
-                Ok(ContinuedValue::FinishedNoMessage { output_share })
+                Ok(PingPongContinuedValue::FinishedNoMessage { output_share })
             }
             (transition, _) => {
                 return Err(PingPongError::StateMismatch(
@@ -596,7 +685,7 @@ mod tests {
 
         // Leader inits into round 0
         let (leader_state, leader_message) = leader
-            .leader_initialize(
+            .leader_initialized(
                 &verify_key,
                 &aggregation_param,
                 &nonce,
@@ -607,7 +696,7 @@ mod tests {
 
         // Helper inits into round 1
         let (helper_state, helper_message) = helper
-            .helper_initialize(
+            .helper_initialized(
                 &verify_key,
                 &aggregation_param,
                 &nonce,
@@ -620,13 +709,16 @@ mod tests {
             .unwrap();
 
         // 1 round VDAF: helper should finish immediately.
-        assert_matches!(helper_state, State::Finished(_));
+        assert_matches!(helper_state, PingPongState::Finished(_));
 
         let leader_state = leader
-            .continued(Role::Leader, leader_state, &helper_message)
+            .leader_continued(leader_state, &helper_message)
             .unwrap();
         // 1 round VDAF: leader should finish when it gets helper message and emit no message.
-        assert_matches!(leader_state, ContinuedValue::FinishedNoMessage { .. });
+        assert_matches!(
+            leader_state,
+            PingPongContinuedValue::FinishedNoMessage { .. }
+        );
     }
 
     #[test]
@@ -643,7 +735,7 @@ mod tests {
 
         // Leader inits into round 0
         let (leader_state, leader_message) = leader
-            .leader_initialize(
+            .leader_initialized(
                 &verify_key,
                 &aggregation_param,
                 &nonce,
@@ -654,7 +746,7 @@ mod tests {
 
         // Helper inits into round 1
         let (helper_state, helper_message) = helper
-            .helper_initialize(
+            .helper_initialized(
                 &verify_key,
                 &aggregation_param,
                 &nonce,
@@ -667,25 +759,28 @@ mod tests {
             .unwrap();
 
         // 2 round VDAF, round 1: helper should continue.
-        assert_matches!(helper_state, State::Continued(_));
+        assert_matches!(helper_state, PingPongState::Continued(_));
 
         let leader_state = leader
-            .continued(Role::Leader, leader_state, &helper_message)
+            .leader_continued(leader_state, &helper_message)
             .unwrap();
         // 2 round VDAF, round 1: leader should finish and emit a finish message.
         let leader_message = assert_matches!(
-            leader_state, ContinuedValue::WithMessage { transition } => {
+            leader_state, PingPongContinuedValue::WithMessage { transition } => {
                 let (state, message) = transition.evaluate(&leader).unwrap();
-                assert_matches!(state, State::Finished(_));
+                assert_matches!(state, PingPongState::Finished(_));
                 message
             }
         );
 
         let helper_state = helper
-            .continued(Role::Helper, helper_state, &leader_message)
+            .helper_continued(helper_state, &leader_message)
             .unwrap();
         // 2 round vdaf, round 1: helper should finish and emit no message.
-        assert_matches!(helper_state, ContinuedValue::FinishedNoMessage { .. });
+        assert_matches!(
+            helper_state,
+            PingPongContinuedValue::FinishedNoMessage { .. }
+        );
     }
 
     #[test]
@@ -702,7 +797,7 @@ mod tests {
 
         // Leader inits into round 0
         let (leader_state, leader_message) = leader
-            .leader_initialize(
+            .leader_initialized(
                 &verify_key,
                 &aggregation_param,
                 &nonce,
@@ -713,7 +808,7 @@ mod tests {
 
         // Helper inits into round 1
         let (helper_state, helper_message) = helper
-            .helper_initialize(
+            .helper_initialized(
                 &verify_key,
                 &aggregation_param,
                 &nonce,
@@ -726,44 +821,47 @@ mod tests {
             .unwrap();
 
         // 3 round VDAF, round 1: helper should continue.
-        assert_matches!(helper_state, State::Continued(_));
+        assert_matches!(helper_state, PingPongState::Continued(_));
 
         let leader_state = leader
-            .continued(Role::Leader, leader_state, &helper_message)
+            .leader_continued(leader_state, &helper_message)
             .unwrap();
         // 3 round VDAF, round 1: leader should continue and emit a continue message.
         let (leader_state, leader_message) = assert_matches!(
-            leader_state, ContinuedValue::WithMessage { transition } => {
+            leader_state, PingPongContinuedValue::WithMessage { transition } => {
                 let (state, message) = transition.evaluate(&leader).unwrap();
-                assert_matches!(state, State::Continued(_));
+                assert_matches!(state, PingPongState::Continued(_));
                 (state, message)
             }
         );
 
         let helper_state = helper
-            .continued(Role::Helper, helper_state, &leader_message)
+            .helper_continued(helper_state, &leader_message)
             .unwrap();
         // 3 round vdaf, round 2: helper should finish and emit a finish message.
         let helper_message = assert_matches!(
-            helper_state, ContinuedValue::WithMessage { transition } => {
+            helper_state, PingPongContinuedValue::WithMessage { transition } => {
                 let (state, message) = transition.evaluate(&helper).unwrap();
-                assert_matches!(state, State::Finished(_));
+                assert_matches!(state, PingPongState::Finished(_));
                 message
             }
         );
 
         let leader_state = leader
-            .continued(Role::Leader, leader_state, &helper_message)
+            .leader_continued(leader_state, &helper_message)
             .unwrap();
         // 3 round VDAF, round 2: leader should finish and emit no message.
-        assert_matches!(leader_state, ContinuedValue::FinishedNoMessage { .. });
+        assert_matches!(
+            leader_state,
+            PingPongContinuedValue::FinishedNoMessage { .. }
+        );
     }
 
     #[test]
     fn roundtrip_message() {
         let messages = [
             (
-                Message::Initialize {
+                PingPongMessage::Initialize {
                     prep_share: Vec::from("prepare share"),
                 },
                 concat!(
@@ -776,7 +874,7 @@ mod tests {
                 ),
             ),
             (
-                Message::Continue {
+                PingPongMessage::Continue {
                     prep_msg: Vec::from("prepare message"),
                     prep_share: Vec::from("prepare share"),
                 },
@@ -795,7 +893,7 @@ mod tests {
                 ),
             ),
             (
-                Message::Finish {
+                PingPongMessage::Finish {
                     prep_msg: Vec::from("prepare message"),
                 },
                 concat!(
@@ -817,7 +915,7 @@ mod tests {
                 &got_hex, expected_hex,
                 "Couldn't roundtrip (encoded value differs): {message:?}",
             );
-            let decoded_val = Message::decode(&mut Cursor::new(&encoded_val)).unwrap();
+            let decoded_val = PingPongMessage::decode(&mut Cursor::new(&encoded_val)).unwrap();
             assert_eq!(
                 decoded_val, message,
                 "Couldn't roundtrip (decoded value differs): {message:?}"
@@ -834,7 +932,7 @@ mod tests {
     fn roundtrip_transition() {
         // VDAF implementations have tests for encoding/decoding their respective PrepareShare and
         // PrepareMessage types, so we test here using the dummy VDAF.
-        let transition = Transition::<0, 16, dummy::Vdaf> {
+        let transition = PingPongTransition::<0, 16, dummy::Vdaf> {
             previous_prepare_state: dummy::PrepareState::default(),
             current_prepare_message: (),
         };
@@ -854,7 +952,7 @@ mod tests {
             )
         );
 
-        let decoded = Transition::get_decoded_with_param(&(), &encoded).unwrap();
+        let decoded = PingPongTransition::get_decoded_with_param(&(), &encoded).unwrap();
         assert_eq!(transition, decoded);
 
         assert_eq!(

--- a/src/topology/ping_pong.rs
+++ b/src/topology/ping_pong.rs
@@ -289,7 +289,7 @@ where
 
 /// Corresponds to the `State` enumeration implicitly defined in [VDAF's Ping-Pong Topology][VDAF].
 /// VDAF describes `Start` and `Rejected` states, but the `Start` state is never instantiated in
-/// code, and the `Rejected` state is represented as `std::result::Result::Error`, so this enum does
+/// code, and the `Rejected` state is represented as `std::result::Result::Err`, so this enum does
 /// not include those variants.
 ///
 /// [VDAF]: https://datatracker.ietf.org/doc/html/draft-irtf-cfrg-vdaf-06#section-5.8
@@ -306,17 +306,6 @@ pub enum State<
 }
 
 /// Values returned by [`PingPongTopology::continued`].
-///
-/// Corresponds to the `State` enumeration implicitly defined in [VDAF's Ping-Pong Topology][VDAF],
-/// but combined with the components of [`Message`] so that no impossible states may be represented.
-/// For example, it's impossible to be in the `Continued` state but to send an outgoing `Message` of
-/// type `Finished`.
-///
-/// VDAF describes `Start` and `Rejected` states, but the `Start` state is never instantiated in
-/// code, and the `Rejected` state is represented as [`std::result::Result::Error`], so this enum
-/// does not include those variants.
-///
-/// [VDAF]: https://datatracker.ietf.org/doc/html/draft-irtf-cfrg-vdaf-06#section-5.8
 #[derive(Clone, Debug)]
 pub enum ContinuedValue<
     const VERIFY_KEY_SIZE: usize,
@@ -420,9 +409,11 @@ pub trait PingPongTopology<const VERIFY_KEY_SIZE: usize, const NONCE_SIZE: usize
     /// # Notes
     ///
     /// The specification of this function in [VDAF] takes the aggregation parameter. This version
-    /// does not, because [`vdaf::Vdaf::prepare_preprocess`] does not take the aggregation
-    /// parameter. This may change in the future if/when [#670][issue] is addressed.
+    /// does not, because [`crate::vdaf::Aggregator::prepare_preprocess`] does not take the
+    /// aggregation parameter. This may change in the future if/when [#670][issue] is addressed.
     ///
+    ///
+    /// [VDAF]: https://datatracker.ietf.org/doc/html/draft-irtf-cfrg-vdaf-06#section-5.8
     /// [issue]: https://github.com/divviup/libprio-rs/issues/670
     fn continued(
         &self,

--- a/src/topology/ping_pong.rs
+++ b/src/topology/ping_pong.rs
@@ -336,6 +336,8 @@ pub trait PingPongTopology<const VERIFY_KEY_SIZE: usize, const NONCE_SIZE: usize
     type State;
     /// Specialization of [`ContinuedValue`] for this VDAF.
     type ContinuedValue;
+    /// Specializaton of [`Transition`] for this VDAF.
+    type Transition;
 
     /// Initialize leader state using the leader's input share. Corresponds to
     /// `ping_pong_leader_init` in the forthcoming `draft-irtf-cfrg-vdaf-07`.
@@ -420,7 +422,7 @@ pub trait PingPongTopology<const VERIFY_KEY_SIZE: usize, const NONCE_SIZE: usize
         role: Role,
         host_state: Self::State,
         inbound: &Message,
-    ) -> Result<ContinuedValue<VERIFY_KEY_SIZE, NONCE_SIZE, Self>, PingPongError>;
+    ) -> Result<Self::ContinuedValue, PingPongError>;
 }
 
 impl<const VERIFY_KEY_SIZE: usize, const NONCE_SIZE: usize, A>
@@ -430,6 +432,7 @@ where
 {
     type State = State<VERIFY_KEY_SIZE, NONCE_SIZE, Self>;
     type ContinuedValue = ContinuedValue<VERIFY_KEY_SIZE, NONCE_SIZE, Self>;
+    type Transition = Transition<VERIFY_KEY_SIZE, NONCE_SIZE, Self>;
 
     fn leader_initialize(
         &self,
@@ -466,7 +469,7 @@ where
         public_share: &Self::PublicShare,
         input_share: &Self::InputShare,
         inbound: &Message,
-    ) -> Result<Transition<VERIFY_KEY_SIZE, NONCE_SIZE, Self>, PingPongError> {
+    ) -> Result<Self::Transition, PingPongError> {
         let (prep_state, prep_share) = self
             .prepare_init(
                 verify_key,

--- a/src/vdaf.rs
+++ b/src/vdaf.rs
@@ -393,7 +393,7 @@ pub trait Aggregatable: Clone + Debug + From<Self::OutputShare> {
 }
 
 /// An output share comprised of a vector of field elements.
-#[derive(Clone, Debug)]
+#[derive(Clone)]
 pub struct OutputShare<F>(Vec<F>);
 
 impl<F: ConstantTimeEq> PartialEq for OutputShare<F> {
@@ -429,6 +429,12 @@ impl<F: FieldElement> Encode for OutputShare<F> {
 
     fn encoded_len(&self) -> Option<usize> {
         Some(F::ENCODED_SIZE * self.0.len())
+    }
+}
+
+impl<F> Debug for OutputShare<F> {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_tuple("OutputShare").finish()
     }
 }
 
@@ -729,6 +735,8 @@ mod tests {
     }
 }
 
+#[cfg(feature = "test-util")]
+pub mod dummy;
 #[cfg(all(feature = "crypto-dependencies", feature = "experimental"))]
 #[cfg_attr(
     docsrs,

--- a/src/vdaf.rs
+++ b/src/vdaf.rs
@@ -222,7 +222,7 @@ pub trait Client<const NONCE_SIZE: usize>: Vdaf {
 /// The Aggregator's role in the execution of a VDAF.
 pub trait Aggregator<const VERIFY_KEY_SIZE: usize, const NONCE_SIZE: usize>: Vdaf {
     /// State of the Aggregator during the Prepare process.
-    type PrepareState: Clone + Debug;
+    type PrepareState: Clone + Debug + PartialEq + Eq;
 
     /// The type of messages sent by each aggregator at each round of the Prepare Process.
     ///
@@ -235,7 +235,12 @@ pub trait Aggregator<const VERIFY_KEY_SIZE: usize, const NONCE_SIZE: usize>: Vda
     ///
     /// Decoding takes a [`Self::PrepareState`] as a parameter; this [`Self::PrepareState`] may be
     /// associated with any aggregator involved in the execution of the VDAF.
-    type PrepareMessage: Clone + Debug + ParameterizedDecode<Self::PrepareState> + Encode;
+    type PrepareMessage: Clone
+        + Debug
+        + PartialEq
+        + Eq
+        + ParameterizedDecode<Self::PrepareState>
+        + Encode;
 
     /// Begins the Prepare process with the other Aggregators. The [`Self::PrepareState`] returned
     /// is passed to [`Self::prepare_next`] to get this aggregator's first-round prepare message.

--- a/src/vdaf/dummy.rs
+++ b/src/vdaf/dummy.rs
@@ -1,0 +1,327 @@
+// SPDX-License-Identifier: MPL-2.0
+
+//! Implementation of a dummy VDAF which conforms to the specification in [draft-irtf-cfrg-vdaf-06]
+//! but does nothing. Useful for testing.
+//!
+//! [draft-irtf-cfrg-vdaf-06]: https://datatracker.ietf.org/doc/draft-irtf-cfrg-vdaf/06/
+
+use crate::{
+    codec::{CodecError, Decode, Encode},
+    vdaf::{self, Aggregatable, PrepareTransition, VdafError},
+};
+use rand::random;
+use std::{fmt::Debug, io::Cursor, sync::Arc};
+
+type ArcPrepInitFn =
+    Arc<dyn Fn(&AggregationParam) -> Result<(), VdafError> + 'static + Send + Sync>;
+type ArcPrepStepFn = Arc<
+    dyn Fn(&PrepareState) -> Result<PrepareTransition<Vdaf, 0, 16>, VdafError>
+        + 'static
+        + Send
+        + Sync,
+>;
+
+/// Dummy VDAF that does nothing.
+#[derive(Clone)]
+pub struct Vdaf {
+    rounds: u32,
+    prep_init_fn: ArcPrepInitFn,
+    prep_step_fn: ArcPrepStepFn,
+}
+
+impl Debug for Vdaf {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("Vdaf")
+            .field("prep_init_result", &"[redacted]")
+            .field("prep_step_result", &"[redacted]")
+            .finish()
+    }
+}
+
+impl Vdaf {
+    /// The length of the verify key parameter for fake VDAF instantiations.
+    pub const VERIFY_KEY_LEN: usize = 0;
+
+    /// Construct a new instance of the dummy VDAF.
+    pub fn new(rounds: u32) -> Self {
+        Self {
+            rounds,
+            prep_init_fn: Arc::new(|_| -> Result<(), VdafError> { Ok(()) }),
+            prep_step_fn: Arc::new(
+                |state| -> Result<PrepareTransition<Self, 0, 16>, VdafError> {
+                    let new_round = state.current_round + 1;
+                    if new_round == state.max_rounds {
+                        Ok(PrepareTransition::Finish(OutputShare(state.input_share)))
+                    } else {
+                        Ok(PrepareTransition::Continue(
+                            PrepareState {
+                                current_round: new_round,
+                                ..*state
+                            },
+                            (),
+                        ))
+                    }
+                },
+            ),
+        }
+    }
+
+    /// Provide an alternate implementation of
+    /// [`vdaf::Aggregator::prepare_init`].
+    pub fn with_prep_init_fn<F: Fn(&AggregationParam) -> Result<(), VdafError>>(
+        mut self,
+        f: F,
+    ) -> Self
+    where
+        F: 'static + Send + Sync,
+    {
+        self.prep_init_fn = Arc::new(f);
+        self
+    }
+
+    /// Provide an alternate implementation of
+    /// [`vdaf::Aggregator::prepare_step`].
+    pub fn with_prep_step_fn<
+        F: Fn(&PrepareState) -> Result<PrepareTransition<Self, 0, 16>, VdafError>,
+    >(
+        mut self,
+        f: F,
+    ) -> Self
+    where
+        F: 'static + Send + Sync,
+    {
+        self.prep_step_fn = Arc::new(f);
+        self
+    }
+}
+
+impl Default for Vdaf {
+    fn default() -> Self {
+        Self::new(1)
+    }
+}
+
+impl vdaf::Vdaf for Vdaf {
+    const ID: u32 = 0xFFFF0000;
+
+    type Measurement = u8;
+    type AggregateResult = u8;
+    type AggregationParam = AggregationParam;
+    type PublicShare = ();
+    type InputShare = InputShare;
+    type OutputShare = OutputShare;
+    type AggregateShare = AggregateShare;
+
+    fn num_aggregators(&self) -> usize {
+        2
+    }
+}
+
+impl vdaf::Aggregator<0, 16> for Vdaf {
+    type PrepareState = PrepareState;
+    type PrepareShare = ();
+    type PrepareMessage = ();
+
+    fn prepare_init(
+        &self,
+        _verify_key: &[u8; 0],
+        _: usize,
+        aggregation_param: &Self::AggregationParam,
+        _nonce: &[u8; 16],
+        _: &Self::PublicShare,
+        input_share: &Self::InputShare,
+    ) -> Result<(Self::PrepareState, Self::PrepareShare), VdafError> {
+        (self.prep_init_fn)(aggregation_param)?;
+        Ok((
+            PrepareState {
+                input_share: input_share.0,
+                current_round: 0,
+                max_rounds: self.rounds,
+            },
+            (),
+        ))
+    }
+
+    fn prepare_preprocess<M: IntoIterator<Item = Self::PrepareMessage>>(
+        &self,
+        _: M,
+    ) -> Result<Self::PrepareMessage, VdafError> {
+        Ok(())
+    }
+
+    fn prepare_step(
+        &self,
+        state: Self::PrepareState,
+        _: Self::PrepareMessage,
+    ) -> Result<PrepareTransition<Self, 0, 16>, VdafError> {
+        (self.prep_step_fn)(&state)
+    }
+
+    fn aggregate<M: IntoIterator<Item = Self::OutputShare>>(
+        &self,
+        _: &Self::AggregationParam,
+        output_shares: M,
+    ) -> Result<Self::AggregateShare, VdafError> {
+        let mut aggregate_share = AggregateShare(0);
+        for output_share in output_shares {
+            aggregate_share.accumulate(&output_share)?;
+        }
+        Ok(aggregate_share)
+    }
+}
+
+impl vdaf::Client<16> for Vdaf {
+    fn shard(
+        &self,
+        measurement: &Self::Measurement,
+        _nonce: &[u8; 16],
+    ) -> Result<(Self::PublicShare, Vec<Self::InputShare>), VdafError> {
+        let first_input_share = random();
+        let (second_input_share, _) = measurement.overflowing_sub(first_input_share);
+        Ok((
+            (),
+            Vec::from([
+                InputShare(first_input_share),
+                InputShare(second_input_share),
+            ]),
+        ))
+    }
+}
+
+/// A dummy input share.
+#[derive(Copy, Clone, Debug, Default, PartialEq, Eq, PartialOrd, Ord)]
+pub struct InputShare(pub u8);
+
+impl Encode for InputShare {
+    fn encode(&self, bytes: &mut Vec<u8>) {
+        self.0.encode(bytes)
+    }
+
+    fn encoded_len(&self) -> Option<usize> {
+        self.0.encoded_len()
+    }
+}
+
+impl Decode for InputShare {
+    fn decode(bytes: &mut Cursor<&[u8]>) -> Result<Self, CodecError> {
+        Ok(Self(u8::decode(bytes)?))
+    }
+}
+
+/// Dummy aggregation parameter.
+#[derive(Copy, Clone, Debug, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+pub struct AggregationParam(pub u8);
+
+impl Encode for AggregationParam {
+    fn encode(&self, bytes: &mut Vec<u8>) {
+        self.0.encode(bytes)
+    }
+
+    fn encoded_len(&self) -> Option<usize> {
+        self.0.encoded_len()
+    }
+}
+
+impl Decode for AggregationParam {
+    fn decode(bytes: &mut Cursor<&[u8]>) -> Result<Self, CodecError> {
+        Ok(Self(u8::decode(bytes)?))
+    }
+}
+
+/// Dummy output share.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub struct OutputShare(pub u8);
+
+impl Decode for OutputShare {
+    fn decode(bytes: &mut Cursor<&[u8]>) -> Result<Self, CodecError> {
+        Ok(Self(u8::decode(bytes)?))
+    }
+}
+
+impl Encode for OutputShare {
+    fn encode(&self, bytes: &mut Vec<u8>) {
+        self.0.encode(bytes);
+    }
+
+    fn encoded_len(&self) -> Option<usize> {
+        self.0.encoded_len()
+    }
+}
+
+/// Dummy prepare state.
+#[derive(Clone, Copy, Debug, Default, PartialEq, Eq)]
+pub struct PrepareState {
+    input_share: u8,
+    current_round: u32,
+    max_rounds: u32,
+}
+
+impl Encode for PrepareState {
+    fn encode(&self, bytes: &mut Vec<u8>) {
+        self.input_share.encode(bytes);
+        self.current_round.encode(bytes);
+        self.max_rounds.encode(bytes);
+    }
+
+    fn encoded_len(&self) -> Option<usize> {
+        Some(
+            self.input_share.encoded_len()?
+                + self.current_round.encoded_len()?
+                + self.max_rounds.encoded_len()?,
+        )
+    }
+}
+
+impl Decode for PrepareState {
+    fn decode(bytes: &mut Cursor<&[u8]>) -> Result<Self, CodecError> {
+        let input_share = u8::decode(bytes)?;
+        let current_round = u32::decode(bytes)?;
+        let max_rounds = u32::decode(bytes)?;
+        Ok(Self {
+            input_share,
+            current_round,
+            max_rounds,
+        })
+    }
+}
+
+/// Dummy aggregate share.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub struct AggregateShare(pub u64);
+
+impl Aggregatable for AggregateShare {
+    type OutputShare = OutputShare;
+
+    fn merge(&mut self, other: &Self) -> Result<(), VdafError> {
+        self.0 += other.0;
+        Ok(())
+    }
+
+    fn accumulate(&mut self, out_share: &Self::OutputShare) -> Result<(), VdafError> {
+        self.0 += u64::from(out_share.0);
+        Ok(())
+    }
+}
+
+impl From<OutputShare> for AggregateShare {
+    fn from(out_share: OutputShare) -> Self {
+        Self(u64::from(out_share.0))
+    }
+}
+
+impl Decode for AggregateShare {
+    fn decode(bytes: &mut Cursor<&[u8]>) -> Result<Self, CodecError> {
+        let val = u64::decode(bytes)?;
+        Ok(Self(val))
+    }
+}
+
+impl Encode for AggregateShare {
+    fn encode(&self, bytes: &mut Vec<u8>) {
+        self.0.encode(bytes)
+    }
+
+    fn encoded_len(&self) -> Option<usize> {
+        self.0.encoded_len()
+    }
+}

--- a/src/vdaf/dummy.rs
+++ b/src/vdaf/dummy.rs
@@ -137,14 +137,15 @@ impl vdaf::Aggregator<0, 16> for Vdaf {
         ))
     }
 
-    fn prepare_preprocess<M: IntoIterator<Item = Self::PrepareMessage>>(
+    fn prepare_shares_to_prepare_message<M: IntoIterator<Item = Self::PrepareShare>>(
         &self,
+        _: &Self::AggregationParam,
         _: M,
     ) -> Result<Self::PrepareMessage, VdafError> {
         Ok(())
     }
 
-    fn prepare_step(
+    fn prepare_next(
         &self,
         state: Self::PrepareState,
         _: Self::PrepareMessage,

--- a/src/vdaf/dummy.rs
+++ b/src/vdaf/dummy.rs
@@ -31,8 +31,8 @@ pub struct Vdaf {
 impl Debug for Vdaf {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         f.debug_struct("Vdaf")
-            .field("prep_init_result", &"[redacted]")
-            .field("prep_step_result", &"[redacted]")
+            .field("prep_init_fn", &"[redacted]")
+            .field("prep_step_fn", &"[redacted]")
             .finish()
     }
 }

--- a/src/vdaf/poplar1.rs
+++ b/src/vdaf/poplar1.rs
@@ -329,6 +329,7 @@ impl<F: ConstantTimeEq> Eq for PrepareState<F> {}
 impl<F: ConstantTimeEq> ConstantTimeEq for PrepareState<F> {
     fn ct_eq(&self, other: &Self) -> Choice {
         self.sketch.ct_eq(&other.sketch) & self.output_share.ct_eq(&other.output_share)
+    }
 }
 
 impl<F> Debug for PrepareState<F> {

--- a/src/vdaf/poplar1.rs
+++ b/src/vdaf/poplar1.rs
@@ -312,7 +312,7 @@ impl<'a, P, const SEED_SIZE: usize> ParameterizedDecode<(&'a Poplar1<P, SEED_SIZ
     }
 }
 
-#[derive(Clone, Debug)]
+#[derive(Clone)]
 struct PrepareState<F> {
     sketch: SketchState<F>,
     output_share: Vec<F>,
@@ -329,6 +329,14 @@ impl<F: ConstantTimeEq> Eq for PrepareState<F> {}
 impl<F: ConstantTimeEq> ConstantTimeEq for PrepareState<F> {
     fn ct_eq(&self, other: &Self) -> Choice {
         self.sketch.ct_eq(&other.sketch) & self.output_share.ct_eq(&other.output_share)
+}
+
+impl<F> Debug for PrepareState<F> {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("PrepareState")
+            .field("sketch", &"[redacted]")
+            .field("output_share", &"[redacted]")
+            .finish()
     }
 }
 

--- a/src/vdaf/prio3.rs
+++ b/src/vdaf/prio3.rs
@@ -970,6 +970,7 @@ impl<F: ConstantTimeEq, const SEED_SIZE: usize> ConstantTimeEq for Prio3PrepareS
             self.joint_rand_seed.as_ref(),
             other.joint_rand_seed.as_ref(),
         ) & self.measurement_share.ct_eq(&other.measurement_share)
+    }
 }
 
 impl<F, const SEED_SIZE: usize> Debug for Prio3PrepareState<F, SEED_SIZE> {

--- a/src/vdaf/prio3.rs
+++ b/src/vdaf/prio3.rs
@@ -942,7 +942,7 @@ where
 }
 
 /// State of each [`Aggregator`] during the Preparation phase.
-#[derive(Clone, Debug)]
+#[derive(Clone)]
 pub struct Prio3PrepareState<F, const SEED_SIZE: usize> {
     measurement_share: Share<F, SEED_SIZE>,
     joint_rand_seed: Option<Seed<SEED_SIZE>>,
@@ -970,6 +970,22 @@ impl<F: ConstantTimeEq, const SEED_SIZE: usize> ConstantTimeEq for Prio3PrepareS
             self.joint_rand_seed.as_ref(),
             other.joint_rand_seed.as_ref(),
         ) & self.measurement_share.ct_eq(&other.measurement_share)
+}
+
+impl<F, const SEED_SIZE: usize> Debug for Prio3PrepareState<F, SEED_SIZE> {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("Prio3PrepareState")
+            .field("measurement_share", &"[redacted]")
+            .field(
+                "joint_rand_seed",
+                match self.joint_rand_seed {
+                    Some(_) => &"Some([redacted])",
+                    None => &"None",
+                },
+            )
+            .field("agg_id", &self.agg_id)
+            .field("verifier_len", &self.verifier_len)
+            .finish()
     }
 }
 

--- a/supply-chain/config.toml
+++ b/supply-chain/config.toml
@@ -187,11 +187,6 @@ criteria = "safe-to-deploy"
 version = "0.8.5"
 criteria = "safe-to-deploy"
 
-[[exemptions.rand_chacha]]
-version = "0.3.1"
-criteria = "safe-to-deploy"
-notes = "This dependency is only used if feature test-util is enabled, which should not be the case for production deployments."
-
 [[exemptions.rand_distr]]
 version = "0.4.3"
 criteria = "safe-to-run"

--- a/supply-chain/config.toml
+++ b/supply-chain/config.toml
@@ -187,6 +187,11 @@ criteria = "safe-to-deploy"
 version = "0.8.5"
 criteria = "safe-to-deploy"
 
+[[exemptions.rand_chacha]]
+version = "0.3.1"
+criteria = "safe-to-deploy"
+notes = "This dependency is only used if feature test-util is enabled, which should not be the case for production deployments."
+
 [[exemptions.rand_distr]]
 version = "0.4.3"
 criteria = "safe-to-run"


### PR DESCRIPTION
Implements the ping-pong topology introduced in VDAF-06, though the
implementation here is based on the revised ping-pong interface in a
yet-unpublished VDAF version.

We add a `topology` module, on the premise that we might someday add new
topologies and their implementations there, and `topology::ping_pong`.

This also adds an implementation of a dummy VDAF, brought over from
Janus ([1]). `vdaf::dummy` is only compiled if the `test-util` Cargo
feature is enabled. The dummy VDAF implements the `vdaf::{Vdaf,
Aggregator, Client, Collector}` traits and provides associated types for output
shares, prepare shares, etc., but it doesn't do anything except return
success, making it useful for testing higher-level constructions like
ping-pong.

Finally, we replace the derived `std::fmt::Debug` implementations on a
few `prio3` and `poplar1` associated types so that they redact fields
that are either sensitive secrets or just too big to be worth printing
when debugging. This is so that we can provide `Debug` impls on new
types in `topology::ping_pong` without pulling in crate `derivative`,
which would require us to do 9,000+ lines of audits.

[1]: https://github.com/divviup/janus