### PR TITLE
Unroll first iteration of fft.

### DIFF
--- a/src/fft.rs
+++ b/src/fft.rs
@@ -58,15 +58,26 @@ pub fn discrete_fourier_transform<F: FftFriendlyFieldElement>(
         w = F::one();
         let r = F::root(l).unwrap();
         let y = 1 << (l - 1);
-        for i in 0..y {
-            for j in 0..(size / y) >> 1 {
-                let x = (1 << l) * j + i;
+        let chunk = (size / y) >> 1;
+
+        // unrolling first iteration of i-loop.
+        for j in 0..chunk {
+            let x = j << l;
+            let u = outp[x];
+            let v = outp[x + y];
+            outp[x] = u + v;
+            outp[x + y] = u - v;
+        }
+
+        for i in 1..y {
+            w *= r;
+            for j in 0..chunk {
+                let x = (j << l) + i;
                 let u = outp[x];
                 let v = w * outp[x + y];
                 outp[x] = u + v;
                 outp[x + y] = u - v;
             }
-            w *= r;
         }
     }
 


### PR DESCRIPTION
Reduces a round of multiplications times 1.

| poly_mul/fft/n | Improvement|
|--|--|
| 1    | -15.324%|
| 30   | -14.770%|
| 60   | -10.638%|
| 90   | -11.503%|
| 120  |  -9.163%|
| 150  |  -9.752%|
| 10^3 |  -7.856%|
| 10^4 |  -6.788%|
| 10^5 |  -5.771%|

