### PR TITLE
Parallel sum circuit improvements

### DIFF
--- a/benches/cycle_counts.rs
+++ b/benches/cycle_counts.rs
@@ -106,7 +106,7 @@ fn prio3_client_count() -> Vec<Prio3InputShare<Field64, 16>> {
 }
 
 fn prio3_client_histogram_10() -> Vec<Prio3InputShare<Field128, 16>> {
-    let prio3 = Prio3::new_histogram(2, 10).unwrap();
+    let prio3 = Prio3::new_histogram(2, 10, 3).unwrap();
     let measurement = 9;
     let nonce = [0; 16];
     prio3
@@ -127,7 +127,7 @@ fn prio3_client_sum_32() -> Vec<Prio3InputShare<Field128, 16>> {
 
 fn prio3_client_count_vec_1000() -> Vec<Prio3InputShare<Field128, 16>> {
     let len = 1000;
-    let prio3 = Prio3::new_sum_vec(2, 1, len).unwrap();
+    let prio3 = Prio3::new_sum_vec(2, 1, len, 31).unwrap();
     let measurement = vec![0; len];
     let nonce = [0; 16];
     prio3
@@ -139,7 +139,7 @@ fn prio3_client_count_vec_1000() -> Vec<Prio3InputShare<Field128, 16>> {
 #[cfg(feature = "multithreaded")]
 fn prio3_client_count_vec_multithreaded_1000() -> Vec<Prio3InputShare<Field128, 16>> {
     let len = 1000;
-    let prio3 = Prio3::new_sum_vec_multithreaded(2, 1, len).unwrap();
+    let prio3 = Prio3::new_sum_vec_multithreaded(2, 1, len, 31).unwrap();
     let measurement = vec![0; len];
     let nonce = [0; 16];
     prio3

--- a/benches/speed_tests.rs
+++ b/benches/speed_tests.rs
@@ -119,13 +119,13 @@ fn poly_mul(c: &mut Criterion) {
 #[cfg(feature = "prio2")]
 fn prio2(c: &mut Criterion) {
     let mut group = c.benchmark_group("prio2_shard");
-    for input_len in [10, 100, 1_000] {
+    for input_length in [10, 100, 1_000] {
         group.bench_with_input(
-            BenchmarkId::from_parameter(input_len),
-            &input_len,
-            |b, input_len| {
-                let vdaf = Prio2::new(*input_len).unwrap();
-                let measurement = (0..u32::try_from(*input_len).unwrap())
+            BenchmarkId::from_parameter(input_length),
+            &input_length,
+            |b, input_length| {
+                let vdaf = Prio2::new(*input_length).unwrap();
+                let measurement = (0..u32::try_from(*input_length).unwrap())
                     .map(|i| i & 1)
                     .collect::<Vec<_>>();
                 let nonce = black_box([0u8; 16]);
@@ -136,13 +136,13 @@ fn prio2(c: &mut Criterion) {
     group.finish();
 
     let mut group = c.benchmark_group("prio2_prepare_init");
-    for input_len in [10, 100, 1_000] {
+    for input_length in [10, 100, 1_000] {
         group.bench_with_input(
-            BenchmarkId::from_parameter(input_len),
-            &input_len,
-            |b, input_len| {
-                let vdaf = Prio2::new(*input_len).unwrap();
-                let measurement = (0..u32::try_from(*input_len).unwrap())
+            BenchmarkId::from_parameter(input_length),
+            &input_length,
+            |b, input_length| {
+                let vdaf = Prio2::new(*input_length).unwrap();
+                let measurement = (0..u32::try_from(*input_length).unwrap())
                     .map(|i| i & 1)
                     .collect::<Vec<_>>();
                 let nonce = black_box([0u8; 16]);
@@ -209,13 +209,13 @@ fn prio3(c: &mut Criterion) {
     group.finish();
 
     let mut group = c.benchmark_group("prio3sumvec_shard");
-    for input_len in [10, 100, 1_000] {
+    for (input_length, chunk_length) in [(10, 3), (100, 10), (1_000, 31)] {
         group.bench_with_input(
-            BenchmarkId::new("serial", input_len),
-            &input_len,
-            |b, input_len| {
-                let vdaf = Prio3::new_sum_vec(num_shares, 1, *input_len).unwrap();
-                let measurement = (0..u128::try_from(*input_len).unwrap())
+            BenchmarkId::new("serial", input_length),
+            &(input_length, chunk_length),
+            |b, (input_length, chunk_length)| {
+                let vdaf = Prio3::new_sum_vec(num_shares, 1, *input_length, *chunk_length).unwrap();
+                let measurement = (0..u128::try_from(*input_length).unwrap())
                     .map(|i| i & 1)
                     .collect::<Vec<_>>();
                 let nonce = black_box([0u8; 16]);
@@ -226,13 +226,19 @@ fn prio3(c: &mut Criterion) {
 
     #[cfg(feature = "multithreaded")]
     {
-        for input_len in [10, 100, 1_000] {
+        for (input_length, chunk_length) in [(10, 3), (100, 10), (1_000, 31)] {
             group.bench_with_input(
-                BenchmarkId::new("parallel", input_len),
-                &input_len,
-                |b, input_len| {
-                    let vdaf = Prio3::new_sum_vec_multithreaded(num_shares, 1, *input_len).unwrap();
-                    let measurement = (0..u128::try_from(*input_len).unwrap())
+                BenchmarkId::new("parallel", input_length),
+                &(input_length, chunk_length),
+                |b, (input_length, chunk_length)| {
+                    let vdaf = Prio3::new_sum_vec_multithreaded(
+                        num_shares,
+                        1,
+                        *input_length,
+                        *chunk_length,
+                    )
+                    .unwrap();
+                    let measurement = (0..u128::try_from(*input_length).unwrap())
                         .map(|i| i & 1)
                         .collect::<Vec<_>>();
                     let nonce = black_box([0u8; 16]);
@@ -244,13 +250,13 @@ fn prio3(c: &mut Criterion) {
     group.finish();
 
     let mut group = c.benchmark_group("prio3sumvec_prepare_init");
-    for input_len in [10, 100, 1_000] {
+    for (input_length, chunk_length) in [(10, 3), (100, 10), (1_000, 31)] {
         group.bench_with_input(
-            BenchmarkId::new("serial", input_len),
-            &input_len,
-            |b, input_len| {
-                let vdaf = Prio3::new_sum_vec(num_shares, 1, *input_len).unwrap();
-                let measurement = (0..u128::try_from(*input_len).unwrap())
+            BenchmarkId::new("serial", input_length),
+            &(input_length, chunk_length),
+            |b, (input_length, chunk_length)| {
+                let vdaf = Prio3::new_sum_vec(num_shares, 1, *input_length, *chunk_length).unwrap();
+                let measurement = (0..u128::try_from(*input_length).unwrap())
                     .map(|i| i & 1)
                     .collect::<Vec<_>>();
                 let nonce = black_box([0u8; 16]);
@@ -266,13 +272,19 @@ fn prio3(c: &mut Criterion) {
 
     #[cfg(feature = "multithreaded")]
     {
-        for input_len in [10, 100, 1_000] {
+        for (input_length, chunk_length) in [(10, 3), (100, 10), (1_000, 31)] {
             group.bench_with_input(
-                BenchmarkId::new("parallel", input_len),
-                &input_len,
-                |b, input_len| {
-                    let vdaf = Prio3::new_sum_vec_multithreaded(num_shares, 1, *input_len).unwrap();
-                    let measurement = (0..u128::try_from(*input_len).unwrap())
+                BenchmarkId::new("parallel", input_length),
+                &(input_length, chunk_length),
+                |b, (input_length, chunk_length)| {
+                    let vdaf = Prio3::new_sum_vec_multithreaded(
+                        num_shares,
+                        1,
+                        *input_length,
+                        *chunk_length,
+                    )
+                    .unwrap();
+                    let measurement = (0..u128::try_from(*input_length).unwrap())
                         .map(|i| i & 1)
                         .collect::<Vec<_>>();
                     let nonce = black_box([0u8; 16]);
@@ -296,33 +308,75 @@ fn prio3(c: &mut Criterion) {
     group.finish();
 
     let mut group = c.benchmark_group("prio3histogram_shard");
-    for input_len in [10, 100, 1_000, 10_000, 100_000] {
-        if input_len >= 100_000 {
+    for (input_length, chunk_length) in [
+        (10, 3),
+        (100, 10),
+        (1_000, 31),
+        (10_000, 100),
+        (100_000, 316),
+    ] {
+        if input_length >= 100_000 {
             group.measurement_time(Duration::from_secs(15));
         }
         group.bench_with_input(
-            BenchmarkId::new("serial", input_len),
-            &input_len,
-            |b, input_len| {
-                let vdaf = Prio3::new_histogram(num_shares, *input_len).unwrap();
+            BenchmarkId::new("serial", input_length),
+            &(input_length, chunk_length),
+            |b, (input_length, chunk_length)| {
+                let vdaf = Prio3::new_histogram(num_shares, *input_length, *chunk_length).unwrap();
                 let measurement = black_box(0);
                 let nonce = black_box([0u8; 16]);
                 b.iter(|| vdaf.shard(&measurement, &nonce).unwrap());
             },
         );
     }
+
+    #[cfg(feature = "multithreaded")]
+    {
+        for (input_length, chunk_length) in [
+            (10, 3),
+            (100, 10),
+            (1_000, 31),
+            (10_000, 100),
+            (100_000, 316),
+        ] {
+            if input_length >= 100_000 {
+                group.measurement_time(Duration::from_secs(15));
+            }
+            group.bench_with_input(
+                BenchmarkId::new("parallel", input_length),
+                &(input_length, chunk_length),
+                |b, (input_length, chunk_length)| {
+                    let vdaf = Prio3::new_histogram_multithreaded(
+                        num_shares,
+                        *input_length,
+                        *chunk_length,
+                    )
+                    .unwrap();
+                    let measurement = black_box(0);
+                    let nonce = black_box([0u8; 16]);
+                    b.iter(|| vdaf.shard(&measurement, &nonce).unwrap());
+                },
+            );
+        }
+    }
     group.finish();
 
     let mut group = c.benchmark_group("prio3histogram_prepare_init");
-    for input_len in [10, 100, 1_000, 10_000, 100_000] {
-        if input_len >= 100_000 {
+    for (input_length, chunk_length) in [
+        (10, 3),
+        (100, 10),
+        (1_000, 31),
+        (10_000, 100),
+        (100_000, 316),
+    ] {
+        if input_length >= 100_000 {
             group.measurement_time(Duration::from_secs(15));
         }
         group.bench_with_input(
-            BenchmarkId::new("serial", input_len),
-            &input_len,
-            |b, input_len| {
-                let vdaf = Prio3::new_histogram(num_shares, *input_len).unwrap();
+            BenchmarkId::new("serial", input_length),
+            &(input_length, chunk_length),
+            |b, (input_length, chunk_length)| {
+                let vdaf = Prio3::new_histogram(num_shares, *input_length, *chunk_length).unwrap();
                 let measurement = black_box(0);
                 let nonce = black_box([0u8; 16]);
                 let verify_key = black_box([0u8; 16]);
@@ -333,6 +387,48 @@ fn prio3(c: &mut Criterion) {
                 });
             },
         );
+    }
+
+    #[cfg(feature = "multithreaded")]
+    {
+        for (input_length, chunk_length) in [
+            (10, 3),
+            (100, 10),
+            (1_000, 31),
+            (10_000, 100),
+            (100_000, 316),
+        ] {
+            if input_length >= 100_000 {
+                group.measurement_time(Duration::from_secs(15));
+            }
+            group.bench_with_input(
+                BenchmarkId::new("parallel", input_length),
+                &(input_length, chunk_length),
+                |b, (input_length, chunk_length)| {
+                    let vdaf = Prio3::new_histogram_multithreaded(
+                        num_shares,
+                        *input_length,
+                        *chunk_length,
+                    )
+                    .unwrap();
+                    let measurement = black_box(0);
+                    let nonce = black_box([0u8; 16]);
+                    let verify_key = black_box([0u8; 16]);
+                    let (public_share, input_shares) = vdaf.shard(&measurement, &nonce).unwrap();
+                    b.iter(|| {
+                        vdaf.prepare_init(
+                            &verify_key,
+                            0,
+                            &(),
+                            &nonce,
+                            &public_share,
+                            &input_shares[0],
+                        )
+                        .unwrap()
+                    });
+                },
+            );
+        }
     }
     group.finish();
 

--- a/binaries/src/bin/vdaf_message_sizes.rs
+++ b/binaries/src/bin/vdaf_message_sizes.rs
@@ -25,7 +25,7 @@ fn main() {
     );
 
     let length = 10;
-    let prio3 = Prio3::new_histogram(num_shares, length).unwrap();
+    let prio3 = Prio3::new_histogram(num_shares, length, 3).unwrap();
     let measurement = 9;
     println!(
         "prio3 histogram ({} buckets) share size = {}",
@@ -43,7 +43,7 @@ fn main() {
     );
 
     let len = 1000;
-    let prio3 = Prio3::new_sum_vec(num_shares, 1, len).unwrap();
+    let prio3 = Prio3::new_sum_vec(num_shares, 1, len, 31).unwrap();
     let measurement = vec![0; len];
     println!(
         "prio3 sumvec ({} len) share size = {}",
@@ -65,7 +65,7 @@ fn main() {
 
     println!();
 
-    for size in [10, 100, 1_000] {
+    for (size, chunk_length) in [(10, 3), (100, 10), (1_000, 31)] {
         // Prio2
         let measurement = vec![0u32; size];
         let prio2 = Prio2::new(size).unwrap();
@@ -77,7 +77,7 @@ fn main() {
 
         // Prio3
         let measurement = vec![0u128; size];
-        let prio3 = Prio3::new_sum_vec(2, 1, size).unwrap();
+        let prio3 = Prio3::new_sum_vec(2, 1, size, chunk_length).unwrap();
         println!(
             "prio3 sumvec ({} entries) size = {}",
             size,

--- a/src/flp/gadgets.rs
+++ b/src/flp/gadgets.rs
@@ -218,127 +218,15 @@ impl<F: FftFriendlyFieldElement> Gadget<F> for PolyEval<F> {
     }
 }
 
-/// An arity-2 gadget that returns `poly(in[0]) * in[1]` for some polynomial `poly`.
-#[derive(Clone, Debug, Eq, PartialEq)]
-pub struct BlindPolyEval<F: FftFriendlyFieldElement> {
-    poly: Vec<F>,
-    /// Size of buffer for the outer FFT multiplication.
-    n: usize,
-    /// Inverse of `n` in `F`.
-    n_inv: F,
-    /// The number of times this gadget will be called.
-    num_calls: usize,
-}
-
-impl<F: FftFriendlyFieldElement> BlindPolyEval<F> {
-    /// Returns a `BlindPolyEval` gadget for polynomial `poly`.
-    pub fn new(poly: Vec<F>, num_calls: usize) -> Self {
-        let n = gadget_poly_fft_mem_len(poly_deg(&poly) + 1, num_calls);
-        let n_inv = F::from(F::Integer::try_from(n).unwrap()).inv();
-        Self {
-            poly,
-            n,
-            n_inv,
-            num_calls,
-        }
-    }
-
-    fn call_poly_direct(&mut self, outp: &mut [F], inp: &[Vec<F>]) -> Result<(), FlpError> {
-        let x = &inp[0];
-        let y = &inp[1];
-
-        let mut z = y.to_vec();
-        for i in 0..self.poly.len() {
-            for j in 0..z.len() {
-                outp[j] += self.poly[i] * z[j];
-            }
-
-            if i < self.poly.len() - 1 {
-                z = poly_mul(&z, x);
-            }
-        }
-        Ok(())
-    }
-
-    fn call_poly_fft(&mut self, outp: &mut [F], inp: &[Vec<F>]) -> Result<(), FlpError> {
-        let n = self.n;
-        let x = &inp[0];
-        let y = &inp[1];
-
-        let mut x_vals = vec![F::zero(); n];
-        discrete_fourier_transform(&mut x_vals, x, n)?;
-
-        let mut z_vals = vec![F::zero(); n];
-        discrete_fourier_transform(&mut z_vals, y, n)?;
-
-        let mut z = vec![F::zero(); n];
-        let mut z_len = y.len();
-        z[..y.len()].clone_from_slice(y);
-
-        for i in 0..self.poly.len() {
-            for j in 0..z_len {
-                outp[j] += self.poly[i] * z[j];
-            }
-
-            if i < self.poly.len() - 1 {
-                for j in 0..n {
-                    z_vals[j] *= x_vals[j];
-                }
-
-                discrete_fourier_transform(&mut z, &z_vals, n)?;
-                discrete_fourier_transform_inv_finish(&mut z, n, self.n_inv);
-                z_len += x.len();
-            }
-        }
-        Ok(())
-    }
-}
-
-impl<F: FftFriendlyFieldElement> Gadget<F> for BlindPolyEval<F> {
-    fn call(&mut self, inp: &[F]) -> Result<F, FlpError> {
-        gadget_call_check(self, inp.len())?;
-        Ok(inp[1] * poly_eval(&self.poly, inp[0]))
-    }
-
-    fn call_poly(&mut self, outp: &mut [F], inp: &[Vec<F>]) -> Result<(), FlpError> {
-        gadget_call_poly_check(self, outp, inp)?;
-
-        for x in outp.iter_mut() {
-            *x = F::zero();
-        }
-
-        if inp[0].len() >= FFT_THRESHOLD {
-            self.call_poly_fft(outp, inp)
-        } else {
-            self.call_poly_direct(outp, inp)
-        }
-    }
-
-    fn arity(&self) -> usize {
-        2
-    }
-
-    fn degree(&self) -> usize {
-        poly_deg(&self.poly) + 1
-    }
-
-    fn calls(&self) -> usize {
-        self.num_calls
-    }
-
-    fn as_any(&mut self) -> &mut dyn Any {
-        self
-    }
-}
-
-/// Marker trait for abstracting over [`ParallelSum`].
+/// Trait for abstracting over [`ParallelSum`].
 pub trait ParallelSumGadget<F: FftFriendlyFieldElement, G>: Gadget<F> + Debug {
-    /// Wraps `inner` into a sum gadget with `chunks` chunks
+    /// Wraps `inner` into a sum gadget that calls it `chunks` many times, and adds the reuslts.
     fn new(inner: G, chunks: usize) -> Self;
 }
 
 /// A wrapper gadget that applies the inner gadget to chunks of input and returns the sum of the
-/// outputs. The arity is equal to the arity of the inner gadget times the number of chunks.
+/// outputs. The arity is equal to the arity of the inner gadget times the number of times it is
+/// called.
 #[derive(Clone, Debug, Eq, PartialEq)]
 pub struct ParallelSum<F: FftFriendlyFieldElement, G: Gadget<F>> {
     inner: G,
@@ -617,25 +505,11 @@ mod tests {
     }
 
     #[test]
-    fn test_blind_poly_eval() {
-        let poly: Vec<TestField> = random_vector(10).unwrap();
-
-        let num_calls = FFT_THRESHOLD / 2;
-        let mut g: BlindPolyEval<TestField> = BlindPolyEval::new(poly.clone(), num_calls);
-        gadget_test(&mut g, num_calls);
-
-        let num_calls = FFT_THRESHOLD;
-        let mut g: BlindPolyEval<TestField> = BlindPolyEval::new(poly, num_calls);
-        gadget_test(&mut g, num_calls);
-    }
-
-    #[test]
     fn test_parallel_sum() {
-        let poly: Vec<TestField> = random_vector(10).unwrap();
         let num_calls = 10;
         let chunks = 23;
 
-        let mut g = ParallelSum::new(BlindPolyEval::new(poly, num_calls), chunks);
+        let mut g = ParallelSum::new(Mul::<TestField>::new(num_calls), chunks);
         gadget_test(&mut g, num_calls);
     }
 
@@ -645,15 +519,13 @@ mod tests {
         use std::iter;
 
         for num_calls in [1, 10, 100] {
-            let poly: Vec<TestField> = random_vector(10).unwrap();
             let chunks = 23;
 
-            let mut g =
-                ParallelSumMultithreaded::new(BlindPolyEval::new(poly.clone(), num_calls), chunks);
+            let mut g = ParallelSumMultithreaded::new(Mul::new(num_calls), chunks);
             gadget_test(&mut g, num_calls);
 
             // Test that the multithreaded version has the same output as the normal version.
-            let mut g_serial = ParallelSum::new(BlindPolyEval::new(poly, num_calls), chunks);
+            let mut g_serial = ParallelSum::new(Mul::new(num_calls), chunks);
             assert_eq!(g.arity(), g_serial.arity());
             assert_eq!(g.degree(), g_serial.degree());
             assert_eq!(g.calls(), g_serial.calls());

--- a/src/flp/types.rs
+++ b/src/flp/types.rs
@@ -3,7 +3,7 @@
 //! A collection of [`Type`] implementations.
 
 use crate::field::{FftFriendlyFieldElement, FieldElementWithIntegerExt};
-use crate::flp::gadgets::{BlindPolyEval, Mul, ParallelSumGadget, PolyEval};
+use crate::flp::gadgets::{Mul, ParallelSumGadget, PolyEval};
 use crate::flp::{FlpError, Gadget, Type};
 use crate::polynomial::poly_range_check;
 use std::convert::TryInto;
@@ -314,38 +314,73 @@ impl<F: FftFriendlyFieldElement> Type for Average<F> {
 
 /// The histogram type. Each measurement is an integer in `[0, length)` and the aggregate is a
 /// histogram counting the number of occurrences of each measurement.
-#[derive(Clone, PartialEq, Eq)]
-pub struct Histogram<F: FftFriendlyFieldElement> {
+#[derive(PartialEq, Eq)]
+pub struct Histogram<F, S> {
     length: usize,
-    range_checker: Vec<F>,
+    chunk_length: usize,
+    gadget_calls: usize,
+    phantom: PhantomData<(F, S)>,
 }
 
-impl<F: FftFriendlyFieldElement> Debug for Histogram<F> {
+impl<F: FftFriendlyFieldElement, S> Debug for Histogram<F, S> {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         f.debug_struct("Histogram")
             .field("length", &self.length)
+            .field("chunk_length", &self.chunk_length)
             .finish()
     }
 }
 
-impl<F: FftFriendlyFieldElement> Histogram<F> {
+impl<F: FftFriendlyFieldElement, S: ParallelSumGadget<F, Mul<F>>> Histogram<F, S> {
     /// Return a new [`Histogram`] type with the given number of buckets.
-    pub fn new(length: usize) -> Result<Self, FlpError> {
+    pub fn new(length: usize, chunk_length: usize) -> Result<Self, FlpError> {
         if length >= u32::MAX as usize {
             return Err(FlpError::Encode(
                 "invalid length: number of buckets exceeds maximum permitted".to_string(),
             ));
         }
+        if length == 0 {
+            return Err(FlpError::InvalidParameter(
+                "length cannot be zero".to_string(),
+            ));
+        }
+        if chunk_length == 0 {
+            return Err(FlpError::InvalidParameter(
+                "chunk_length cannot be zero".to_string(),
+            ));
+        }
+
+        let mut gadget_calls = length / chunk_length;
+        if length % chunk_length != 0 {
+            gadget_calls += 1;
+        }
 
         Ok(Self {
             length,
-            range_checker: poly_range_check(0, 2),
+            chunk_length,
+            gadget_calls,
+            phantom: PhantomData,
         })
     }
 }
 
-impl<F: FftFriendlyFieldElement> Type for Histogram<F> {
-    const ID: u32 = 0x00000002;
+impl<F, S> Clone for Histogram<F, S> {
+    fn clone(&self) -> Self {
+        Self {
+            length: self.length,
+            chunk_length: self.chunk_length,
+            gadget_calls: self.gadget_calls,
+            phantom: self.phantom,
+        }
+    }
+}
+
+impl<F, S> Type for Histogram<F, S>
+where
+    F: FftFriendlyFieldElement,
+    S: ParallelSumGadget<F, Mul<F>> + Eq + 'static,
+{
+    const ID: u32 = 0x00000003;
     type Measurement = usize;
     type AggregateResult = Vec<F::Integer>;
     type Field = F;
@@ -366,9 +401,9 @@ impl<F: FftFriendlyFieldElement> Type for Histogram<F> {
     }
 
     fn gadget(&self) -> Vec<Box<dyn Gadget<F>>> {
-        vec![Box::new(PolyEval::new(
-            self.range_checker.to_vec(),
-            self.input_len(),
+        vec![Box::new(S::new(
+            Mul::new(self.gadget_calls),
+            self.chunk_length,
         ))]
     }
 
@@ -382,7 +417,13 @@ impl<F: FftFriendlyFieldElement> Type for Histogram<F> {
         self.valid_call_check(input, joint_rand)?;
 
         // Check that each element of `input` is a 0 or 1.
-        let range_check = call_gadget_on_vec_entries(&mut g[0], input, joint_rand[0])?;
+        let range_check = parallel_sum_range_checks(
+            &mut g[0],
+            input,
+            joint_rand[0],
+            self.chunk_length,
+            num_shares,
+        )?;
 
         // Check that the elements of `input` sum to 1.
         let mut sum_check = -(F::one() / F::from(F::valid_integer_try_from(num_shares)?));
@@ -405,11 +446,11 @@ impl<F: FftFriendlyFieldElement> Type for Histogram<F> {
     }
 
     fn proof_len(&self) -> usize {
-        2 * ((1 + self.input_len()).next_power_of_two() - 1) + 2
+        (self.chunk_length * 2) + 2 * ((1 + self.gadget_calls).next_power_of_two() - 1) + 1
     }
 
     fn verifier_len(&self) -> usize {
-        3
+        2 + self.chunk_length * 2
     }
 
     fn output_len(&self) -> usize {
@@ -421,7 +462,7 @@ impl<F: FftFriendlyFieldElement> Type for Histogram<F> {
     }
 
     fn prove_rand_len(&self) -> usize {
-        1
+        self.chunk_length * 2
     }
 
     fn query_rand_len(&self) -> usize {
@@ -435,12 +476,11 @@ impl<F: FftFriendlyFieldElement> Type for Histogram<F> {
 /// [BBCG+19]: https://eprint.iacr.org/2019/188
 #[derive(PartialEq, Eq)]
 pub struct SumVec<F: FftFriendlyFieldElement, S> {
-    range_checker: Vec<F>,
     len: usize,
     bits: usize,
     flattened_len: usize,
     max: F::Integer,
-    chunk_len: usize,
+    chunk_length: usize,
     gadget_calls: usize,
     phantom: PhantomData<S>,
 }
@@ -450,11 +490,12 @@ impl<F: FftFriendlyFieldElement, S> Debug for SumVec<F, S> {
         f.debug_struct("SumVec")
             .field("len", &self.len)
             .field("bits", &self.bits)
+            .field("chunk_length", &self.chunk_length)
             .finish()
     }
 }
 
-impl<F: FftFriendlyFieldElement, S: ParallelSumGadget<F, BlindPolyEval<F>>> SumVec<F, S> {
+impl<F: FftFriendlyFieldElement, S: ParallelSumGadget<F, Mul<F>>> SumVec<F, S> {
     /// Returns a new [`SumVec`] with the desired bit width and vector length.
     ///
     /// # Errors
@@ -462,7 +503,8 @@ impl<F: FftFriendlyFieldElement, S: ParallelSumGadget<F, BlindPolyEval<F>>> SumV
     /// * The length of the encoded measurement, i.e., `bits * len`, overflows addressable memory.
     /// * The bit width cannot be encoded, i.e., `bits` is larger than or equal to the number of
     ///   bits required to encode field elements.
-    pub fn new(bits: usize, len: usize) -> Result<Self, FlpError> {
+    /// * Any of `bits`, `len`, or `chunk_length` are zero.
+    pub fn new(bits: usize, len: usize, chunk_length: usize) -> Result<Self, FlpError> {
         let flattened_len = bits.checked_mul(len).ok_or_else(|| {
             FlpError::InvalidParameter("`bits*len` overflows addressable memory".into())
         })?;
@@ -477,27 +519,36 @@ impl<F: FftFriendlyFieldElement, S: ParallelSumGadget<F, BlindPolyEval<F>>> SumV
             )));
         }
 
+        // Check for degenerate parameters.
+        if bits == 0 {
+            return Err(FlpError::InvalidParameter(
+                "bits cannot be zero".to_string(),
+            ));
+        }
+        if len == 0 {
+            return Err(FlpError::InvalidParameter("len cannot be zero".to_string()));
+        }
+        if chunk_length == 0 {
+            return Err(FlpError::InvalidParameter(
+                "chunk_length cannot be zero".to_string(),
+            ));
+        }
+
         // Compute the largest encodable measurement.
         let one = F::Integer::from(F::one());
         let max = (one << bits) - one;
 
-        // The optimal chunk length is the square root of the input length. If the input length is
-        // not a perfect square, then round down. If the result is 0, then let the chunk length be
-        // 1 so that the underlying gadget can still be called.
-        let chunk_len = std::cmp::max(1, (flattened_len as f64).sqrt() as usize);
-
-        let mut gadget_calls = flattened_len / chunk_len;
-        if flattened_len % chunk_len != 0 {
+        let mut gadget_calls = flattened_len / chunk_length;
+        if flattened_len % chunk_length != 0 {
             gadget_calls += 1;
         }
 
         Ok(Self {
-            range_checker: poly_range_check(0, 2),
             len,
             bits,
             flattened_len,
             max,
-            chunk_len,
+            chunk_length,
             gadget_calls,
             phantom: PhantomData,
         })
@@ -507,12 +558,11 @@ impl<F: FftFriendlyFieldElement, S: ParallelSumGadget<F, BlindPolyEval<F>>> SumV
 impl<F: FftFriendlyFieldElement, S> Clone for SumVec<F, S> {
     fn clone(&self) -> Self {
         Self {
-            range_checker: self.range_checker.clone(),
             len: self.len,
             bits: self.bits,
             flattened_len: self.flattened_len,
             max: self.max,
-            chunk_len: self.chunk_len,
+            chunk_length: self.chunk_length,
             gadget_calls: self.gadget_calls,
             phantom: PhantomData,
         }
@@ -522,9 +572,9 @@ impl<F: FftFriendlyFieldElement, S> Clone for SumVec<F, S> {
 impl<F, S> Type for SumVec<F, S>
 where
     F: FftFriendlyFieldElement,
-    S: ParallelSumGadget<F, BlindPolyEval<F>> + Eq + 'static,
+    S: ParallelSumGadget<F, Mul<F>> + Eq + 'static,
 {
-    const ID: u32 = 0xFFFF0000;
+    const ID: u32 = 0x00000002;
     type Measurement = Vec<F::Integer>;
     type AggregateResult = Vec<F::Integer>;
     type Field = F;
@@ -565,8 +615,8 @@ where
 
     fn gadget(&self) -> Vec<Box<dyn Gadget<F>>> {
         vec![Box::new(S::new(
-            BlindPolyEval::new(self.range_checker.clone(), self.gadget_calls),
-            self.chunk_len,
+            Mul::new(self.gadget_calls),
+            self.chunk_length,
         ))]
     }
 
@@ -579,28 +629,13 @@ where
     ) -> Result<F, FlpError> {
         self.valid_call_check(input, joint_rand)?;
 
-        let s = F::from(F::valid_integer_try_from(num_shares)?).inv();
-        let mut r = joint_rand[0];
-        let mut outp = F::zero();
-        let mut padded_chunk = vec![F::zero(); 2 * self.chunk_len];
-        for chunk in input.chunks(self.chunk_len) {
-            let d = chunk.len();
-            for i in 0..self.chunk_len {
-                if i < d {
-                    padded_chunk[2 * i] = chunk[i];
-                } else {
-                    // If the chunk is smaller than the chunk length, then copy the last element of
-                    // the chunk into the remaining slots.
-                    padded_chunk[2 * i] = chunk[d - 1];
-                }
-                padded_chunk[2 * i + 1] = r * s;
-                r *= joint_rand[0];
-            }
-
-            outp += g[0].call(&padded_chunk)?;
-        }
-
-        Ok(outp)
+        parallel_sum_range_checks(
+            &mut g[0],
+            input,
+            joint_rand[0],
+            self.chunk_length,
+            num_shares,
+        )
     }
 
     fn truncate(&self, input: Vec<F>) -> Result<Vec<F>, FlpError> {
@@ -617,11 +652,11 @@ where
     }
 
     fn proof_len(&self) -> usize {
-        (self.chunk_len * 2) + 3 * ((1 + self.gadget_calls).next_power_of_two() - 1) + 1
+        (self.chunk_length * 2) + 2 * ((1 + self.gadget_calls).next_power_of_two() - 1) + 1
     }
 
     fn verifier_len(&self) -> usize {
-        2 + self.chunk_len * 2
+        2 + self.chunk_length * 2
     }
 
     fn output_len(&self) -> usize {
@@ -633,7 +668,7 @@ where
     }
 
     fn prove_rand_len(&self) -> usize {
-        self.chunk_len * 2
+        self.chunk_length * 2
     }
 
     fn query_rand_len(&self) -> usize {
@@ -685,6 +720,62 @@ pub(crate) fn decode_result_vec<F: FftFriendlyFieldElement>(
     Ok(data.iter().map(|elem| F::Integer::from(*elem)).collect())
 }
 
+/// This evaluates range checks on a slice of field elements, using a ParallelSum gadget evaluating
+/// many multiplication gates.
+///
+/// # Arguments
+///
+/// * `gadget`: A `ParallelSumGadget<F, Mul<F>>` gadget, or a shim wrapping the same.
+/// * `input`: A slice of inputs. This calculation will check that all inputs were zero or one
+///   before secret sharing.
+/// * `joint_randomness`: A joint randomness value, used to compute a random linear combination of
+///   individual range checks.
+/// * `chunk_length`: How many multiplication gates per ParallelSum gadget. This must match what the
+///   gadget was constructed with.
+/// * `num_shares`: The number of shares that the inputs were secret shared into. This is needed to
+///   correct constant terms in the circuit.
+///
+/// # Returns
+///
+/// This returns (additive shares of) zero if all inputs were zero or one, and otherwise returns a
+/// non-zero value with high probability.
+pub(crate) fn parallel_sum_range_checks<F: FftFriendlyFieldElement>(
+    gadget: &mut Box<dyn Gadget<F>>,
+    input: &[F],
+    joint_randomness: F,
+    chunk_length: usize,
+    num_shares: usize,
+) -> Result<F, FlpError> {
+    let f_num_shares = F::from(F::valid_integer_try_from::<usize>(num_shares)?);
+    let num_shares_inverse = f_num_shares.inv();
+
+    let mut output = F::zero();
+    let mut r_power = joint_randomness;
+    let mut padded_chunk = vec![F::zero(); 2 * chunk_length];
+
+    for chunk in input.chunks(chunk_length) {
+        // Construct arguments for the Mul subcircuits.
+        for (input, args) in chunk.iter().zip(padded_chunk.chunks_exact_mut(2)) {
+            args[0] = r_power * *input;
+            args[1] = *input - num_shares_inverse;
+            r_power *= joint_randomness;
+        }
+        // If the chunk of the input is smaller than chunk_length, use zeros instead of measurement
+        // inputs for the remaining calls.
+        for args in padded_chunk[chunk.len() * 2..].chunks_exact_mut(2) {
+            args[0] = F::zero();
+            args[1] = -num_shares_inverse;
+            // Skip updating r_power. This inner loop is only used during the last iteration of the
+            // outer loop, if the last input chunk is a partial chunk. Thus, r_power won't be
+            // accessed again before returning.
+        }
+
+        output += gadget.call(&padded_chunk)?;
+    }
+
+    Ok(output)
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -693,6 +784,7 @@ mod tests {
     #[cfg(feature = "multithreaded")]
     use crate::flp::gadgets::ParallelSumMultithreaded;
     use crate::flp::types::test_utils::{flp_validity_test, ValidityTestCase};
+    use std::cmp;
 
     #[test]
     fn test_count() {
@@ -883,9 +975,12 @@ mod tests {
         );
     }
 
-    #[test]
-    fn test_histogram() {
-        let hist = Histogram::new(3).unwrap();
+    fn test_histogram<F, S>(f: F)
+    where
+        F: Fn(usize, usize) -> Result<Histogram<TestField, S>, FlpError>,
+        S: ParallelSumGadget<TestField, Mul<TestField>> + Eq + 'static,
+    {
+        let hist = f(3, 2).unwrap();
         let zero = TestField::zero();
         let one = TestField::one();
         let nine = TestField::from(9);
@@ -984,17 +1079,31 @@ mod tests {
         .unwrap();
     }
 
+    #[test]
+    fn test_histogram_serial() {
+        test_histogram(Histogram::<TestField, ParallelSum<TestField, Mul<TestField>>>::new);
+    }
+
+    #[test]
+    #[cfg(feature = "multithreaded")]
+    fn test_histogram_parallel() {
+        test_histogram(
+            Histogram::<TestField, ParallelSumMultithreaded<TestField, Mul<TestField>>>::new,
+        );
+    }
+
     fn test_sum_vec<F, S>(f: F)
     where
-        F: Fn(usize, usize) -> Result<SumVec<TestField, S>, FlpError>,
-        S: 'static + ParallelSumGadget<TestField, BlindPolyEval<TestField>> + Eq,
+        F: Fn(usize, usize, usize) -> Result<SumVec<TestField, S>, FlpError>,
+        S: 'static + ParallelSumGadget<TestField, Mul<TestField>> + Eq,
     {
         let one = TestField::one();
         let nine = TestField::from(9);
 
         // Test on valid inputs.
-        for len in 0..10 {
-            let sum_vec = f(1, len).unwrap();
+        for len in 1..10 {
+            let chunk_length = cmp::max((len as f64).sqrt() as usize, 1);
+            let sum_vec = f(1, len, chunk_length).unwrap();
             flp_validity_test(
                 &sum_vec,
                 &sum_vec.encode_measurement(&vec![1; len]).unwrap(),
@@ -1008,7 +1117,7 @@ mod tests {
         }
 
         let len = 100;
-        let sum_vec = f(1, len).unwrap();
+        let sum_vec = f(1, len, 10).unwrap();
         flp_validity_test(
             &sum_vec,
             &sum_vec.encode_measurement(&vec![1; len]).unwrap(),
@@ -1021,7 +1130,7 @@ mod tests {
         .unwrap();
 
         let len = 23;
-        let sum_vec = f(4, len).unwrap();
+        let sum_vec = f(4, len, 4).unwrap();
         flp_validity_test(
             &sum_vec,
             &sum_vec.encode_measurement(&vec![9; len]).unwrap(),
@@ -1035,7 +1144,8 @@ mod tests {
 
         // Test on invalid inputs.
         for len in 1..10 {
-            let sum_vec = f(1, len).unwrap();
+            let chunk_length = cmp::max((len as f64).sqrt() as usize, 1);
+            let sum_vec = f(1, len, chunk_length).unwrap();
             flp_validity_test(
                 &sum_vec,
                 &vec![nine; len],
@@ -1049,7 +1159,7 @@ mod tests {
         }
 
         let len = 23;
-        let sum_vec = f(2, len).unwrap();
+        let sum_vec = f(2, len, 4).unwrap();
         flp_validity_test(
             &sum_vec,
             &vec![nine; 2 * len],
@@ -1078,21 +1188,18 @@ mod tests {
 
     #[test]
     fn test_sum_vec_serial() {
-        test_sum_vec(SumVec::<TestField, ParallelSum<TestField, BlindPolyEval<TestField>>>::new)
+        test_sum_vec(SumVec::<TestField, ParallelSum<TestField, Mul<TestField>>>::new)
     }
 
     #[test]
     #[cfg(feature = "multithreaded")]
     fn test_sum_vec_parallel() {
-        test_sum_vec(
-            SumVec::<TestField, ParallelSumMultithreaded<TestField, BlindPolyEval<TestField>>>::new,
-        )
+        test_sum_vec(SumVec::<TestField, ParallelSumMultithreaded<TestField, Mul<TestField>>>::new)
     }
 
     #[test]
     fn sum_vec_serial_long() {
-        let typ: SumVec<TestField, ParallelSum<TestField, BlindPolyEval<TestField>>> =
-            SumVec::new(1, 1000).unwrap();
+        let typ: SumVec<TestField, ParallelSum<TestField, _>> = SumVec::new(1, 1000, 31).unwrap();
         let input = typ.encode_measurement(&vec![0; 1000]).unwrap();
         assert_eq!(input.len(), typ.input_len());
         let joint_rand = random_vector(typ.joint_rand_len()).unwrap();
@@ -1109,8 +1216,8 @@ mod tests {
     #[test]
     #[cfg(feature = "multithreaded")]
     fn sum_vec_parallel_long() {
-        let typ: SumVec<TestField, ParallelSumMultithreaded<TestField, BlindPolyEval<TestField>>> =
-            SumVec::new(1, 1000).unwrap();
+        let typ: SumVec<TestField, ParallelSumMultithreaded<TestField, _>> =
+            SumVec::new(1, 1000, 31).unwrap();
         let input = typ.encode_measurement(&vec![0; 1000]).unwrap();
         assert_eq!(input.len(), typ.input_len());
         let joint_rand = random_vector(typ.joint_rand_len()).unwrap();

--- a/src/vdaf/prio3_test.rs
+++ b/src/vdaf/prio3_test.rs
@@ -172,13 +172,11 @@ fn test_vec_prio3_sum() {
     }
 }
 
-// TODO Re-enable this test once https://github.com/divviup/libprio-rs/pull/695
-#[ignore]
 #[test]
 fn test_vec_prio3_sum_vec() {
     let t: TPrio3<Vec<u128>> =
         serde_json::from_str(include_str!("test_vec/07/Prio3SumVec_0.json")).unwrap();
-    let prio3 = Prio3::new_sum_vec(2, 8, 10).unwrap();
+    let prio3 = Prio3::new_sum_vec(2, 8, 10, 9).unwrap();
     let verify_key = t.verify_key.as_ref().try_into().unwrap();
 
     for (test_num, p) in t.prep.iter().enumerate() {
@@ -187,7 +185,7 @@ fn test_vec_prio3_sum_vec() {
 
     let t: TPrio3<Vec<u128>> =
         serde_json::from_str(include_str!("test_vec/07/Prio3SumVec_1.json")).unwrap();
-    let prio3 = Prio3::new_sum_vec(3, 16, 3).unwrap();
+    let prio3 = Prio3::new_sum_vec(3, 16, 3, 7).unwrap();
     let verify_key = t.verify_key.as_ref().try_into().unwrap();
 
     for (test_num, p) in t.prep.iter().enumerate() {
@@ -195,13 +193,11 @@ fn test_vec_prio3_sum_vec() {
     }
 }
 
-// TODO Re-enable this test once https://github.com/divviup/libprio-rs/pull/695
-#[ignore]
 #[test]
 fn test_vec_prio3_histogram() {
     let t: TPrio3<usize> =
         serde_json::from_str(include_str!("test_vec/07/Prio3Histogram_0.json")).unwrap();
-    let prio3 = Prio3::new_histogram(2, 4).unwrap();
+    let prio3 = Prio3::new_histogram(2, 4, 2).unwrap();
     let verify_key = t.verify_key.as_ref().try_into().unwrap();
 
     for (test_num, p) in t.prep.iter().enumerate() {
@@ -210,7 +206,7 @@ fn test_vec_prio3_histogram() {
 
     let t: TPrio3<usize> =
         serde_json::from_str(include_str!("test_vec/07/Prio3Histogram_1.json")).unwrap();
-    let prio3 = Prio3::new_histogram(3, 4).unwrap();
+    let prio3 = Prio3::new_histogram(3, 11, 3).unwrap();
     let verify_key = t.verify_key.as_ref().try_into().unwrap();
 
     for (test_num, p) in t.prep.iter().enumerate() {


### PR DESCRIPTION
This supersedes #669, rewriting Prio3SumVec to reflect its newly specified form, and #682, applying the parallel sum optimization to Prio3Histogram, and additionally addresses #671 by making similar improvements to Prio3FixedPointBoundedL2VecSum. I have added some custom test vectors produced from the tip of the VDAF repository, as an interim measure between VDAF versions. The `BlindPolyEval` gadget is deleted, since it is no longer needed.

Here are the benchmark improvements on Prio3FixedPointBoundedL2VecSum:
```
prio3_client/fixedpoint16_boundedl2_vec/1000
                        time:   [28.453 ms 28.615 ms 28.784 ms]
                        change: [-36.595% -36.187% -35.727%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 3 outliers among 100 measurements (3.00%)
  3 (3.00%) high mild
prio3_client/prio3_fixedpoint16_boundedl2_vec_multithreaded/1000
                        time:   [15.217 ms 15.516 ms 15.842 ms]
                        change: [-32.289% -30.814% -29.252%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 6 outliers among 100 measurements (6.00%)
  6 (6.00%) high mild
```

For now, I think I'm going to hold off on exposing the two parallel sum gadget chunk lengths as parameters of Prio3FixedPointBoundedL2VecSum. This isn't immediately needed, since we're not yet writing up a specification of it. (so we don't need to worry about interoperability of square root operations in the VDAF's constructor)