### PR TITLE
Improve test vec tests

### DIFF
--- a/src/idpf.rs
+++ b/src/idpf.rs
@@ -1804,6 +1804,8 @@ mod tests {
     struct IdpfTestVector {
         /// The number of bits in IDPF inputs.
         bits: usize,
+        /// The binder string used when generating and evaluating keys.
+        binder: Vec<u8>,
         /// The IDPF input provided to the key generation algorithm.
         alpha: IdpfInput,
         /// The IDPF output values, at each inner level, provided to the key generation algorithm.
@@ -1883,8 +1885,12 @@ mod tests {
         let public_share_hex = test_vec_obj.get("public_share").unwrap();
         let public_share = hex::decode(public_share_hex.as_str().unwrap()).unwrap();
 
+        let binder_hex = test_vec_obj.get("binder").unwrap();
+        let binder = hex::decode(binder_hex.as_str().unwrap()).unwrap();
+
         IdpfTestVector {
             bits,
+            binder,
             alpha,
             beta_inner,
             beta_leaf,
@@ -1902,7 +1908,7 @@ mod tests {
                 &test_vector.alpha,
                 test_vector.beta_inner,
                 test_vector.beta_leaf,
-                b"some nonce",
+                &test_vector.binder,
                 &test_vector.keys,
             )
             .unwrap();

--- a/src/idpf.rs
+++ b/src/idpf.rs
@@ -953,7 +953,6 @@ mod tests {
         collections::HashMap,
         convert::{TryFrom, TryInto},
         io::Cursor,
-        iter,
         ops::{Add, AddAssign, Sub},
         str::FromStr,
         sync::Mutex,
@@ -1897,11 +1896,6 @@ mod tests {
     #[test]
     fn idpf_poplar_generate_test_vector() {
         let test_vector = load_idpfpoplar_test_vector();
-        let random_iter = iter::repeat(0..=255u8).flatten();
-        let mut random = [[0u8; 16]; 2];
-        for (src, dest) in random_iter.zip(random.iter_mut().flat_map(|seed| seed.iter_mut())) {
-            *dest = src;
-        }
         let idpf = Idpf::new((), ());
         let (public_share, keys) = idpf
             .gen_with_random(
@@ -1909,7 +1903,7 @@ mod tests {
                 test_vector.beta_inner,
                 test_vector.beta_leaf,
                 b"some nonce",
-                &random,
+                &test_vector.keys,
             )
             .unwrap();
 

--- a/src/vdaf/prio3.rs
+++ b/src/vdaf/prio3.rs
@@ -400,7 +400,7 @@ where
     }
 
     #[allow(clippy::type_complexity)]
-    fn shard_with_random<const N: usize>(
+    pub(crate) fn shard_with_random<const N: usize>(
         &self,
         measurement: &T::Measurement,
         nonce: &[u8; N],
@@ -570,29 +570,6 @@ where
         }
 
         Ok((public_share, out))
-    }
-
-    /// Shard measurement with constant randomness of repeated bytes.
-    /// This method is not secure. It is used for running test vectors for Prio3.
-    #[allow(clippy::type_complexity)]
-    #[cfg(test)]
-    pub(crate) fn test_vec_shard<const N: usize>(
-        &self,
-        measurement: &T::Measurement,
-        nonce: &[u8; N],
-    ) -> Result<
-        (
-            Prio3PublicShare<SEED_SIZE>,
-            Vec<Prio3InputShare<T::Field, SEED_SIZE>>,
-        ),
-        VdafError,
-    > {
-        let size = self.random_size();
-        let random = iter::repeat(0..=255)
-            .flatten()
-            .take(size)
-            .collect::<Vec<u8>>();
-        self.shard_with_random(measurement, nonce, &random)
     }
 
     fn role_try_from(&self, agg_id: usize) -> Result<u8, VdafError> {

--- a/src/vdaf/prio3_test.rs
+++ b/src/vdaf/prio3_test.rs
@@ -10,7 +10,7 @@ use crate::{
     },
 };
 use serde::{Deserialize, Serialize};
-use std::{convert::TryInto, fmt::Debug};
+use std::{collections::HashMap, convert::TryInto, fmt::Debug};
 
 #[derive(Debug, Deserialize, Serialize)]
 struct TEncoded(#[serde(with = "hex")] Vec<u8>);
@@ -40,6 +40,8 @@ struct TPrio3<M> {
     verify_key: TEncoded,
     shares: u8,
     prep: Vec<TPrio3Prep<M>>,
+    #[serde(flatten)]
+    other_params: HashMap<String, serde_json::Value>,
 }
 
 macro_rules! err {
@@ -158,7 +160,8 @@ fn test_vec_prio3_count() {
 fn test_vec_prio3_sum() {
     let t: TPrio3<u128> =
         serde_json::from_str(include_str!("test_vec/07/Prio3Sum_0.json")).unwrap();
-    let prio3 = Prio3::new_sum(t.shares, 8).unwrap();
+    let bits = t.other_params["bits"].as_u64().unwrap() as usize;
+    let prio3 = Prio3::new_sum(t.shares, bits).unwrap();
     let verify_key = t.verify_key.as_ref().try_into().unwrap();
 
     for (test_num, p) in t.prep.iter().enumerate() {
@@ -167,7 +170,8 @@ fn test_vec_prio3_sum() {
 
     let t: TPrio3<u128> =
         serde_json::from_str(include_str!("test_vec/07/Prio3Sum_1.json")).unwrap();
-    let prio3 = Prio3::new_sum(t.shares, 8).unwrap();
+    let bits = t.other_params["bits"].as_u64().unwrap() as usize;
+    let prio3 = Prio3::new_sum(t.shares, bits).unwrap();
     let verify_key = t.verify_key.as_ref().try_into().unwrap();
 
     for (test_num, p) in t.prep.iter().enumerate() {
@@ -179,7 +183,10 @@ fn test_vec_prio3_sum() {
 fn test_vec_prio3_sum_vec() {
     let t: TPrio3<Vec<u128>> =
         serde_json::from_str(include_str!("test_vec/07/Prio3SumVec_0.json")).unwrap();
-    let prio3 = Prio3::new_sum_vec(t.shares, 8, 10, 9).unwrap();
+    let bits = t.other_params["bits"].as_u64().unwrap() as usize;
+    let length = t.other_params["length"].as_u64().unwrap() as usize;
+    let chunk_length = t.other_params["chunk_length"].as_u64().unwrap() as usize;
+    let prio3 = Prio3::new_sum_vec(t.shares, bits, length, chunk_length).unwrap();
     let verify_key = t.verify_key.as_ref().try_into().unwrap();
 
     for (test_num, p) in t.prep.iter().enumerate() {
@@ -188,7 +195,10 @@ fn test_vec_prio3_sum_vec() {
 
     let t: TPrio3<Vec<u128>> =
         serde_json::from_str(include_str!("test_vec/07/Prio3SumVec_1.json")).unwrap();
-    let prio3 = Prio3::new_sum_vec(t.shares, 16, 3, 7).unwrap();
+    let bits = t.other_params["bits"].as_u64().unwrap() as usize;
+    let length = t.other_params["length"].as_u64().unwrap() as usize;
+    let chunk_length = t.other_params["chunk_length"].as_u64().unwrap() as usize;
+    let prio3 = Prio3::new_sum_vec(t.shares, bits, length, chunk_length).unwrap();
     let verify_key = t.verify_key.as_ref().try_into().unwrap();
 
     for (test_num, p) in t.prep.iter().enumerate() {
@@ -200,7 +210,9 @@ fn test_vec_prio3_sum_vec() {
 fn test_vec_prio3_histogram() {
     let t: TPrio3<usize> =
         serde_json::from_str(include_str!("test_vec/07/Prio3Histogram_0.json")).unwrap();
-    let prio3 = Prio3::new_histogram(t.shares, 4, 2).unwrap();
+    let length = t.other_params["length"].as_u64().unwrap() as usize;
+    let chunk_length = t.other_params["chunk_length"].as_u64().unwrap() as usize;
+    let prio3 = Prio3::new_histogram(t.shares, length, chunk_length).unwrap();
     let verify_key = t.verify_key.as_ref().try_into().unwrap();
 
     for (test_num, p) in t.prep.iter().enumerate() {
@@ -209,7 +221,9 @@ fn test_vec_prio3_histogram() {
 
     let t: TPrio3<usize> =
         serde_json::from_str(include_str!("test_vec/07/Prio3Histogram_1.json")).unwrap();
-    let prio3 = Prio3::new_histogram(t.shares, 11, 3).unwrap();
+    let length = t.other_params["length"].as_u64().unwrap() as usize;
+    let chunk_length = t.other_params["chunk_length"].as_u64().unwrap() as usize;
+    let prio3 = Prio3::new_histogram(t.shares, length, chunk_length).unwrap();
     let verify_key = t.verify_key.as_ref().try_into().unwrap();
 
     for (test_num, p) in t.prep.iter().enumerate() {

--- a/src/vdaf/prio3_test.rs
+++ b/src/vdaf/prio3_test.rs
@@ -38,6 +38,7 @@ struct TPrio3Prep<M> {
 #[derive(Deserialize, Serialize)]
 struct TPrio3<M> {
     verify_key: TEncoded,
+    shares: u8,
     prep: Vec<TPrio3Prep<M>>,
 }
 
@@ -136,7 +137,7 @@ fn check_prep_test_vec<M, T, P, const SEED_SIZE: usize>(
 fn test_vec_prio3_count() {
     let t: TPrio3<u64> =
         serde_json::from_str(include_str!("test_vec/07/Prio3Count_0.json")).unwrap();
-    let prio3 = Prio3::new_count(2).unwrap();
+    let prio3 = Prio3::new_count(t.shares).unwrap();
     let verify_key = t.verify_key.as_ref().try_into().unwrap();
 
     for (test_num, p) in t.prep.iter().enumerate() {
@@ -145,7 +146,7 @@ fn test_vec_prio3_count() {
 
     let t: TPrio3<u64> =
         serde_json::from_str(include_str!("test_vec/07/Prio3Count_1.json")).unwrap();
-    let prio3 = Prio3::new_count(3).unwrap();
+    let prio3 = Prio3::new_count(t.shares).unwrap();
     let verify_key = t.verify_key.as_ref().try_into().unwrap();
 
     for (test_num, p) in t.prep.iter().enumerate() {
@@ -157,7 +158,7 @@ fn test_vec_prio3_count() {
 fn test_vec_prio3_sum() {
     let t: TPrio3<u128> =
         serde_json::from_str(include_str!("test_vec/07/Prio3Sum_0.json")).unwrap();
-    let prio3 = Prio3::new_sum(2, 8).unwrap();
+    let prio3 = Prio3::new_sum(t.shares, 8).unwrap();
     let verify_key = t.verify_key.as_ref().try_into().unwrap();
 
     for (test_num, p) in t.prep.iter().enumerate() {
@@ -166,7 +167,7 @@ fn test_vec_prio3_sum() {
 
     let t: TPrio3<u128> =
         serde_json::from_str(include_str!("test_vec/07/Prio3Sum_1.json")).unwrap();
-    let prio3 = Prio3::new_sum(3, 8).unwrap();
+    let prio3 = Prio3::new_sum(t.shares, 8).unwrap();
     let verify_key = t.verify_key.as_ref().try_into().unwrap();
 
     for (test_num, p) in t.prep.iter().enumerate() {
@@ -178,7 +179,7 @@ fn test_vec_prio3_sum() {
 fn test_vec_prio3_sum_vec() {
     let t: TPrio3<Vec<u128>> =
         serde_json::from_str(include_str!("test_vec/07/Prio3SumVec_0.json")).unwrap();
-    let prio3 = Prio3::new_sum_vec(2, 8, 10, 9).unwrap();
+    let prio3 = Prio3::new_sum_vec(t.shares, 8, 10, 9).unwrap();
     let verify_key = t.verify_key.as_ref().try_into().unwrap();
 
     for (test_num, p) in t.prep.iter().enumerate() {
@@ -187,7 +188,7 @@ fn test_vec_prio3_sum_vec() {
 
     let t: TPrio3<Vec<u128>> =
         serde_json::from_str(include_str!("test_vec/07/Prio3SumVec_1.json")).unwrap();
-    let prio3 = Prio3::new_sum_vec(3, 16, 3, 7).unwrap();
+    let prio3 = Prio3::new_sum_vec(t.shares, 16, 3, 7).unwrap();
     let verify_key = t.verify_key.as_ref().try_into().unwrap();
 
     for (test_num, p) in t.prep.iter().enumerate() {
@@ -199,7 +200,7 @@ fn test_vec_prio3_sum_vec() {
 fn test_vec_prio3_histogram() {
     let t: TPrio3<usize> =
         serde_json::from_str(include_str!("test_vec/07/Prio3Histogram_0.json")).unwrap();
-    let prio3 = Prio3::new_histogram(2, 4, 2).unwrap();
+    let prio3 = Prio3::new_histogram(t.shares, 4, 2).unwrap();
     let verify_key = t.verify_key.as_ref().try_into().unwrap();
 
     for (test_num, p) in t.prep.iter().enumerate() {
@@ -208,7 +209,7 @@ fn test_vec_prio3_histogram() {
 
     let t: TPrio3<usize> =
         serde_json::from_str(include_str!("test_vec/07/Prio3Histogram_1.json")).unwrap();
-    let prio3 = Prio3::new_histogram(3, 11, 3).unwrap();
+    let prio3 = Prio3::new_histogram(t.shares, 11, 3).unwrap();
     let verify_key = t.verify_key.as_ref().try_into().unwrap();
 
     for (test_num, p) in t.prep.iter().enumerate() {

--- a/src/vdaf/prio3_test.rs
+++ b/src/vdaf/prio3_test.rs
@@ -143,13 +143,14 @@ where
 #[must_use]
 fn check_aggregate_test_vec<M, T, P, const SEED_SIZE: usize>(
     prio3: &Prio3<T, P, SEED_SIZE>,
-    verify_key: &[u8; SEED_SIZE],
     t: &TPrio3<M>,
 ) -> T::AggregateResult
 where
     T: Type<Measurement = M>,
     P: Xof<SEED_SIZE>,
 {
+    let verify_key = t.verify_key.as_ref().try_into().unwrap();
+
     let mut all_output_shares = vec![Vec::new(); prio3.num_aggregators()];
     for (test_num, p) in t.prep.iter().enumerate() {
         let output_shares = check_prep_test_vec(prio3, verify_key, test_num, p);
@@ -181,9 +182,8 @@ fn test_vec_prio3_count() {
     ] {
         let t: TPrio3<u64> = serde_json::from_str(test_vector_str).unwrap();
         let prio3 = Prio3::new_count(t.shares).unwrap();
-        let verify_key = t.verify_key.as_ref().try_into().unwrap();
 
-        let aggregate_result = check_aggregate_test_vec(&prio3, &verify_key, &t);
+        let aggregate_result = check_aggregate_test_vec(&prio3, &t);
         assert_eq!(aggregate_result, t.agg_result.as_u64().unwrap());
     }
 }
@@ -197,9 +197,8 @@ fn test_vec_prio3_sum() {
         let t: TPrio3<u128> = serde_json::from_str(test_vector_str).unwrap();
         let bits = t.other_params["bits"].as_u64().unwrap() as usize;
         let prio3 = Prio3::new_sum(t.shares, bits).unwrap();
-        let verify_key = t.verify_key.as_ref().try_into().unwrap();
 
-        let aggregate_result = check_aggregate_test_vec(&prio3, &verify_key, &t);
+        let aggregate_result = check_aggregate_test_vec(&prio3, &t);
         assert_eq!(aggregate_result, t.agg_result.as_u64().unwrap() as u128);
     }
 }
@@ -215,9 +214,8 @@ fn test_vec_prio3_sum_vec() {
         let length = t.other_params["length"].as_u64().unwrap() as usize;
         let chunk_length = t.other_params["chunk_length"].as_u64().unwrap() as usize;
         let prio3 = Prio3::new_sum_vec(t.shares, bits, length, chunk_length).unwrap();
-        let verify_key = t.verify_key.as_ref().try_into().unwrap();
 
-        let aggregate_result = check_aggregate_test_vec(&prio3, &verify_key, &t);
+        let aggregate_result = check_aggregate_test_vec(&prio3, &t);
         let expected_aggregate_result = t
             .agg_result
             .as_array()
@@ -239,9 +237,8 @@ fn test_vec_prio3_histogram() {
         let length = t.other_params["length"].as_u64().unwrap() as usize;
         let chunk_length = t.other_params["chunk_length"].as_u64().unwrap() as usize;
         let prio3 = Prio3::new_histogram(t.shares, length, chunk_length).unwrap();
-        let verify_key = t.verify_key.as_ref().try_into().unwrap();
 
-        let aggregate_result = check_aggregate_test_vec(&prio3, &verify_key, &t);
+        let aggregate_result = check_aggregate_test_vec(&prio3, &t);
         let expected_aggregate_result = t
             .agg_result
             .as_array()

--- a/src/vdaf/prio3_test.rs
+++ b/src/vdaf/prio3_test.rs
@@ -137,96 +137,70 @@ fn check_prep_test_vec<M, T, P, const SEED_SIZE: usize>(
 
 #[test]
 fn test_vec_prio3_count() {
-    let t: TPrio3<u64> =
-        serde_json::from_str(include_str!("test_vec/07/Prio3Count_0.json")).unwrap();
-    let prio3 = Prio3::new_count(t.shares).unwrap();
-    let verify_key = t.verify_key.as_ref().try_into().unwrap();
+    for test_vector_str in [
+        include_str!("test_vec/07/Prio3Count_0.json"),
+        include_str!("test_vec/07/Prio3Count_1.json"),
+    ] {
+        let t: TPrio3<u64> = serde_json::from_str(test_vector_str).unwrap();
+        let prio3 = Prio3::new_count(t.shares).unwrap();
+        let verify_key = t.verify_key.as_ref().try_into().unwrap();
 
-    for (test_num, p) in t.prep.iter().enumerate() {
-        check_prep_test_vec(&prio3, &verify_key, test_num, p);
-    }
-
-    let t: TPrio3<u64> =
-        serde_json::from_str(include_str!("test_vec/07/Prio3Count_1.json")).unwrap();
-    let prio3 = Prio3::new_count(t.shares).unwrap();
-    let verify_key = t.verify_key.as_ref().try_into().unwrap();
-
-    for (test_num, p) in t.prep.iter().enumerate() {
-        check_prep_test_vec(&prio3, &verify_key, test_num, p);
+        for (test_num, p) in t.prep.iter().enumerate() {
+            check_prep_test_vec(&prio3, &verify_key, test_num, p);
+        }
     }
 }
 
 #[test]
 fn test_vec_prio3_sum() {
-    let t: TPrio3<u128> =
-        serde_json::from_str(include_str!("test_vec/07/Prio3Sum_0.json")).unwrap();
-    let bits = t.other_params["bits"].as_u64().unwrap() as usize;
-    let prio3 = Prio3::new_sum(t.shares, bits).unwrap();
-    let verify_key = t.verify_key.as_ref().try_into().unwrap();
+    for test_vector_str in [
+        include_str!("test_vec/07/Prio3Sum_0.json"),
+        include_str!("test_vec/07/Prio3Sum_1.json"),
+    ] {
+        let t: TPrio3<u128> = serde_json::from_str(test_vector_str).unwrap();
+        let bits = t.other_params["bits"].as_u64().unwrap() as usize;
+        let prio3 = Prio3::new_sum(t.shares, bits).unwrap();
+        let verify_key = t.verify_key.as_ref().try_into().unwrap();
 
-    for (test_num, p) in t.prep.iter().enumerate() {
-        check_prep_test_vec(&prio3, &verify_key, test_num, p);
-    }
-
-    let t: TPrio3<u128> =
-        serde_json::from_str(include_str!("test_vec/07/Prio3Sum_1.json")).unwrap();
-    let bits = t.other_params["bits"].as_u64().unwrap() as usize;
-    let prio3 = Prio3::new_sum(t.shares, bits).unwrap();
-    let verify_key = t.verify_key.as_ref().try_into().unwrap();
-
-    for (test_num, p) in t.prep.iter().enumerate() {
-        check_prep_test_vec(&prio3, &verify_key, test_num, p);
+        for (test_num, p) in t.prep.iter().enumerate() {
+            check_prep_test_vec(&prio3, &verify_key, test_num, p);
+        }
     }
 }
 
 #[test]
 fn test_vec_prio3_sum_vec() {
-    let t: TPrio3<Vec<u128>> =
-        serde_json::from_str(include_str!("test_vec/07/Prio3SumVec_0.json")).unwrap();
-    let bits = t.other_params["bits"].as_u64().unwrap() as usize;
-    let length = t.other_params["length"].as_u64().unwrap() as usize;
-    let chunk_length = t.other_params["chunk_length"].as_u64().unwrap() as usize;
-    let prio3 = Prio3::new_sum_vec(t.shares, bits, length, chunk_length).unwrap();
-    let verify_key = t.verify_key.as_ref().try_into().unwrap();
+    for test_vector_str in [
+        include_str!("test_vec/07/Prio3SumVec_0.json"),
+        include_str!("test_vec/07/Prio3SumVec_1.json"),
+    ] {
+        let t: TPrio3<Vec<u128>> = serde_json::from_str(test_vector_str).unwrap();
+        let bits = t.other_params["bits"].as_u64().unwrap() as usize;
+        let length = t.other_params["length"].as_u64().unwrap() as usize;
+        let chunk_length = t.other_params["chunk_length"].as_u64().unwrap() as usize;
+        let prio3 = Prio3::new_sum_vec(t.shares, bits, length, chunk_length).unwrap();
+        let verify_key = t.verify_key.as_ref().try_into().unwrap();
 
-    for (test_num, p) in t.prep.iter().enumerate() {
-        check_prep_test_vec(&prio3, &verify_key, test_num, p);
-    }
-
-    let t: TPrio3<Vec<u128>> =
-        serde_json::from_str(include_str!("test_vec/07/Prio3SumVec_1.json")).unwrap();
-    let bits = t.other_params["bits"].as_u64().unwrap() as usize;
-    let length = t.other_params["length"].as_u64().unwrap() as usize;
-    let chunk_length = t.other_params["chunk_length"].as_u64().unwrap() as usize;
-    let prio3 = Prio3::new_sum_vec(t.shares, bits, length, chunk_length).unwrap();
-    let verify_key = t.verify_key.as_ref().try_into().unwrap();
-
-    for (test_num, p) in t.prep.iter().enumerate() {
-        check_prep_test_vec(&prio3, &verify_key, test_num, p);
+        for (test_num, p) in t.prep.iter().enumerate() {
+            check_prep_test_vec(&prio3, &verify_key, test_num, p);
+        }
     }
 }
 
 #[test]
 fn test_vec_prio3_histogram() {
-    let t: TPrio3<usize> =
-        serde_json::from_str(include_str!("test_vec/07/Prio3Histogram_0.json")).unwrap();
-    let length = t.other_params["length"].as_u64().unwrap() as usize;
-    let chunk_length = t.other_params["chunk_length"].as_u64().unwrap() as usize;
-    let prio3 = Prio3::new_histogram(t.shares, length, chunk_length).unwrap();
-    let verify_key = t.verify_key.as_ref().try_into().unwrap();
+    for test_vector_str in [
+        include_str!("test_vec/07/Prio3Histogram_0.json"),
+        include_str!("test_vec/07/Prio3Histogram_1.json"),
+    ] {
+        let t: TPrio3<usize> = serde_json::from_str(test_vector_str).unwrap();
+        let length = t.other_params["length"].as_u64().unwrap() as usize;
+        let chunk_length = t.other_params["chunk_length"].as_u64().unwrap() as usize;
+        let prio3 = Prio3::new_histogram(t.shares, length, chunk_length).unwrap();
+        let verify_key = t.verify_key.as_ref().try_into().unwrap();
 
-    for (test_num, p) in t.prep.iter().enumerate() {
-        check_prep_test_vec(&prio3, &verify_key, test_num, p);
-    }
-
-    let t: TPrio3<usize> =
-        serde_json::from_str(include_str!("test_vec/07/Prio3Histogram_1.json")).unwrap();
-    let length = t.other_params["length"].as_u64().unwrap() as usize;
-    let chunk_length = t.other_params["chunk_length"].as_u64().unwrap() as usize;
-    let prio3 = Prio3::new_histogram(t.shares, length, chunk_length).unwrap();
-    let verify_key = t.verify_key.as_ref().try_into().unwrap();
-
-    for (test_num, p) in t.prep.iter().enumerate() {
-        check_prep_test_vec(&prio3, &verify_key, test_num, p);
+        for (test_num, p) in t.prep.iter().enumerate() {
+            check_prep_test_vec(&prio3, &verify_key, test_num, p);
+        }
     }
 }

--- a/src/vdaf/prio3_test.rs
+++ b/src/vdaf/prio3_test.rs
@@ -26,6 +26,8 @@ struct TPrio3Prep<M> {
     measurement: M,
     #[serde(with = "hex")]
     nonce: Vec<u8>,
+    #[serde(with = "hex")]
+    rand: Vec<u8>,
     public_share: TEncoded,
     input_shares: Vec<TEncoded>,
     prep_shares: Vec<Vec<TEncoded>>,
@@ -62,7 +64,7 @@ fn check_prep_test_vec<M, T, P, const SEED_SIZE: usize>(
 {
     let nonce = <[u8; 16]>::try_from(t.nonce.clone()).unwrap();
     let (public_share, input_shares) = prio3
-        .test_vec_shard(&t.measurement, &nonce)
+        .shard_with_random(&t.measurement, &nonce, &t.rand)
         .expect("failed to generate input shares");
 
     assert_eq!(

--- a/src/vdaf/prio3_test.rs
+++ b/src/vdaf/prio3_test.rs
@@ -57,7 +57,7 @@ macro_rules! err {
 }
 
 // TODO Generalize this method to work with any VDAF. To do so we would need to add
-// `test_vec_setup()` and `test_vec_shard()` to traits. (There may be a less invasive alternative.)
+// `shard_with_random()` to traits. (There may be a less invasive alternative.)
 fn check_prep_test_vec<M, T, P, const SEED_SIZE: usize>(
     prio3: &Prio3<T, P, SEED_SIZE>,
     verify_key: &[u8; SEED_SIZE],


### PR DESCRIPTION
This changes our various test vector tests to replace various hardcoded inputs with fields from the test vector file. (these were gradually added over the past few VDAF drafts) The Prio3 tests are also expanded to check the results of aggregation and unsharding.