### PR TITLE
Rewrite Criterion benchmarks

### DIFF
--- a/benches/speed_tests.rs
+++ b/benches/speed_tests.rs
@@ -1,32 +1,26 @@
 // SPDX-License-Identifier: MPL-2.0
 
-use criterion::{criterion_group, criterion_main, BenchmarkId, Criterion};
+use criterion::{black_box, criterion_group, criterion_main, BenchmarkId, Criterion};
 #[cfg(feature = "experimental")]
 use criterion::{BatchSize, Throughput};
 #[cfg(feature = "experimental")]
+use fixed::types::{I1F15, I1F31};
+#[cfg(feature = "experimental")]
 use fixed_macro::fixed;
-#[cfg(feature = "multithreaded")]
-use prio::flp::gadgets::ParallelSumMultithreaded;
 #[cfg(feature = "prio2")]
 use prio::vdaf::prio2::Prio2;
 use prio::{
     benchmarked::*,
     field::{random_vector, Field128 as F, FieldElement},
-    flp::{
-        gadgets::{BlindPolyEval, Mul, ParallelSum},
-        types::SumVec,
-        Type,
-    },
-    vdaf::{prio3::Prio3, Client},
+    flp::gadgets::Mul,
+    vdaf::{prio3::Prio3, Aggregator, Client},
 };
 #[cfg(feature = "experimental")]
 use prio::{
     field::{Field255, Field64},
+    flp::types::fixedpoint_l2::FixedPointBoundedL2VecSum,
     idpf::{Idpf, IdpfInput, RingBufferCache},
-    vdaf::{
-        poplar1::{Poplar1, Poplar1AggregationParam, Poplar1IdpfValue},
-        Aggregator,
-    },
+    vdaf::poplar1::{Poplar1, Poplar1AggregationParam, Poplar1IdpfValue},
 };
 #[cfg(feature = "experimental")]
 use rand::prelude::*;
@@ -43,12 +37,12 @@ use zipf::ZipfDistribution;
 const RNG_SEED: u64 = 0;
 
 /// Speed test for generating a seed and deriving a pseudorandom sequence of field elements.
