### PR TITLE
Remove non-constant-time comparisons of secret values.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -46,7 +46,7 @@ itertools = "0.11.0"
 modinverse = "0.1.0"
 num-bigint = "0.4.4"
 once_cell = "1.18.0"
-prio = { path = ".", features = ["crypto-dependencies", "test-util"] }
+prio = { path = ".", features = ["crypto-dependencies"] }
 rand = "0.8"
 serde_json = "1.0"
 statrs = "0.16.0"
@@ -58,7 +58,6 @@ experimental = ["bitvec", "fiat-crypto", "fixed", "num-bigint", "num-rational", 
 multithreaded = ["rayon"]
 prio2 = ["crypto-dependencies", "hmac", "sha2"]
 crypto-dependencies = ["aes", "ctr"]
-test-util = []
 
 [workspace]
 members = [".", "binaries"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -46,7 +46,7 @@ itertools = "0.11.0"
 modinverse = "0.1.0"
 num-bigint = "0.4.4"
 once_cell = "1.18.0"
-prio = { path = ".", features = ["crypto-dependencies"] }
+prio = { path = ".", features = ["crypto-dependencies", "test-util"] }
 rand = "0.8"
 serde_json = "1.0"
 statrs = "0.16.0"
@@ -58,6 +58,7 @@ experimental = ["bitvec", "fiat-crypto", "fixed", "num-bigint", "num-rational", 
 multithreaded = ["rayon"]
 prio2 = ["crypto-dependencies", "hmac", "sha2"]
 crypto-dependencies = ["aes", "ctr"]
+test-util = []
 
 [workspace]
 members = [".", "binaries"]

--- a/src/vdaf/poplar1.rs
+++ b/src/vdaf/poplar1.rs
@@ -391,7 +391,8 @@ impl<F: ConstantTimeEq> Eq for SketchState<F> {}
 
 impl<F: ConstantTimeEq> ConstantTimeEq for SketchState<F> {
     fn ct_eq(&self, other: &Self) -> Choice {
-        // We allow short-circuiting on the round (RoundOne vs RoundTwo).
+        // We allow short-circuiting on the round (RoundOne vs RoundTwo), as well as is_leader for
+        // RoundOne comparisons.
         match (self, other) {
             (
                 SketchState::RoundOne {
@@ -405,12 +406,12 @@ impl<F: ConstantTimeEq> ConstantTimeEq for SketchState<F> {
                     is_leader: other_is_leader,
                 },
             ) => {
-                let self_is_leader = Choice::from(*self_is_leader as u8);
-                let other_is_leader = Choice::from(*other_is_leader as u8);
-
+                if self_is_leader != other_is_leader {
+                    return Choice::from(0);
+                }
+                
                 self_a_share.ct_eq(other_a_share)
                     & self_b_share.ct_eq(other_b_share)
-                    & self_is_leader.ct_eq(&other_is_leader)
             }
 
             (SketchState::RoundTwo, SketchState::RoundTwo) => Choice::from(1),

--- a/src/vdaf/poplar1.rs
+++ b/src/vdaf/poplar1.rs
@@ -409,9 +409,8 @@ impl<F: ConstantTimeEq> ConstantTimeEq for SketchState<F> {
                 if self_is_leader != other_is_leader {
                     return Choice::from(0);
                 }
-                
-                self_a_share.ct_eq(other_a_share)
-                    & self_b_share.ct_eq(other_b_share)
+
+                self_a_share.ct_eq(other_a_share) & self_b_share.ct_eq(other_b_share)
             }
 
             (SketchState::RoundTwo, SketchState::RoundTwo) => Choice::from(1),

--- a/src/vdaf/prio2.rs
+++ b/src/vdaf/prio2.rs
@@ -385,7 +385,10 @@ fn role_try_from(agg_id: usize) -> Result<bool, VdafError> {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::vdaf::{fieldvec_roundtrip_test, prio2::test_vector::Priov2TestVector, run_vdaf};
+    use crate::vdaf::{
+        equality_comparison_test, fieldvec_roundtrip_test, prio2::test_vector::Priov2TestVector,
+        run_vdaf,
+    };
     use assert_matches::assert_matches;
     use rand::prelude::*;
 
@@ -515,5 +518,25 @@ mod tests {
             .collect::<Vec<_>>();
 
         assert_eq!(reconstructed, test_vector.reference_sum);
+    }
+
+    #[test]
+    fn prepare_state_equality_test() {
+        equality_comparison_test(&[
+            Prio2PrepareState(Share::Leader(Vec::from([
+                FieldPrio2::from(0),
+                FieldPrio2::from(1),
+            ]))),
+            Prio2PrepareState(Share::Leader(Vec::from([
+                FieldPrio2::from(1),
+                FieldPrio2::from(0),
+            ]))),
+            Prio2PrepareState(Share::Helper(Seed(
+                (0..32).collect::<Vec<_>>().try_into().unwrap(),
+            ))),
+            Prio2PrepareState(Share::Helper(Seed(
+                (1..33).collect::<Vec<_>>().try_into().unwrap(),
+            ))),
+        ])
     }
 }

--- a/src/vdaf/prio2.rs
+++ b/src/vdaf/prio2.rs
@@ -165,7 +165,9 @@ impl Client<16> for Prio2 {
 }
 
 /// State of each [`Aggregator`] during the Preparation phase.
-#[derive(Clone, Debug, Eq, PartialEq)]
+#[derive(Clone, Debug)]
+// Only derive equality checks in test code, as the content of this type is a secret.
+#[cfg_attr(feature = "test-util", derive(PartialEq, Eq))]
 pub struct Prio2PrepareState(Share<FieldPrio2, 32>);
 
 impl Encode for Prio2PrepareState {

--- a/src/vdaf/prio3.rs
+++ b/src/vdaf/prio3.rs
@@ -632,7 +632,10 @@ impl<const SEED_SIZE: usize> Eq for Prio3PublicShare<SEED_SIZE> {}
 impl<const SEED_SIZE: usize> ConstantTimeEq for Prio3PublicShare<SEED_SIZE> {
     fn ct_eq(&self, other: &Self) -> Choice {
         // We allow short-circuiting on the presence or absence of the joint_rand_parts.
-        option_ct_eq(self.joint_rand_parts.as_deref(), other.joint_rand_parts.as_deref())
+        option_ct_eq(
+            self.joint_rand_parts.as_deref(),
+            other.joint_rand_parts.as_deref(),
+        )
     }
 }
 
@@ -686,8 +689,10 @@ impl<F: ConstantTimeEq, const SEED_SIZE: usize> Eq for Prio3InputShare<F, SEED_S
 impl<F: ConstantTimeEq, const SEED_SIZE: usize> ConstantTimeEq for Prio3InputShare<F, SEED_SIZE> {
     fn ct_eq(&self, other: &Self) -> Choice {
         // We allow short-circuiting on the presence or absence of the joint_rand_blind.
-        option_ct_eq(self.joint_rand_blind.as_ref(), other.joint_rand_blind.as_ref())
-            & self.measurement_share.ct_eq(&other.measurement_share)
+        option_ct_eq(
+            self.joint_rand_blind.as_ref(),
+            other.joint_rand_blind.as_ref(),
+        ) & self.measurement_share.ct_eq(&other.measurement_share)
             & self.proof_share.ct_eq(&other.proof_share)
     }
 }
@@ -780,8 +785,10 @@ impl<F: ConstantTimeEq, const SEED_SIZE: usize> Eq for Prio3PrepareShare<F, SEED
 impl<F: ConstantTimeEq, const SEED_SIZE: usize> ConstantTimeEq for Prio3PrepareShare<F, SEED_SIZE> {
     fn ct_eq(&self, other: &Self) -> Choice {
         // We allow short-circuiting on the presence or absence of the joint_rand_part.
-        option_ct_eq(self.joint_rand_part.as_ref(), other.joint_rand_part.as_ref())
-            & self.verifier.ct_eq(&other.verifier)
+        option_ct_eq(
+            self.joint_rand_part.as_ref(),
+            other.joint_rand_part.as_ref(),
+        ) & self.verifier.ct_eq(&other.verifier)
     }
 }
 
@@ -850,7 +857,10 @@ impl<const SEED_SIZE: usize> Eq for Prio3PrepareMessage<SEED_SIZE> {}
 impl<const SEED_SIZE: usize> ConstantTimeEq for Prio3PrepareMessage<SEED_SIZE> {
     fn ct_eq(&self, other: &Self) -> Choice {
         // We allow short-circuiting on the presnce or absence of the joint_rand_seed.
-        option_ct_eq(self.joint_rand_seed.as_ref(), other.joint_rand_seed.as_ref())
+        option_ct_eq(
+            self.joint_rand_seed.as_ref(),
+            other.joint_rand_seed.as_ref(),
+        )
     }
 }
 
@@ -929,8 +939,10 @@ impl<F: ConstantTimeEq, const SEED_SIZE: usize> ConstantTimeEq for Prio3PrepareS
             return Choice::from(0);
         }
 
-        option_ct_eq(self.joint_rand_seed.as_ref(), other.joint_rand_seed.as_ref())
-            & self.measurement_share.ct_eq(&other.measurement_share)
+        option_ct_eq(
+            self.joint_rand_seed.as_ref(),
+            other.joint_rand_seed.as_ref(),
+        ) & self.measurement_share.ct_eq(&other.measurement_share)
     }
 }
 
@@ -1354,7 +1366,10 @@ where
 // short-circuits on the existence (but not contents) of the values -- a timing side-channel may
 // reveal whether the values match on Some or None.
 #[inline]
-fn option_ct_eq<T>(left: Option<&T>, right: Option<&T>) -> Choice where T: ConstantTimeEq + ?Sized {
+fn option_ct_eq<T>(left: Option<&T>, right: Option<&T>) -> Choice
+where
+    T: ConstantTimeEq + ?Sized,
+{
     match (left, right) {
         (Some(left), Some(right)) => left.ct_eq(right),
         (None, None) => Choice::from(1),

--- a/src/vdaf/prio3.rs
+++ b/src/vdaf/prio3.rs
@@ -765,7 +765,6 @@ where
 
 #[derive(Clone, Debug)]
 /// Message broadcast by each [`Aggregator`] in each round of the Preparation phase.
-
 pub struct Prio3PrepareShare<F, const SEED_SIZE: usize> {
     /// A share of the FLP verifier message. (See [`Type`].)
     verifier: Vec<F>,

--- a/src/vdaf/prio3.rs
+++ b/src/vdaf/prio3.rs
@@ -1357,7 +1357,9 @@ mod tests {
     use super::*;
     #[cfg(feature = "experimental")]
     use crate::flp::gadgets::ParallelSumGadget;
-    use crate::vdaf::{fieldvec_roundtrip_test, run_vdaf, run_vdaf_prepare};
+    use crate::vdaf::{
+        equality_comparison_test, fieldvec_roundtrip_test, run_vdaf, run_vdaf_prepare,
+    };
     use assert_matches::assert_matches;
     #[cfg(feature = "experimental")]
     use fixed::{
@@ -1824,5 +1826,148 @@ mod tests {
             &(),
             12,
         );
+    }
+
+    #[test]
+    fn public_share_equality_test() {
+        equality_comparison_test(&[
+            Prio3PublicShare {
+                joint_rand_parts: Some(Vec::from([Seed([0])])),
+            },
+            Prio3PublicShare {
+                joint_rand_parts: Some(Vec::from([Seed([1])])),
+            },
+            Prio3PublicShare {
+                joint_rand_parts: None,
+            },
+        ])
+    }
+
+    #[test]
+    fn input_share_equality_test() {
+        equality_comparison_test(&[
+            // Default.
+            Prio3InputShare {
+                measurement_share: Share::Leader(Vec::from([0])),
+                proof_share: Share::Leader(Vec::from([1])),
+                joint_rand_blind: Some(Seed([2])),
+            },
+            // Modified measurement share.
+            Prio3InputShare {
+                measurement_share: Share::Leader(Vec::from([100])),
+                proof_share: Share::Leader(Vec::from([1])),
+                joint_rand_blind: Some(Seed([2])),
+            },
+            // Modified proof share.
+            Prio3InputShare {
+                measurement_share: Share::Leader(Vec::from([0])),
+                proof_share: Share::Leader(Vec::from([101])),
+                joint_rand_blind: Some(Seed([2])),
+            },
+            // Modified joint_rand_blind.
+            Prio3InputShare {
+                measurement_share: Share::Leader(Vec::from([0])),
+                proof_share: Share::Leader(Vec::from([1])),
+                joint_rand_blind: Some(Seed([102])),
+            },
+            // Missing joint_rand_blind.
+            Prio3InputShare {
+                measurement_share: Share::Leader(Vec::from([0])),
+                proof_share: Share::Leader(Vec::from([1])),
+                joint_rand_blind: None,
+            },
+        ])
+    }
+
+    #[test]
+    fn prepare_share_equality_test() {
+        equality_comparison_test(&[
+            // Default.
+            Prio3PrepareShare {
+                verifier: Vec::from([0]),
+                joint_rand_part: Some(Seed([1])),
+            },
+            // Modified verifier.
+            Prio3PrepareShare {
+                verifier: Vec::from([100]),
+                joint_rand_part: Some(Seed([1])),
+            },
+            // Modified joint_rand_part.
+            Prio3PrepareShare {
+                verifier: Vec::from([0]),
+                joint_rand_part: Some(Seed([101])),
+            },
+            // Missing joint_rand_part.
+            Prio3PrepareShare {
+                verifier: Vec::from([0]),
+                joint_rand_part: None,
+            },
+        ])
+    }
+
+    #[test]
+    fn prepare_message_equality_test() {
+        equality_comparison_test(&[
+            // Default.
+            Prio3PrepareMessage {
+                joint_rand_seed: Some(Seed([0])),
+            },
+            // Modified joint_rand_seed.
+            Prio3PrepareMessage {
+                joint_rand_seed: Some(Seed([100])),
+            },
+            // Missing joint_rand_seed.
+            Prio3PrepareMessage {
+                joint_rand_seed: None,
+            },
+        ])
+    }
+
+    #[test]
+    fn prepare_state_equality_test() {
+        equality_comparison_test(&[
+            // Default.
+            Prio3PrepareState {
+                measurement_share: Share::Leader(Vec::from([0])),
+                joint_rand_seed: Some(Seed([1])),
+                agg_id: 2,
+                verifier_len: 3,
+            },
+            // Modified measurement share.
+            Prio3PrepareState {
+                measurement_share: Share::Leader(Vec::from([100])),
+                joint_rand_seed: Some(Seed([1])),
+                agg_id: 2,
+                verifier_len: 3,
+            },
+            // Modified joint_rand_seed.
+            Prio3PrepareState {
+                measurement_share: Share::Leader(Vec::from([0])),
+                joint_rand_seed: Some(Seed([101])),
+                agg_id: 2,
+                verifier_len: 3,
+            },
+            // Missing joint_rand_seed.
+            Prio3PrepareState {
+                measurement_share: Share::Leader(Vec::from([0])),
+                joint_rand_seed: None,
+                agg_id: 2,
+                verifier_len: 3,
+            },
+            // Modified agg_id.
+            Prio3PrepareState {
+                measurement_share: Share::Leader(Vec::from([0])),
+                joint_rand_seed: Some(Seed([1])),
+                agg_id: 102,
+                verifier_len: 3,
+            },
+            // Modified verifier_len.
+            Prio3PrepareState {
+                measurement_share: Share::Leader(Vec::from([0])),
+                joint_rand_seed: Some(Seed([1])),
+                agg_id: 2,
+                verifier_len: 103,
+            },
+        ])
     }
 }

--- a/src/vdaf/xof.rs
+++ b/src/vdaf/xof.rs
@@ -38,7 +38,9 @@ use std::{
 use subtle::{Choice, ConstantTimeEq};
 
 /// Input of [`Xof`].
-#[derive(Clone, Debug, Eq)]
+#[derive(Clone, Debug)]
+// Only derive equality checks in test code, as the content of this type is sometimes a secret.
+#[cfg_attr(feature = "test-util", derive(PartialEq, Eq))]
 pub struct Seed<const SEED_SIZE: usize>(pub(crate) [u8; SEED_SIZE]);
 
 impl<const SEED_SIZE: usize> Seed<SEED_SIZE> {
@@ -64,12 +66,6 @@ impl<const SEED_SIZE: usize> AsRef<[u8; SEED_SIZE]> for Seed<SEED_SIZE> {
 impl<const SEED_SIZE: usize> ConstantTimeEq for Seed<SEED_SIZE> {
     fn ct_eq(&self, other: &Self) -> Choice {
         self.0.ct_eq(&other.0)
-    }
-}
-
-impl<const SEED_SIZE: usize> PartialEq for Seed<SEED_SIZE> {
-    fn eq(&self, other: &Self) -> bool {
-        self.ct_eq(other).into()
     }
 }
 

--- a/src/vdaf/xof.rs
+++ b/src/vdaf/xof.rs
@@ -407,7 +407,7 @@ impl SeedStreamFixedKeyAes128 {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::field::Field128;
+    use crate::{field::Field128, vdaf::equality_comparison_test};
     use serde::{Deserialize, Serialize};
     use std::{convert::TryInto, io::Cursor};
 
@@ -536,5 +536,10 @@ mod tests {
 
         assert_eq!(output_1_trait_api, output_1_alternate_api);
         assert_eq!(output_2_trait_api, output_2_alternate_api);
+    }
+
+    #[test]
+    fn seed_equality_test() {
+        equality_comparison_test(&[Seed([1, 2, 3]), Seed([3, 2, 1])])
     }
 }

--- a/src/vdaf/xof.rs
+++ b/src/vdaf/xof.rs
@@ -39,8 +39,6 @@ use subtle::{Choice, ConstantTimeEq};
 
 /// Input of [`Xof`].
 #[derive(Clone, Debug)]
-// Only derive equality checks in test code, as the content of this type is sometimes a secret.
-#[cfg_attr(feature = "test-util", derive(PartialEq, Eq))]
 pub struct Seed<const SEED_SIZE: usize>(pub(crate) [u8; SEED_SIZE]);
 
 impl<const SEED_SIZE: usize> Seed<SEED_SIZE> {
@@ -62,6 +60,14 @@ impl<const SEED_SIZE: usize> AsRef<[u8; SEED_SIZE]> for Seed<SEED_SIZE> {
         &self.0
     }
 }
+
+impl<const SEED_SIZE: usize> PartialEq for Seed<SEED_SIZE> {
+    fn eq(&self, other: &Self) -> bool {
+        self.ct_eq(other).into()
+    }
+}
+
+impl<const SEED_SIZE: usize> Eq for Seed<SEED_SIZE> {}
 
 impl<const SEED_SIZE: usize> ConstantTimeEq for Seed<SEED_SIZE> {
     fn ct_eq(&self, other: &Self) -> Choice {


### PR DESCRIPTION
This affects the types representing:
  * Input shares
  * Preparation states
  * Output shares
  * Aggregate shares

(and their constituent types)

Mostly, the comparisons were either dropped entirely or updated to be test-only.  Input shares were instead given a constant-time equality implementation, as it is believed this is required for DAP implementations.

PartialEq & Eq implementations are still derived when the "test-util" feature is enabled. This is to ease testing for users of this library.

Closes #722.