### PR TITLE
Remove redundant link targets in documentation

### DIFF
--- a/src/flp/types.rs
+++ b/src/flp/types.rs
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: MPL-2.0
 
-//! A collection of [`Type`](crate::flp::Type) implementations.
+//! A collection of [`Type`] implementations.
 
 use crate::field::{FftFriendlyFieldElement, FieldElementWithIntegerExt};
 use crate::flp::gadgets::{BlindPolyEval, Mul, ParallelSumGadget, PolyEval};

--- a/src/vdaf/prio2.rs
+++ b/src/vdaf/prio2.rs
@@ -58,10 +58,9 @@ impl Prio2 {
     /// Prepare an input share for aggregation using the given field element `query_rand` to
     /// compute the verifier share.
     ///
-    /// In the [`Aggregator`](crate::vdaf::Aggregator) trait implementation for [`Prio2`], the
-    /// query randomness is computed jointly by the Aggregators. This method is designed to be used
-    /// in applications, like ENPA, in which the query randomness is instead chosen by a
-    /// third-party.
+    /// In the [`Aggregator`] trait implementation for [`Prio2`], the query randomness is computed
+    /// jointly by the Aggregators. This method is designed to be used in applications, like ENPA,
+    /// in which the query randomness is instead chosen by a third-party.
     pub fn prepare_init_with_query_rand(
         &self,
         query_rand: FieldPrio2,
@@ -165,7 +164,7 @@ impl Client<16> for Prio2 {
     }
 }
 
-/// State of each [`Aggregator`](crate::vdaf::Aggregator) during the Preparation phase.
+/// State of each [`Aggregator`] during the Preparation phase.
 #[derive(Clone, Debug, Eq, PartialEq)]
 pub struct Prio2PrepareState(Share<FieldPrio2, 32>);
 
@@ -194,7 +193,7 @@ impl<'a> ParameterizedDecode<(&'a Prio2, usize)> for Prio2PrepareState {
     }
 }
 
-/// Message emitted by each [`Aggregator`](crate::vdaf::Aggregator) during the Preparation phase.
+/// Message emitted by each [`Aggregator`] during the Preparation phase.
 #[derive(Clone, Debug)]
 pub struct Prio2PrepareShare(v2_server::VerificationMessage<FieldPrio2>);
 

--- a/src/vdaf/prio3.rs
+++ b/src/vdaf/prio3.rs
@@ -241,8 +241,8 @@ impl Prio3Average {
 ///
 /// An instance of Prio3 is determined by:
 ///
-/// - a [`Type`](crate::flp::Type) that defines the set of valid input measurements; and
-/// - a [`Prg`](crate::vdaf::prg::Prg) for deriving vectors of field elements from seeds.
+/// - a [`Type`] that defines the set of valid input measurements; and
+/// - a [`Prg`] for deriving vectors of field elements from seeds.
 ///
 /// New instances can be defined by aliasing the base type. For example, [`Prio3Count`] is an alias
 /// for `Prio3<Count<Field64>, PrgSha3, 16>`.
@@ -718,10 +718,9 @@ where
 }
 
 #[derive(Clone, Debug, Eq, PartialEq)]
-/// Message broadcast by each [`Aggregator`](crate::vdaf::Aggregator) in each round of the
-/// Preparation phase.
+/// Message broadcast by each [`Aggregator`] in each round of the Preparation phase.
 pub struct Prio3PrepareShare<F, const SEED_SIZE: usize> {
-    /// A share of the FLP verifier message. (See [`Type`](crate::flp::Type).)
+    /// A share of the FLP verifier message. (See [`Type`].)
     verifier: Vec<F>,
 
     /// A part of the joint randomness seed.
@@ -832,7 +831,7 @@ where
     }
 }
 
-/// State of each [`Aggregator`](crate::vdaf::Aggregator) during the Preparation phase.
+/// State of each [`Aggregator`] during the Preparation phase.
 #[derive(Clone, Debug, Eq, PartialEq)]
 pub struct Prio3PrepareState<F, const SEED_SIZE: usize> {
     measurement_share: Share<F, SEED_SIZE>,


### PR DESCRIPTION
This fixes some `warning: redundant explicit link target` messages from the nightly version of rustdoc.