### PR TITLE
Align `Aggregator` trait with spec

### DIFF
--- a/src/vdaf/prio2.rs
+++ b/src/vdaf/prio2.rs
@@ -268,8 +268,9 @@ impl Aggregator<32, 16> for Prio2 {
         self.prepare_init_with_query_rand(query_rand, input_share, is_leader)
     }
 
-    fn prepare_preprocess<M: IntoIterator<Item = Prio2PrepareShare>>(
+    fn prepare_shares_to_prepare_message<M: IntoIterator<Item = Prio2PrepareShare>>(
         &self,
+        _: &Self::AggregationParam,
         inputs: M,
     ) -> Result<(), VdafError> {
         let verifier_shares: Vec<v2_server::VerificationMessage<FieldPrio2>> =
@@ -289,7 +290,7 @@ impl Aggregator<32, 16> for Prio2 {
         Ok(())
     }
 
-    fn prepare_step(
+    fn prepare_next(
         &self,
         state: Prio2PrepareState,
         _input: (),
@@ -491,12 +492,12 @@ mod tests {
             let (prepare_state_2, prepare_share_2) = vdaf
                 .prepare_init(&[0; 32], 1, &(), &[0; 16], &(), &input_share_2)
                 .unwrap();
-            vdaf.prepare_preprocess([prepare_share_1, prepare_share_2])
+            vdaf.prepare_shares_to_prepare_message(&(), [prepare_share_1, prepare_share_2])
                 .unwrap();
-            let transition_1 = vdaf.prepare_step(prepare_state_1, ()).unwrap();
+            let transition_1 = vdaf.prepare_next(prepare_state_1, ()).unwrap();
             let output_share_1 =
                 assert_matches!(transition_1, PrepareTransition::Finish(out) => out);
-            let transition_2 = vdaf.prepare_step(prepare_state_2, ()).unwrap();
+            let transition_2 = vdaf.prepare_next(prepare_state_2, ()).unwrap();
             let output_share_2 =
                 assert_matches!(transition_2, PrepareTransition::Finish(out) => out);
             leader_output_shares.push(output_share_1);

--- a/src/vdaf/prio3.rs
+++ b/src/vdaf/prio3.rs
@@ -313,7 +313,7 @@ impl Prio3Average {
 ///         prep_states.push(state);
 ///         prep_shares.push(share);
 ///     }
-///     let prep_msg = vdaf.prepare_preprocess(prep_shares).unwrap();
+///     let prep_msg = vdaf.prepare_shares_to_prepare_message(&(), prep_shares).unwrap();
 ///
 ///     for (agg_id, state) in prep_states.into_iter().enumerate() {
 ///         let out_share = match vdaf.prepare_step(state, prep_msg.clone()).unwrap() {
@@ -1173,8 +1173,11 @@ where
         ))
     }
 
-    fn prepare_preprocess<M: IntoIterator<Item = Prio3PrepareShare<T::Field, SEED_SIZE>>>(
+    fn prepare_shares_to_prepare_message<
+        M: IntoIterator<Item = Prio3PrepareShare<T::Field, SEED_SIZE>>,
+    >(
         &self,
+        _: &Self::AggregationParam,
         inputs: M,
     ) -> Result<Prio3PrepareMessage<SEED_SIZE>, VdafError> {
         let mut verifier = vec![T::Field::zero(); self.typ.verifier_len()];
@@ -1228,7 +1231,7 @@ where
         Ok(Prio3PrepareMessage { joint_rand_seed })
     }
 
-    fn prepare_step(
+    fn prepare_next(
         &self,
         step: Prio3PrepareState<T::Field, SEED_SIZE>,
         msg: Prio3PrepareMessage<SEED_SIZE>,
@@ -1851,7 +1854,9 @@ mod tests {
             last_prepare_state = Some(prepare_state);
         }
 
-        let prepare_message = prio3.prepare_preprocess(prepare_shares).unwrap();
+        let prepare_message = prio3
+            .prepare_shares_to_prepare_message(&(), prepare_shares)
+            .unwrap();
 
         let encoded_prepare_message = prepare_message.get_encoded();
         let decoded_prepare_message = Prio3PrepareMessage::get_decoded_with_param(

--- a/src/vdaf/prio3_test.rs
+++ b/src/vdaf/prio3_test.rs
@@ -106,14 +106,14 @@ fn check_prep_test_vec<M, T, P, const SEED_SIZE: usize>(
     }
 
     let inbound = prio3
-        .prepare_preprocess(prep_shares)
+        .prepare_shares_to_prepare_message(&(), prep_shares)
         .unwrap_or_else(|e| err!(test_num, e, "prep preprocess"));
     assert_eq!(t.prep_messages.len(), 1);
     assert_eq!(inbound.get_encoded(), t.prep_messages[0].as_ref());
 
     let mut out_shares = Vec::new();
     for state in states.iter_mut() {
-        match prio3.prepare_step(state.clone(), inbound.clone()).unwrap() {
+        match prio3.prepare_next(state.clone(), inbound.clone()).unwrap() {
             PrepareTransition::Finish(out_share) => {
                 out_shares.push(out_share);
             }


### PR DESCRIPTION
`Vdaf::prepare_preprocess` was missing the `&Vdaf::AggregationParam` argument specified in VDAF. This adds that argument to the trait method and its implementations. While we're at it, to further align with the spec, we add new methods `prepare_shares_to_prepare_message` and `prepare_next`, to align with the spec's `prep_shares_to_prep` and `prep_next`, as aliases for the existing `prepare_preprocess` and `prepare_step`. The existing methods are marked as deprecated.

Resolves #670