### PR TITLE
Fix clippy warnings

### DIFF
--- a/src/polynomial.rs
+++ b/src/polynomial.rs
@@ -246,7 +246,7 @@ fn test_roots() {
 fn test_eval() {
     use crate::field::Field32;
 
-    let mut poly = vec![Field32::from(0); 4];
+    let mut poly = [Field32::from(0); 4];
     poly[0] = 2.into();
     poly[1] = 1.into();
     poly[2] = 5.into();

--- a/src/vdaf/poplar1.rs
+++ b/src/vdaf/poplar1.rs
@@ -250,7 +250,7 @@ impl Encode for BTreeSet<IdpfInput> {
 impl Decode for BTreeSet<IdpfInput> {
     fn decode(bytes: &mut Cursor<&[u8]>) -> Result<Self, CodecError> {
         let inputs = decode_u24_items(&(), bytes)?;
-        Ok(Self::from_iter(inputs.into_iter()))
+        Ok(Self::from_iter(inputs))
     }
 }
 


### PR DESCRIPTION
This fixes two Clippy warnings with 1.72.0, backporting #698.