### PR TITLE
Fix clippy warning

### DIFF
--- a/src/polynomial.rs
+++ b/src/polynomial.rs
@@ -258,7 +258,7 @@ mod tests {
 
     #[test]
     fn test_eval() {
-        let mut poly = vec![FieldPrio2::from(0); 4];
+        let mut poly = [FieldPrio2::from(0); 4];
         poly[0] = 2.into();
         poly[1] = 1.into();
         poly[2] = 5.into();


### PR DESCRIPTION
This fixes a new Clippy warning present with toolchain version 1.72.0.