### PR TITLE
Prio3: reduce allocations

### DIFF
--- a/src/field.rs
+++ b/src/field.rs
@@ -838,7 +838,7 @@ pub fn random_vector<F: FieldElement>(len: usize) -> Result<Vec<F>, PrngError> {
 #[inline(always)]
 pub(crate) fn encode_fieldvec<F: FieldElement, T: AsRef<[F]>>(val: T, bytes: &mut Vec<u8>) {
     for elem in val.as_ref() {
-        bytes.append(&mut (*elem).into());
+        elem.encode(bytes);
     }
 }
 

--- a/src/flp/types.rs
+++ b/src/flp/types.rs
@@ -538,17 +538,18 @@ where
             )));
         }
 
-        let mut flattened = Vec::with_capacity(self.flattened_len);
-        for summand in measurement {
+        let mut flattened = vec![F::zero(); self.flattened_len];
+        for (summand, chunk) in measurement
+            .iter()
+            .zip(flattened.chunks_exact_mut(self.bits))
+        {
             if summand > &self.max {
                 return Err(FlpError::Encode(format!(
                     "summand exceeds maximum of 2^{}-1",
                     self.bits
                 )));
             }
-            flattened.append(&mut F::encode_into_bitvector_representation(
-                summand, self.bits,
-            )?);
+            F::fill_with_bitvector_representation(summand, chunk)?;
         }
 
         Ok(flattened)

--- a/src/vdaf/prio3.rs
+++ b/src/vdaf/prio3.rs
@@ -419,12 +419,15 @@ where
                     joint_rand_part_prg.update(&[agg_id]); // Aggregator ID
                     joint_rand_part_prg.update(nonce);
 
+                    let mut encoding_buffer = Vec::with_capacity(T::Field::ENCODED_SIZE);
                     for (x, y) in leader_measurement_share
                         .iter_mut()
                         .zip(measurement_share_prng)
                     {
                         *x -= y;
-                        joint_rand_part_prg.update(&y.into());
+                        y.encode(&mut encoding_buffer);
+                        joint_rand_part_prg.update(&encoding_buffer);
+                        encoding_buffer.clear();
                     }
 
                     helper_joint_rand_parts.push(joint_rand_part_prg.into_seed());
@@ -458,8 +461,11 @@ where
                     );
                     joint_rand_part_prg.update(&[0]); // Aggregator ID
                     joint_rand_part_prg.update(nonce);
+                    let mut encoding_buffer = Vec::with_capacity(T::Field::ENCODED_SIZE);
                     for x in leader_measurement_share.iter() {
-                        joint_rand_part_prg.update(&(*x).into());
+                        x.encode(&mut encoding_buffer);
+                        joint_rand_part_prg.update(&encoding_buffer);
+                        encoding_buffer.clear();
                     }
                     leader_blind_opt = Some(leader_blind);
 
@@ -973,8 +979,11 @@ where
             );
             joint_rand_part_prg.update(&[agg_id]);
             joint_rand_part_prg.update(nonce);
+            let mut encoding_buffer = Vec::with_capacity(T::Field::ENCODED_SIZE);
             for x in measurement_share {
-                joint_rand_part_prg.update(&(*x).into());
+                x.encode(&mut encoding_buffer);
+                joint_rand_part_prg.update(&encoding_buffer);
+                encoding_buffer.clear();
             }
             let own_joint_rand_part = joint_rand_part_prg.into_seed();
 


### PR DESCRIPTION
This reduces the number of small allocations we make, as described in https://github.com/divviup/libprio-rs/pull/668#issuecomment-1660690120. These changes improve Prio3SumVec benchmarks by 1%-2%.