### PR TITLE
Upgrade fiat-crypto, rewrite to use new types

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -359,9 +359,9 @@ dependencies = [
 
 [[package]]
 name = "fiat-crypto"
-version = "0.1.20"
+version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e825f6987101665dea6ec934c09ec6d721de7bc1bf92248e1d5810c8cd636b77"
+checksum = "692de2d08cf3ee05b2d6ec4a5bbee781034f3bfc7cd35dc980f7b305af66d0f8"
 
 [[package]]
 name = "fixed"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,7 +17,7 @@ bitvec = { version = "1.0.1", optional = true }
 byteorder = "1.4.3"
 cmac = { version = "0.7.2", optional = true }
 ctr = { version = "0.9.2", optional = true }
-fiat-crypto = { version = "0.1.20", optional = true }
+fiat-crypto = { version = "0.2.0", optional = true }
 fixed = { version = "1.23", optional = true }
 getrandom = { version = "0.2.10", features = ["std"] }
 hmac = { version = "0.12.1", optional = true }

--- a/supply-chain/audits.toml
+++ b/supply-chain/audits.toml
@@ -158,6 +158,11 @@ who = "David Cook <dcook@divviup.org>"
 criteria = "safe-to-deploy"
 delta = "0.1.19 -> 0.1.20"
 
+[[audits.fiat-crypto]]
+who = "David Cook <dcook@divviup.org>"
+criteria = "safe-to-deploy"
+delta = "0.1.20 -> 0.2.0"
+
 [[audits.fixed]]
 who = "David Cook <dcook@divviup.org>"
 criteria = "safe-to-deploy"


### PR DESCRIPTION
I recently made a contribution to fiat-crypto to improve the API's type safety by replacing some type aliases with newtypes. That has now been released, so this PR updates our dependency, and changes the Field255 implementation to use the newtypes. We had everything right already, so we just need to shuffle in constructors and add some `relax` operations before multiplications. (relax is the identity map from a field element representation with tight bounds to one with loose bounds)