### PR TITLE
Upgrade fiat-crypto, rewrite to use new types, 0.12 backport

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -477,9 +477,9 @@ dependencies = [
 
 [[package]]
 name = "fiat-crypto"
-version = "0.1.20"
+version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e825f6987101665dea6ec934c09ec6d721de7bc1bf92248e1d5810c8cd636b77"
+checksum = "d0870c84016d4b481be5c9f323c24f65e31e901ae618f0e80f4308fb00de1d2d"
 
 [[package]]
 name = "fixed"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,7 +17,7 @@ ctr = { version = "0.9.2", optional = true }
 cmac = { version = "0.7.2", optional = true }
 base64 = "0.21.3"
 byteorder = "1.4.3"
-fiat-crypto = { version = "0.1.20", optional = true }
+fiat-crypto = { version = "0.2.1", optional = true }
 fixed = { version = "1.23", optional = true }
 getrandom = { version = "0.2.10", features = ["std"] }
 serde = { version = "1.0", features = ["derive"] }

--- a/supply-chain/audits.toml
+++ b/supply-chain/audits.toml
@@ -143,6 +143,11 @@ who = "David Cook <dcook@divviup.org>"
 criteria = "safe-to-deploy"
 delta = "0.1.19 -> 0.1.20"
 
+[[audits.fiat-crypto]]
+who = "David Cook <dcook@divviup.org>"
+criteria = "safe-to-deploy"
+delta = "0.1.20 -> 0.2.0"
+
 [[audits.fixed]]
 who = "David Cook <dcook@divviup.org>"
 criteria = "safe-to-deploy"

--- a/supply-chain/imports.lock
+++ b/supply-chain/imports.lock
@@ -388,6 +388,11 @@ who = "David Cook <dcook@divviup.org>"
 criteria = "safe-to-deploy"
 delta = "0.21.2 -> 0.21.3"
 
+[[audits.divviup.audits.fiat-crypto]]
+who = "Brandon Pitman <bran@bran.land>"
+criteria = "safe-to-deploy"
+delta = "0.2.0 -> 0.2.1"
+
 [[audits.divviup.audits.itertools]]
 who = "David Cook <dcook@divviup.org>"
 criteria = "safe-to-run"


### PR DESCRIPTION
This backports #719 to the 0.12 release branch. This supersedes #727.