### PR TITLE
Upgrade fiat-crypto, rewrite to use new types

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -477,9 +477,9 @@ dependencies = [
 
 [[package]]
 name = "fiat-crypto"
-version = "0.1.20"
+version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e825f6987101665dea6ec934c09ec6d721de7bc1bf92248e1d5810c8cd636b77"
+checksum = "d0870c84016d4b481be5c9f323c24f65e31e901ae618f0e80f4308fb00de1d2d"
 
 [[package]]
 name = "fixed"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,7 +17,7 @@ ctr = { version = "0.9.2", optional = true }
 cmac = { version = "0.7.2", optional = true }
 base64 = "0.21.2"
 byteorder = "1.4.3"
-fiat-crypto = { version = "0.1.20", optional = true }
+fiat-crypto = { version = "0.2.1", optional = true }
 fixed = { version = "1.23", optional = true }
 getrandom = { version = "0.2.10", features = ["std"] }
 serde = { version = "1.0", features = ["derive"] }

--- a/supply-chain/audits.toml
+++ b/supply-chain/audits.toml
@@ -143,6 +143,11 @@ who = "David Cook <dcook@divviup.org>"
 criteria = "safe-to-deploy"
 delta = "0.1.19 -> 0.1.20"
 
+[[audits.fiat-crypto]]
+who = "David Cook <dcook@divviup.org>"
+criteria = "safe-to-deploy"
+delta = "0.1.20 -> 0.2.0"
+
 [[audits.fixed]]
 who = "David Cook <dcook@divviup.org>"
 criteria = "safe-to-deploy"

--- a/supply-chain/config.toml
+++ b/supply-chain/config.toml
@@ -2,7 +2,7 @@
 # cargo-vet config file
 
 [cargo-vet]
-version = "0.7"
+version = "0.8"
 
 [imports.bytecode-alliance]
 url = "https://raw.githubusercontent.com/bytecodealliance/wasmtime/main/supply-chain/audits.toml"
@@ -33,10 +33,6 @@ audit-as-crates-io = false
 criteria = "safe-to-deploy"
 
 [policy.prio-binaries]
-criteria = "safe-to-run"
-
-[[exemptions.adler]]
-version = "1.0.2"
 criteria = "safe-to-run"
 
 [[exemptions.aead]]
@@ -215,16 +211,6 @@ version = "0.8.5"
 criteria = "safe-to-deploy"
 notes = "This is only used when the \"test-util\" feature is enabled."
 
-[[exemptions.rand_chacha]]
-version = "0.3.1"
-criteria = "safe-to-deploy"
-notes = "This is only used when the \"test-util\" feature is enabled."
-
-[[exemptions.rand_core]]
-version = "0.6.3"
-criteria = "safe-to-deploy"
-notes = "This is only used when the \"test-util\" feature is enabled."
-
 [[exemptions.ring]]
 version = "0.16.20"
 criteria = "safe-to-deploy"
@@ -254,11 +240,6 @@ criteria = "safe-to-run"
 [[exemptions.structopt-derive]]
 version = "0.4.18"
 criteria = "safe-to-run"
-
-[[exemptions.subtle]]
-version = "2.4.1"
-criteria = "safe-to-deploy"
-notes = "This is only used when the \"crypto-dependencies\" or \"prio2\" features are enabled."
 
 [[exemptions.tinytemplate]]
 version = "1.2.1"

--- a/supply-chain/imports.lock
+++ b/supply-chain/imports.lock
@@ -239,6 +239,12 @@ user-id = 64539
 user-login = "kennykerr"
 user-name = "Kenny Kerr"
 
+[[audits.bytecode-alliance.audits.adler]]
+who = "Alex Crichton <alex@alexcrichton.com>"
+criteria = "safe-to-deploy"
+version = "1.0.2"
+notes = "This is a small crate which forbids unsafe code and is a straightforward implementation of the adler hashing algorithm."
+
 [[audits.bytecode-alliance.audits.anes]]
 who = "Pat Hickey <phickey@fastly.com>"
 criteria = "safe-to-deploy"
@@ -344,13 +350,20 @@ criteria = "safe-to-deploy"
 version = "0.37.13"
 notes = "The Bytecode Alliance is the author of this crate."
 
-[audits.divviup.audits]
-
-[[audits.embark-studios.audits.epaint]]
-who = "Johan Andersson <opensource@embark-studios.com>"
+[[audits.divviup.audits.fiat-crypto]]
+who = "Brandon Pitman <bran@bran.land>"
 criteria = "safe-to-deploy"
-violation = "<0.20.0"
-notes = "Specified crate license does not include licenses of embedded fonts if using default features or the `default_fonts` feature. Tracked in: https://github.com/emilk/egui/issues/2321"
+delta = "0.2.0 -> 0.2.1"
+
+[[audits.divviup.audits.rand_chacha]]
+who = "David Cook <dcook@divviup.org>"
+criteria = "safe-to-deploy"
+version = "0.3.1"
+
+[[audits.divviup.audits.rand_core]]
+who = "David Cook <dcook@divviup.org>"
+criteria = "safe-to-deploy"
+version = "0.6.3"
 
 [[audits.embark-studios.audits.tap]]
 who = "Johan Andersson <opensource@embark-studios.com>"
@@ -574,6 +587,12 @@ delta = "1.9.3 -> 1.10.1"
 who = "Mike Hommey <mh+mozilla@glandium.org>"
 criteria = "safe-to-deploy"
 delta = "1.10.1 -> 1.10.2"
+
+[[audits.firefox.audits.subtle]]
+who = "Simon Friedberger <simon@mozilla.com>"
+criteria = "safe-to-deploy"
+version = "2.5.0"
+notes = "The goal is to provide some constant-time correctness for cryptographic implementations. The approach is reasonable, it is known to be insufficient but this is pointed out in the documentation."
 
 [[audits.firefox.audits.tracing]]
 who = "Mike Hommey <mh+mozilla@glandium.org>"


### PR DESCRIPTION
(This is a cherrypick of https://github.com/divviup/libprio-rs/commit/a964428ae93df256a95fb800fac2864e203d33c9; dependabot wants to upgrade `fiat-crypto` in this branch, too: https://github.com/divviup/libprio-rs/pull/727)