-pub fn prng(c: &mut Criterion) {
+fn prng(c: &mut Criterion) {
     let mut group = c.benchmark_group("rand");
     let test_sizes = [16, 256, 1024, 4096];
     for size in test_sizes {
-        group.bench_function(BenchmarkId::from_parameter(size), |b| {
-            b.iter(|| random_vector::<F>(size))
+        group.bench_with_input(BenchmarkId::from_parameter(size), &size, |b, size| {
+            b.iter(|| random_vector::<F>(*size))
         });
     }
     group.finish();
@@ -58,23 +52,28 @@ pub fn prng(c: &mut Criterion) {
 /// the naive method. This benchmark demonstrates that the latter has better concrete performance
 /// for small polynomials. The result is used to pick the `FFT_THRESHOLD` constant in
 /// `src/flp/gadgets.rs`.
-pub fn poly_mul(c: &mut Criterion) {
+fn poly_mul(c: &mut Criterion) {
     let test_sizes = [1_usize, 30, 60, 90, 120, 150];
 
     let mut group = c.benchmark_group("poly_mul");
     for size in test_sizes {
-        let m = (size + 1).next_power_of_two();
-        let mut g: Mul<F> = Mul::new(size);
-        let mut outp = vec![F::zero(); 2 * m];
-        let inp = vec![random_vector(m).unwrap(); 2];
+        group.bench_with_input(BenchmarkId::new("fft", size), &size, |b, size| {
+            let m = (size + 1).next_power_of_two();
+            let mut g: Mul<F> = Mul::new(*size);
+            let mut outp = vec![F::zero(); 2 * m];
+            let inp = vec![random_vector(m).unwrap(); 2];
 
-        group.bench_function(BenchmarkId::new("fft", size), |b| {
             b.iter(|| {
                 benchmarked_gadget_mul_call_poly_fft(&mut g, &mut outp, &inp).unwrap();
             })
         });
 
-        group.bench_function(BenchmarkId::new("direct", size), |b| {
+        group.bench_with_input(BenchmarkId::new("direct", size), &size, |b, size| {
+            let m = (size + 1).next_power_of_two();
+            let mut g: Mul<F> = Mul::new(*size);
+            let mut outp = vec![F::zero(); 2 * m];
+            let inp = vec![random_vector(m).unwrap(); 2];
+
             b.iter(|| {
                 benchmarked_gadget_mul_call_poly_direct(&mut g, &mut outp, &inp).unwrap();
             })
@@ -83,177 +82,430 @@ pub fn poly_mul(c: &mut Criterion) {
     group.finish();
 }
 
-/// Benchmark generation and verification of boolean vectors.
-pub fn count_vec(c: &mut Criterion) {
-    let mut group = c.benchmark_group("count_vec");
-    let test_sizes = [10, 100, 1_000];
-    for size in test_sizes {
-        #[cfg(feature = "prio2")]
-        {
-            // Prio2
-            let input = vec![0u32; size];
-            let ignored_nonce = [0; 16];
-            let prio2 = Prio2::new(size).unwrap();
+/// Benchmark prio2.
+#[cfg(feature = "prio2")]
+fn prio2(c: &mut Criterion) {
+    let mut group = c.benchmark_group("prio2_shard");
+    for input_len in [10, 100, 1_000] {
+        group.bench_with_input(
+            BenchmarkId::from_parameter(input_len),
+            &input_len,
+            |b, input_len| {
+                let vdaf = Prio2::new(*input_len).unwrap();
+                let measurement = (0..u32::try_from(*input_len).unwrap())
+                    .map(|i| i & 1)
+                    .collect::<Vec<_>>();
+                let nonce = black_box([0u8; 16]);
+                b.iter(|| vdaf.shard(&measurement, &nonce).unwrap());
+            },
+        );
+    }
+    group.finish();
 
-            group.bench_function(BenchmarkId::new("prio2_prove", size), |b| {
+    let mut group = c.benchmark_group("prio2_prepare_init");
+    for input_len in [10, 100, 1_000] {
+        group.bench_with_input(
+            BenchmarkId::from_parameter(input_len),
+            &input_len,
+            |b, input_len| {
+                let vdaf = Prio2::new(*input_len).unwrap();
+                let measurement = (0..u32::try_from(*input_len).unwrap())
+                    .map(|i| i & 1)
+                    .collect::<Vec<_>>();
+                let nonce = black_box([0u8; 16]);
+                let verify_key = black_box([0u8; 32]);
+                let (public_share, input_shares) = vdaf.shard(&measurement, &nonce).unwrap();
                 b.iter(|| {
-                    prio2.shard(&input, &ignored_nonce).unwrap();
-                })
-            });
-
-            let (_, input_shares) = prio2.shard(&input, &ignored_nonce).unwrap();
-            let query_rand = random_vector(1).unwrap()[0];
-
-            group.bench_function(BenchmarkId::new("prio2_query", size), |b| {
-                let input_share = &input_shares[0];
-                b.iter(|| {
-                    prio2
-                        .prepare_init_with_query_rand(query_rand, input_share, true)
+                    vdaf.prepare_init(&verify_key, 0, &(), &nonce, &public_share, &input_shares[0])
                         .unwrap();
-                })
-            });
-        }
-
-        // Prio3
-        let input = vec![F::zero(); size];
-        let sum_vec: SumVec<F, ParallelSum<F, BlindPolyEval<F>>> = SumVec::new(1, size).unwrap();
-        let joint_rand = random_vector(sum_vec.joint_rand_len()).unwrap();
-        let prove_rand = random_vector(sum_vec.prove_rand_len()).unwrap();
-        let proof = sum_vec.prove(&input, &prove_rand, &joint_rand).unwrap();
-
-        group.bench_function(BenchmarkId::new("prio3_countvec_prove", size), |b| {
-            b.iter(|| {
-                let prove_rand = random_vector(sum_vec.prove_rand_len()).unwrap();
-                sum_vec.prove(&input, &prove_rand, &joint_rand).unwrap();
-            })
-        });
-
-        group.bench_function(BenchmarkId::new("prio3_countvec_query", size), |b| {
-            b.iter(|| {
-                let query_rand = random_vector(sum_vec.query_rand_len()).unwrap();
-                sum_vec
-                    .query(&input, &proof, &query_rand, &joint_rand, 1)
-                    .unwrap();
-            })
-        });
-
-        #[cfg(feature = "multithreaded")]
-        {
-            let sum_vec: SumVec<F, ParallelSumMultithreaded<F, BlindPolyEval<F>>> =
-                SumVec::new(1, size).unwrap();
-
-            group.bench_function(
-                BenchmarkId::new("prio3_countvec_multithreaded_prove", size),
-                |b| {
-                    b.iter(|| {
-                        let prove_rand = random_vector(sum_vec.prove_rand_len()).unwrap();
-                        sum_vec.prove(&input, &prove_rand, &joint_rand).unwrap();
-                    })
-                },
-            );
-
-            group.bench_function(
-                BenchmarkId::new("prio3_countvec_multithreaded_query", size),
-                |b| {
-                    b.iter(|| {
-                        let query_rand = random_vector(sum_vec.query_rand_len()).unwrap();
-                        sum_vec
-                            .query(&input, &proof, &query_rand, &joint_rand, 1)
-                            .unwrap();
-                    })
-                },
-            );
-        }
+                });
+            },
+        );
     }
     group.finish();
 }
 
-/// Benchmark prio3 client performance.
-pub fn prio3_client(c: &mut Criterion) {
+/// Benchmark prio3.
+fn prio3(c: &mut Criterion) {
     let num_shares = 2;
-    let mut group = c.benchmark_group("prio3_client");
 
-    let nonce = [0; 16];
-    let prio3 = Prio3::new_count(num_shares).unwrap();
-    let measurement = 1;
-    group.bench_function("count", |b| {
-        b.iter(|| {
-            prio3.shard(&measurement, &nonce).unwrap();
-        })
+    c.bench_function("prio3count_shard", |b| {
+        let vdaf = Prio3::new_count(num_shares).unwrap();
+        let measurement = black_box(1);
+        let nonce = black_box([0u8; 16]);
+        b.iter(|| vdaf.shard(&measurement, &nonce).unwrap());
     });
 
-    let length = 10;
-    let prio3 = Prio3::new_histogram(num_shares, 10).unwrap();
-    let measurement = 9;
-    group.bench_function(BenchmarkId::new("histogram", length), |b| {
+    c.bench_function("prio3count_prepare_init", |b| {
+        let vdaf = Prio3::new_count(num_shares).unwrap();
+        let measurement = black_box(1);
+        let nonce = black_box([0u8; 16]);
+        let verify_key = black_box([0u8; 16]);
+        let (public_share, input_shares) = vdaf.shard(&measurement, &nonce).unwrap();
         b.iter(|| {
-            prio3.shard(&measurement, &nonce).unwrap();
-        })
+            vdaf.prepare_init(&verify_key, 0, &(), &nonce, &public_share, &input_shares[0])
+                .unwrap()
+        });
     });
 
-    let bits = 32;
-    let prio3 = Prio3::new_sum(num_shares, bits).unwrap();
-    let measurement = 1337;
-    group.bench_function(BenchmarkId::new("sum", bits), |b| {
-        b.iter(|| {
-            prio3.shard(&measurement, &nonce).unwrap();
-        })
-    });
-
-    let len = 1000;
-    let prio3 = Prio3::new_sum_vec(num_shares, 1, len).unwrap();
-    let measurement = vec![0; len];
-    group.bench_function(BenchmarkId::new("countvec", len), |b| {
-        b.iter(|| {
-            prio3.shard(&measurement, &nonce).unwrap();
-        })
-    });
-
-    #[cfg(feature = "multithreaded")]
-    {
-        let prio3 = Prio3::new_sum_vec_multithreaded(num_shares, 1, len).unwrap();
-        let measurement = vec![0; len];
-        group.bench_function(BenchmarkId::new("countvec_parallel", len), |b| {
-            b.iter(|| {
-                prio3.shard(&measurement, &nonce).unwrap();
-            })
+    let mut group = c.benchmark_group("prio3sum_shard");
+    for bits in [8, 32] {
+        group.bench_with_input(BenchmarkId::from_parameter(bits), &bits, |b, bits| {
+            let vdaf = Prio3::new_sum(num_shares, *bits).unwrap();
+            let measurement = (1 << bits) - 1;
+            let nonce = black_box([0u8; 16]);
+            b.iter(|| vdaf.shard(&measurement, &nonce).unwrap());
         });
     }
+    group.finish();
 
-    #[cfg(feature = "experimental")]
-    {
-        let len = 1000;
-        let prio3 = Prio3::new_fixedpoint_boundedl2_vec_sum(num_shares, len).unwrap();
-        let fp_num = fixed!(0.0001: I1F15);
-        let measurement = vec![fp_num; len];
-        group.bench_function(BenchmarkId::new("fixedpoint16_boundedl2_vec", len), |b| {
+    let mut group = c.benchmark_group("prio3sum_prepare_init");
+    for bits in [8, 32] {
+        group.bench_with_input(BenchmarkId::from_parameter(bits), &bits, |b, bits| {
+            let vdaf = Prio3::new_sum(num_shares, *bits).unwrap();
+            let measurement = (1 << bits) - 1;
+            let nonce = black_box([0u8; 16]);
+            let verify_key = black_box([0u8; 16]);
+            let (public_share, input_shares) = vdaf.shard(&measurement, &nonce).unwrap();
             b.iter(|| {
-                prio3.shard(&measurement, &nonce).unwrap();
-            })
+                vdaf.prepare_init(&verify_key, 0, &(), &nonce, &public_share, &input_shares[0])
+                    .unwrap()
+            });
         });
     }
+    group.finish();
 
-    #[cfg(all(feature = "experimental", feature = "multithreaded"))]
-    {
-        let prio3 = Prio3::new_fixedpoint_boundedl2_vec_sum_multithreaded(num_shares, len).unwrap();
-        let fp_num = fixed!(0.0001: I1F15);
-        let measurement = vec![fp_num; len];
-        group.bench_function(
-            BenchmarkId::new("prio3_fixedpoint16_boundedl2_vec_multithreaded", len),
-            |b| {
-                b.iter(|| {
-                    prio3.shard(&measurement, &nonce).unwrap();
-                })
+    let mut group = c.benchmark_group("prio3sumvec_shard");
+    for input_len in [10, 100, 1_000] {
+        group.bench_with_input(
+            BenchmarkId::new("serial", input_len),
+            &input_len,
+            |b, input_len| {
+                let vdaf = Prio3::new_sum_vec(num_shares, 1, *input_len).unwrap();
+                let measurement = (0..u128::try_from(*input_len).unwrap())
+                    .map(|i| i & 1)
+                    .collect::<Vec<_>>();
+                let nonce = black_box([0u8; 16]);
+                b.iter(|| vdaf.shard(&measurement, &nonce).unwrap());
             },
         );
     }
 
+    #[cfg(feature = "multithreaded")]
+    {
+        for input_len in [10, 100, 1_000] {
+            group.bench_with_input(
+                BenchmarkId::new("parallel", input_len),
+                &input_len,
+                |b, input_len| {
+                    let vdaf = Prio3::new_sum_vec_multithreaded(num_shares, 1, *input_len).unwrap();
+                    let measurement = (0..u128::try_from(*input_len).unwrap())
+                        .map(|i| i & 1)
+                        .collect::<Vec<_>>();
+                    let nonce = black_box([0u8; 16]);
+                    b.iter(|| vdaf.shard(&measurement, &nonce).unwrap());
+                },
+            );
+        }
+    }
     group.finish();
+
+    let mut group = c.benchmark_group("prio3sumvec_prepare_init");
+    for input_len in [10, 100, 1_000] {
+        group.bench_with_input(
+            BenchmarkId::new("serial", input_len),
+            &input_len,
+            |b, input_len| {
+                let vdaf = Prio3::new_sum_vec(num_shares, 1, *input_len).unwrap();
+                let measurement = (0..u128::try_from(*input_len).unwrap())
+                    .map(|i| i & 1)
+                    .collect::<Vec<_>>();
+                let nonce = black_box([0u8; 16]);
+                let verify_key = black_box([0u8; 16]);
+                let (public_share, input_shares) = vdaf.shard(&measurement, &nonce).unwrap();
+                b.iter(|| {
+                    vdaf.prepare_init(&verify_key, 0, &(), &nonce, &public_share, &input_shares[0])
+                        .unwrap()
+                });
+            },
+        );
+    }
+
+    #[cfg(feature = "multithreaded")]
+    {
+        for input_len in [10, 100, 1_000] {
+            group.bench_with_input(
+                BenchmarkId::new("parallel", input_len),
+                &input_len,
+                |b, input_len| {
+                    let vdaf = Prio3::new_sum_vec_multithreaded(num_shares, 1, *input_len).unwrap();
+                    let measurement = (0..u128::try_from(*input_len).unwrap())
+                        .map(|i| i & 1)
+                        .collect::<Vec<_>>();
+                    let nonce = black_box([0u8; 16]);
+                    let verify_key = black_box([0u8; 16]);
+                    let (public_share, input_shares) = vdaf.shard(&measurement, &nonce).unwrap();
+                    b.iter(|| {
+                        vdaf.prepare_init(
+                            &verify_key,
+                            0,
+                            &(),
+                            &nonce,
+                            &public_share,
+                            &input_shares[0],
+                        )
+                        .unwrap()
+                    });
+                },
+            );
+        }
+    }
+    group.finish();
+
+    let mut group = c.benchmark_group("prio3histogram_shard");
+    for input_len in [10, 100, 1_000] {
+        group.bench_with_input(
+            BenchmarkId::new("serial", input_len),
+            &input_len,
+            |b, input_len| {
+                let vdaf = Prio3::new_histogram(num_shares, *input_len).unwrap();
+                let measurement = black_box(0);
+                let nonce = black_box([0u8; 16]);
+                b.iter(|| vdaf.shard(&measurement, &nonce).unwrap());
+            },
+        );
+    }
+    group.finish();
+
+    let mut group = c.benchmark_group("prio3histogram_prepare_init");
+    for input_len in [10, 100, 1_000] {
+        group.bench_with_input(
+            BenchmarkId::new("serial", input_len),
+            &input_len,
+            |b, input_len| {
+                let vdaf = Prio3::new_histogram(num_shares, *input_len).unwrap();
+                let measurement = black_box(0);
+                let nonce = black_box([0u8; 16]);
+                let verify_key = black_box([0u8; 16]);
+                let (public_share, input_shares) = vdaf.shard(&measurement, &nonce).unwrap();
+                b.iter(|| {
+                    vdaf.prepare_init(&verify_key, 0, &(), &nonce, &public_share, &input_shares[0])
+                        .unwrap()
+                });
+            },
+        );
+    }
+    group.finish();
+
+    #[cfg(feature = "experimental")]
+    {
+        let mut group = c.benchmark_group("prio3fixedpointboundedl2vecsum_i1f15_shard");
+        for dimension in [10, 100, 1_000] {
+            group.bench_with_input(
+                BenchmarkId::new("serial", dimension),
+                &dimension,
+                |b, dimension| {
+                    let vdaf: Prio3<FixedPointBoundedL2VecSum<I1F15, _, _, _>, _, 16> =
+                        Prio3::new_fixedpoint_boundedl2_vec_sum(num_shares, *dimension).unwrap();
+                    let mut measurement = vec![fixed!(0: I1F15); *dimension];
+                    measurement[0] = fixed!(0.5: I1F15);
+                    let nonce = black_box([0u8; 16]);
+                    b.iter(|| vdaf.shard(&measurement, &nonce).unwrap());
+                },
+            );
+        }
+
+        #[cfg(feature = "multithreaded")]
+        {
+            for dimension in [10, 100, 1_000] {
+                group.bench_with_input(
+                    BenchmarkId::new("parallel", dimension),
+                    &dimension,
+                    |b, dimension| {
+                        let vdaf: Prio3<FixedPointBoundedL2VecSum<I1F15, _, _, _>, _, 16> =
+                            Prio3::new_fixedpoint_boundedl2_vec_sum_multithreaded(
+                                num_shares, *dimension,
+                            )
+                            .unwrap();
+                        let mut measurement = vec![fixed!(0: I1F15); *dimension];
+                        measurement[0] = fixed!(0.5: I1F15);
+                        let nonce = black_box([0u8; 16]);
+                        b.iter(|| vdaf.shard(&measurement, &nonce).unwrap());
+                    },
+                );
+            }
+        }
+        group.finish();
+
+        let mut group = c.benchmark_group("prio3fixedpointboundedl2vecsum_i1f15_prepare_init");
+        for dimension in [10, 100, 1_000] {
+            group.bench_with_input(
+                BenchmarkId::new("series", dimension),
+                &dimension,
+                |b, dimension| {
+                    let vdaf: Prio3<FixedPointBoundedL2VecSum<I1F15, _, _, _>, _, 16> =
+                        Prio3::new_fixedpoint_boundedl2_vec_sum(num_shares, *dimension).unwrap();
+                    let mut measurement = vec![fixed!(0: I1F15); *dimension];
+                    measurement[0] = fixed!(0.5: I1F15);
+                    let nonce = black_box([0u8; 16]);
+                    let verify_key = black_box([0u8; 16]);
+                    let (public_share, input_shares) = vdaf.shard(&measurement, &nonce).unwrap();
+                    b.iter(|| {
+                        vdaf.prepare_init(
+                            &verify_key,
+                            0,
+                            &(),
+                            &nonce,
+                            &public_share,
+                            &input_shares[0],
+                        )
+                        .unwrap()
+                    });
+                },
+            );
+        }
+
+        #[cfg(feature = "multithreaded")]
+        {
+            for dimension in [10, 100, 1_000] {
+                group.bench_with_input(
+                    BenchmarkId::new("parallel", dimension),
+                    &dimension,
+                    |b, dimension| {
+                        let vdaf: Prio3<FixedPointBoundedL2VecSum<I1F15, _, _, _>, _, 16> =
+                            Prio3::new_fixedpoint_boundedl2_vec_sum_multithreaded(
+                                num_shares, *dimension,
+                            )
+                            .unwrap();
+                        let mut measurement = vec![fixed!(0: I1F15); *dimension];
+                        measurement[0] = fixed!(0.5: I1F15);
+                        let nonce = black_box([0u8; 16]);
+                        let verify_key = black_box([0u8; 16]);
+                        let (public_share, input_shares) =
+                            vdaf.shard(&measurement, &nonce).unwrap();
+                        b.iter(|| {
+                            vdaf.prepare_init(
+                                &verify_key,
+                                0,
+                                &(),
+                                &nonce,
+                                &public_share,
+                                &input_shares[0],
+                            )
+                            .unwrap()
+                        });
+                    },
+                );
+            }
+        }
+        group.finish();
+
+        let mut group = c.benchmark_group("prio3fixedpointboundedl2vecsum_i1f31_shard");
+        for dimension in [10, 100, 1_000] {
+            group.bench_with_input(
+                BenchmarkId::new("serial", dimension),
+                &dimension,
+                |b, dimension| {
+                    let vdaf: Prio3<FixedPointBoundedL2VecSum<I1F31, _, _, _>, _, 16> =
+                        Prio3::new_fixedpoint_boundedl2_vec_sum(num_shares, *dimension).unwrap();
+                    let mut measurement = vec![fixed!(0: I1F31); *dimension];
+                    measurement[0] = fixed!(0.5: I1F31);
+                    let nonce = black_box([0u8; 16]);
+                    b.iter(|| vdaf.shard(&measurement, &nonce).unwrap());
+                },
+            );
+        }
+
+        #[cfg(feature = "multithreaded")]
+        {
+            for dimension in [10, 100, 1_000] {
+                group.bench_with_input(
+                    BenchmarkId::new("parallel", dimension),
+                    &dimension,
+                    |b, dimension| {
+                        let vdaf: Prio3<FixedPointBoundedL2VecSum<I1F31, _, _, _>, _, 16> =
+                            Prio3::new_fixedpoint_boundedl2_vec_sum_multithreaded(
+                                num_shares, *dimension,
+                            )
+                            .unwrap();
+                        let mut measurement = vec![fixed!(0: I1F31); *dimension];
+                        measurement[0] = fixed!(0.5: I1F31);
+                        let nonce = black_box([0u8; 16]);
+                        b.iter(|| vdaf.shard(&measurement, &nonce).unwrap());
+                    },
+                );
+            }
+        }
+        group.finish();
+
+        let mut group = c.benchmark_group("prio3fixedpointboundedl2vecsum_i1f31_prepare_init");
+        for dimension in [10, 100, 1_000] {
+            group.bench_with_input(
+                BenchmarkId::new("series", dimension),
+                &dimension,
+                |b, dimension| {
+                    let vdaf: Prio3<FixedPointBoundedL2VecSum<I1F31, _, _, _>, _, 16> =
+                        Prio3::new_fixedpoint_boundedl2_vec_sum(num_shares, *dimension).unwrap();
+                    let mut measurement = vec![fixed!(0: I1F31); *dimension];
+                    measurement[0] = fixed!(0.5: I1F31);
+                    let nonce = black_box([0u8; 16]);
+                    let verify_key = black_box([0u8; 16]);
+                    let (public_share, input_shares) = vdaf.shard(&measurement, &nonce).unwrap();
+                    b.iter(|| {
+                        vdaf.prepare_init(
+                            &verify_key,
+                            0,
+                            &(),
+                            &nonce,
+                            &public_share,
+                            &input_shares[0],
+                        )
+                        .unwrap()
+                    });
+                },
+            );
+        }
+
+        #[cfg(feature = "multithreaded")]
+        {
+            for dimension in [10, 100, 1_000] {
+                group.bench_with_input(
+                    BenchmarkId::new("parallel", dimension),
+                    &dimension,
+                    |b, dimension| {
+                        let vdaf: Prio3<FixedPointBoundedL2VecSum<I1F31, _, _, _>, _, 16> =
+                            Prio3::new_fixedpoint_boundedl2_vec_sum_multithreaded(
+                                num_shares, *dimension,
+                            )
+                            .unwrap();
+                        let mut measurement = vec![fixed!(0: I1F31); *dimension];
+                        measurement[0] = fixed!(0.5: I1F31);
+                        let nonce = black_box([0u8; 16]);
+                        let verify_key = black_box([0u8; 16]);
+                        let (public_share, input_shares) =
+                            vdaf.shard(&measurement, &nonce).unwrap();
+                        b.iter(|| {
+                            vdaf.prepare_init(
+                                &verify_key,
+                                0,
+                                &(),
+                                &nonce,
+                                &public_share,
+                                &input_shares[0],
+                            )
+                            .unwrap()
+                        });
+                    },
+                );
+            }
+        }
+        group.finish();
+    }
 }
 
 /// Benchmark IdpfPoplar performance.
 #[cfg(feature = "experimental")]
-pub fn idpf(c: &mut Criterion) {
+fn idpf(c: &mut Criterion) {
     let test_sizes = [8usize, 8 * 16, 8 * 256];
 
     let mut group = c.benchmark_group("idpf_gen");
@@ -318,7 +570,7 @@ pub fn idpf(c: &mut Criterion) {
 
 /// Benchmark Poplar1.
 #[cfg(feature = "experimental")]
-pub fn poplar1(c: &mut Criterion) {
+fn poplar1(c: &mut Criterion) {
     let test_sizes = [16_usize, 128, 256];
 
     let mut group = c.benchmark_group("poplar1_shard");
@@ -478,20 +730,12 @@ fn poplar1_generate_zipf_distributed_batch(
 }
 
 #[cfg(all(feature = "prio2", feature = "experimental"))]
-criterion_group!(
-    benches,
-    poplar1,
-    prio3_client,
-    count_vec,
-    poly_mul,
-    prng,
-    idpf
-);
+criterion_group!(benches, poplar1, prio3, prio2, poly_mul, prng, idpf);
 #[cfg(all(not(feature = "prio2"), feature = "experimental"))]
-criterion_group!(benches, poplar1, prio3_client, poly_mul, prng, idpf);
+criterion_group!(benches, poplar1, prio3, poly_mul, prng, idpf);
 #[cfg(all(feature = "prio2", not(feature = "experimental")))]
-criterion_group!(benches, prio3_client, count_vec, prng, poly_mul);
+criterion_group!(benches, prio3, prio2, prng, poly_mul);
 #[cfg(all(not(feature = "prio2"), not(feature = "experimental")))]
-criterion_group!(benches, prio3_client, prng, poly_mul);
+criterion_group!(benches, prio3, prng, poly_mul);
 
 criterion_main!(benches);

--- a/benches/speed_tests.rs
+++ b/benches/speed_tests.rs
@@ -25,7 +25,8 @@ use prio::{
 #[cfg(feature = "experimental")]
 use rand::prelude::*;
 #[cfg(feature = "experimental")]
-use std::{iter, time::Duration};
+use std::iter;
+use std::time::Duration;
 #[cfg(feature = "experimental")]
 use zipf::ZipfDistribution;
 
@@ -263,7 +264,10 @@ fn prio3(c: &mut Criterion) {
     group.finish();
 
     let mut group = c.benchmark_group("prio3histogram_shard");
-    for input_len in [10, 100, 1_000] {
+    for input_len in [10, 100, 1_000, 10_000, 100_000] {
+        if input_len >= 100_000 {
+            group.measurement_time(Duration::from_secs(15));
+        }
         group.bench_with_input(
             BenchmarkId::new("serial", input_len),
             &input_len,
@@ -278,7 +282,10 @@ fn prio3(c: &mut Criterion) {
     group.finish();
 
     let mut group = c.benchmark_group("prio3histogram_prepare_init");
-    for input_len in [10, 100, 1_000] {
+    for input_len in [10, 100, 1_000, 10_000, 100_000] {
+        if input_len >= 100_000 {
+            group.measurement_time(Duration::from_secs(15));
+        }
         group.bench_with_input(
             BenchmarkId::new("serial", input_len),
             &input_len,


### PR DESCRIPTION
This rewrites the Criterion benchmarks for Prio2 and Prio3. Benchmarks operating at the FLP level are removed, and we instead benchmark each VDAF through the VDAF interface. Benchmarks are also added for `prepare_init()`, in addition to sharding. I put the multithreaded implementations of VDAFs in the same groups as their respective serial implementations, where applicable, so that the reports will give us plots comparing the two.