### PR TITLE
derive `Hash` on `Poplar1AggregationParam`

### DIFF
--- a/src/vdaf/poplar1.rs
+++ b/src/vdaf/poplar1.rs
@@ -553,7 +553,7 @@ impl Aggregatable for Poplar1FieldVec {
 ///
 /// This includes an indication of what level of the IDPF tree is being evaluated and the set of
 /// prefixes to evaluate at that level.
-#[derive(Clone, Debug, PartialEq, Eq)]
+#[derive(Clone, Debug, Hash, PartialEq, Eq)]
 pub struct Poplar1AggregationParam {
     level: u16,
     prefixes: Vec<IdpfInput>,


### PR DESCRIPTION
Given that `IdpfInput` is already `Hash`, this is trivial to derive, and is needed for Janus.