### PR TITLE
DO NOT MERGE Benchmark XOF alternatives for Prio3

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,7 +28,7 @@ rand = { version = "0.8", optional = true }
 rand_core = "0.6.4"
 rayon = { version = "1.8.0", optional = true }
 serde = { version = "1.0", features = ["derive"] }
-sha2 = { version = "0.10.7", optional = true }
+sha2 = "0.10.7"
 sha3 = "0.10.8"
 subtle = "2.5.0"
 thiserror = "1.0"
@@ -56,7 +56,7 @@ zipf = "7.0.1"
 default = ["crypto-dependencies"]
 experimental = ["bitvec", "fiat-crypto", "fixed", "num-bigint", "num-rational", "num-traits", "num-integer", "num-iter", "rand"]
 multithreaded = ["rayon"]
-prio2 = ["crypto-dependencies", "hmac", "sha2"]
+prio2 = ["crypto-dependencies", "hmac"]
 crypto-dependencies = ["aes", "ctr"]
 test-util = ["rand"]
 


### PR DESCRIPTION
* To run Prio3 benchmarks with SHAKE128, do `cargo bench`. 
* To run Prio3 benchmarks with TurboSHAKE128, do `s/XofShake128/XofTurboShake128/g` in `src/vdaf/prio3.rs`, then `cargo bench`.
* To run Prio3 benchmarks with SHA2, do `s/XofShake128/XofSha2/g` in `src/vdaf/prio3.rs`, then `cargo bench`.