### PR TITLE
Record new audit and exemptions

### DIFF
--- a/supply-chain/audits.toml
+++ b/supply-chain/audits.toml
@@ -321,6 +321,11 @@ delta = "1.0.52 -> 1.0.54"
 
 [[audits.rand_chacha]]
 who = "David Cook <dcook@divviup.org>"
+criteria = "safe-to-deploy"
+version = "0.3.1"
+
+[[audits.rand_chacha]]
+who = "David Cook <dcook@divviup.org>"
 criteria = "safe-to-run"
 delta = "0.3.0 -> 0.2.2"
 

--- a/supply-chain/config.toml
+++ b/supply-chain/config.toml
@@ -189,6 +189,10 @@ criteria = "safe-to-run"
 
 [[exemptions.ppv-lite86]]
 version = "0.2.16"
+criteria = "safe-to-deploy"
+
+[[exemptions.ppv-lite86]]
+version = "0.2.16"
 criteria = "safe-to-run"
 
 [[exemptions.proc-macro-error]]
@@ -202,6 +206,10 @@ criteria = "safe-to-deploy"
 [[exemptions.rand]]
 version = "0.7.3"
 criteria = "safe-to-run"
+
+[[exemptions.rand]]
+version = "0.8.5"
+criteria = "safe-to-deploy"
 
 [[exemptions.rand]]
 version = "0.8.5"

--- a/supply-chain/imports.lock
+++ b/supply-chain/imports.lock
@@ -448,6 +448,12 @@ criteria = "safe-to-deploy"
 version = "0.1.45"
 notes = "All code written or reviewed by Josh Stone."
 
+[[audits.firefox.audits.num-iter]]
+who = "Josh Stone <jistone@redhat.com>"
+criteria = "safe-to-deploy"
+version = "0.1.43"
+notes = "All code written or reviewed by Josh Stone."
+
 [[audits.firefox.audits.num-rational]]
 who = "Josh Stone <jistone@redhat.com>"
 criteria = "safe-to-deploy"


### PR DESCRIPTION
This records an audit of `rand_chacha` and exemptions for `rand` and `ppv-lite86`. These are being added to support #578, which needs the `rand` crate for `rand::distributions::Distribution`.