### PR TITLE
xof: Replace `SeedStream` trait with `RngCore`

### DIFF
--- a/src/vdaf/poplar1.rs
+++ b/src/vdaf/poplar1.rs
@@ -10,11 +10,12 @@ use crate::{
     idpf::{Idpf, IdpfInput, IdpfOutputShare, IdpfPublicShare, IdpfValue, RingBufferCache},
     prng::Prng,
     vdaf::{
-        xof::{Seed, SeedStream, Xof, XofShake128},
+        xof::{Seed, Xof, XofShake128},
         Aggregatable, Aggregator, Client, Collector, PrepareTransition, Vdaf, VdafError,
     },
 };
 use bitvec::{prelude::Lsb0, vec::BitVec};
+use rand_core::RngCore;
 use std::{
     convert::TryFrom,
     fmt::Debug,
@@ -1117,7 +1118,7 @@ impl From<IdpfOutputShare<Poplar1IdpfValue<Field64>, Poplar1IdpfValue<Field255>>
 // seed, rather than iteratively, as we do in Doplar. This would be more efficient for the
 // Aggregators. As long as the Client isn't significantly slower, this should be a win.
 #[allow(non_snake_case)]
-fn compute_next_corr_shares<F: FieldElement + From<u64>, S: SeedStream>(
+fn compute_next_corr_shares<F: FieldElement + From<u64>, S: RngCore>(
     prng: &mut Prng<F, S>,
     corr_prng_0: &mut Prng<F, S>,
     corr_prng_1: &mut Prng<F, S>,
@@ -1261,7 +1262,7 @@ where
         Self([F::zero(); 2])
     }
 
-    fn generate<S: SeedStream>(seed_stream: &mut S, _: &()) -> Self {
+    fn generate<S: RngCore>(seed_stream: &mut S, _: &()) -> Self {
         Self([F::generate(seed_stream, &()), F::generate(seed_stream, &())])
     }
 

--- a/src/vdaf/prio2.rs
+++ b/src/vdaf/prio2.rs
@@ -2,7 +2,6 @@
 
 //! Backwards-compatible port of the ENPA Prio system to a VDAF.
 
-use super::{xof::SeedStream, AggregateShare, OutputShare};
 use crate::{
     codec::{CodecError, Decode, Encode, ParameterizedDecode},
     field::{
@@ -15,11 +14,12 @@ use crate::{
             server as v2_server,
         },
         xof::Seed,
-        Aggregatable, Aggregator, Client, Collector, PrepareTransition, Share,
-        ShareDecodingParameter, Vdaf, VdafError,
+        Aggregatable, AggregateShare, Aggregator, Client, Collector, OutputShare,
+        PrepareTransition, Share, ShareDecodingParameter, Vdaf, VdafError,
     },
 };
 use hmac::{Hmac, Mac};
+use rand_core::RngCore;
 use sha2::Sha256;
 use std::{convert::TryFrom, io::Cursor};
 
@@ -98,7 +98,7 @@ impl Prio2 {
     /// The point returned is not one of the roots used for polynomial interpolation.
     pub(crate) fn choose_eval_at<S>(&self, prng: &mut Prng<FieldPrio2, S>) -> FieldPrio2
     where
-        S: SeedStream,
+        S: RngCore,
     {
         // Make sure the query randomness isn't a root of unity. Evaluating the proof at any of
         // these points would be a privacy violation, since these points were used by the prover to

--- a/src/vdaf/prio3.rs
+++ b/src/vdaf/prio3.rs
@@ -49,7 +49,7 @@ use crate::flp::Type;
 #[cfg(feature = "experimental")]
 use crate::flp::TypeWithNoise;
 use crate::prng::Prng;
-use crate::vdaf::xof::{Seed, SeedStream, Xof};
+use crate::vdaf::xof::{IntoFieldVec, Seed, Xof};
 use crate::vdaf::{
     Aggregatable, AggregateShare, Aggregator, Client, Collector, OutputShare, PrepareTransition,
     Share, ShareDecodingParameter, Vdaf, VdafError,
@@ -493,7 +493,7 @@ where
                     &Self::domain_separation_tag(DST_JOINT_RANDOMNESS),
                     &[],
                 )
-                .into_vec(self.typ.joint_rand_len())
+                .into_field_vec(self.typ.joint_rand_len())
             })
             .unwrap_or_default();
 
@@ -504,7 +504,7 @@ where
             &Self::domain_separation_tag(DST_PROVE_RANDOMNESS),
             &[],
         )
-        .into_vec(self.typ.prove_rand_len());
+        .into_field_vec(self.typ.prove_rand_len());
         let mut leader_proof_share =
             self.typ
                 .prove(&encoded_measurement, &prove_rand, &joint_rand)?;
@@ -940,7 +940,7 @@ where
         query_rand_xof.update(nonce);
         let query_rand = query_rand_xof
             .into_seed_stream()
-            .into_vec(self.typ.query_rand_len());
+            .into_field_vec(self.typ.query_rand_len());
 
         // Create a reference to the (expanded) measurement share.
         let expanded_measurement_share: Option<Vec<T::Field>> = match msg.measurement_share {
@@ -951,7 +951,7 @@ where
                     &Self::domain_separation_tag(DST_MEASUREMENT_SHARE),
                     &[agg_id],
                 )
-                .into_vec(self.typ.input_len()),
+                .into_field_vec(self.typ.input_len()),
             ),
         };
         let measurement_share = match msg.measurement_share {
@@ -968,7 +968,7 @@ where
                     &Self::domain_separation_tag(DST_PROOF_SHARE),
                     &[agg_id],
                 )
-                .into_vec(self.typ.proof_len()),
+                .into_field_vec(self.typ.proof_len()),
             ),
         };
         let proof_share = match msg.proof_share {
@@ -1020,7 +1020,7 @@ where
                 &Self::domain_separation_tag(DST_JOINT_RANDOMNESS),
                 &[],
             )
-            .into_vec(self.typ.joint_rand_len());
+            .into_field_vec(self.typ.joint_rand_len());
             (Some(joint_rand_seed), Some(own_joint_rand_part), joint_rand)
         } else {
             (None, None, Vec::new())
@@ -1123,7 +1123,7 @@ where
             Share::Leader(data) => data,
             Share::Helper(seed) => {
                 let dst = Self::domain_separation_tag(DST_MEASUREMENT_SHARE);
-                P::seed_stream(&seed, &dst, &[step.agg_id]).into_vec(self.typ.input_len())
+                P::seed_stream(&seed, &dst, &[step.agg_id]).into_field_vec(self.typ.input_len())
             }
         };
 


### PR DESCRIPTION
Closes #644.

Most of our `SeedStream` implementors also implement `RngCore`, which requires a method with the same semantics as `SeedStream::fill()`. Further, the blanket trait `Rng` provides a method with the same name that does pretty much the same thing (but is slightly more generic).

To avoid confusion going forward, drop `SeedSstream` and use `RngCore` instead. Accordingly:

* Implement `RngCore` for `SeedStreamFixedKeyAes128` (the only `SeedStream` that does not already implement `RngCore`)

* Move `SeedStream::into_vec()` it its own trait, `IntoVec`, and provide a blanket implementation for `RngCore`.