### PR TITLE
Fix ignored clippy::needless_range_loop lints

### DIFF
--- a/src/fft.rs
+++ b/src/fft.rs
@@ -47,10 +47,9 @@ pub fn discrete_fourier_transform<F: FftFriendlyFieldElement>(
         return Err(FftError::SizeInvalid);
     }
 
-    #[allow(clippy::needless_range_loop)]
-    for i in 0..size {
+    for (i, outp_val) in outp[..size].iter_mut().enumerate() {
         let j = bitrev(d, i);
-        outp[i] = if j < inp.len() { inp[j] } else { F::zero() }
+        *outp_val = if j < inp.len() { inp[j] } else { F::zero() };
     }
 
     let mut w: F;
@@ -197,14 +196,11 @@ mod tests {
         // Just for fun, let's do something different with a subset of the inputs. For the first
         // share, every odd element is set to the plaintext value. For all shares but the first,
         // every odd element is set to 0.
-        #[allow(clippy::needless_range_loop)]
-        for i in 0..len {
+        for (i, x_val) in x.iter().enumerate() {
             if i % 2 != 0 {
-                x_shares[0][i] = x[i];
-            }
-            for j in 1..num_shares {
-                if i % 2 != 0 {
-                    x_shares[j][i] = Field64::zero();
+                x_shares[0][i] = *x_val;
+                for x_share in x_shares[1..num_shares].iter_mut() {
+                    x_share[i] = Field64::zero();
                 }
             }
         }

--- a/src/flp.rs
+++ b/src/flp.rs
@@ -227,7 +227,6 @@ pub trait Type: Sized + Eq + Clone + Debug {
     /// * `input` is the input.
     /// * `prove_rand` is the prover' randomness.
     /// * `joint_rand` is the randomness shared by the prover and verifier.
-    #[allow(clippy::needless_range_loop)]
     fn prove(
         &self,
         input: &[Self::Field],
@@ -259,7 +258,7 @@ pub trait Type: Sized + Eq + Clone + Debug {
         }
 
         let mut prove_rand_len = 0;
-        let mut shim = self
+        let mut shims = self
             .gadget()
             .into_iter()
             .map(|inner| {
@@ -285,10 +284,10 @@ pub trait Type: Sized + Eq + Clone + Debug {
 
         // Create a buffer for storing the proof. The buffer is longer than the proof itself; the extra
         // length is to accommodate the computation of each gadget polynomial.
-        let data_len = (0..shim.len())
-            .map(|idx| {
-                let gadget_poly_len =
-                    gadget_poly_len(shim[idx].degree(), wire_poly_len(shim[idx].calls()));
+        let data_len = shims
+            .iter()
+            .map(|shim| {
+                let gadget_poly_len = gadget_poly_len(shim.degree(), wire_poly_len(shim.calls()));
 
                 // Computing the gadget polynomial using FFT requires an amount of memory that is a
                 // power of 2. Thus we choose the smallest power of 2 that is at least as large as
@@ -296,7 +295,7 @@ pub trait Type: Sized + Eq + Clone + Debug {
                 // include the arity of the gadget to ensure there is always enough room at the end
                 // of the buffer to compute the next gadget polynomial. It's likely that the
                 // memory footprint here can be reduced, with a bit of care.
-                shim[idx].arity() + gadget_poly_len.next_power_of_two()
+                shim.arity() + gadget_poly_len.next_power_of_two()
             })
             .sum();
         let mut proof = vec![Self::Field::zero(); data_len];
@@ -304,12 +303,12 @@ pub trait Type: Sized + Eq + Clone + Debug {
         // Run the validity circuit with a sequence of "shim" gadgets that record the value of each
         // input wire of each gadget evaluation. These values are used to construct the wire
         // polynomials for each gadget in the next step.
-        let _ = self.valid(&mut shim, input, joint_rand, 1)?;
+        let _ = self.valid(&mut shims, input, joint_rand, 1)?;
 
         // Construct the proof.
         let mut proof_len = 0;
-        for idx in 0..shim.len() {
-            let gadget = shim[idx]
+        for shim in shims.iter_mut() {
+            let gadget = shim
                 .as_any()
                 .downcast_mut::<ProveShimGadget<Self::Field>>()
                 .unwrap();
@@ -322,14 +321,18 @@ pub trait Type: Sized + Eq + Clone + Debug {
             )
             .inv();
             let mut f = vec![vec![Self::Field::zero(); m]; gadget.arity()];
-            for wire in 0..gadget.arity() {
-                discrete_fourier_transform(&mut f[wire], &gadget.f_vals[wire], m)?;
-                discrete_fourier_transform_inv_finish(&mut f[wire], m, m_inv);
+            for ((coefficients, values), proof_val) in f[..gadget.arity()]
+                .iter_mut()
+                .zip(gadget.f_vals[..gadget.arity()].iter())
+                .zip(proof[proof_len..proof_len + gadget.arity()].iter_mut())
+            {
+                discrete_fourier_transform(coefficients, values, m)?;
+                discrete_fourier_transform_inv_finish(coefficients, m, m_inv);
 
                 // The first point on each wire polynomial is a random value chosen by the prover. This
                 // point is stored in the proof so that the verifier can reconstruct the wire
                 // polynomials.
-                proof[proof_len + wire] = gadget.f_vals[wire][0];
+                *proof_val = values[0];
             }
 
             // Construct the gadget polynomial `G(f[0], ..., f[g_arity-1])` and append it to `proof`.
@@ -397,7 +400,7 @@ pub trait Type: Sized + Eq + Clone + Debug {
         }
 
         let mut proof_len = 0;
-        let mut shim = self
+        let mut shims = self
             .gadget()
             .into_iter()
             .enumerate()
@@ -431,10 +434,7 @@ pub trait Type: Sized + Eq + Clone + Debug {
         // Create a buffer for the verifier data. This includes the output of the validity circuit and,
         // for each gadget `shim[idx].inner`, the wire polynomials evaluated at the query randomness
         // `query_rand[idx]` and the gadget polynomial evaluated at `query_rand[idx]`.
-        let data_len = 1
-            + (0..shim.len())
-                .map(|idx| shim[idx].arity() + 1)
-                .sum::<usize>();
+        let data_len = 1 + shims.iter().map(|shim| shim.arity() + 1).sum::<usize>();
         let mut verifier = Vec::with_capacity(data_len);
 
         // Run the validity circuit with a sequence of "shim" gadgets that record the inputs to each
@@ -445,19 +445,18 @@ pub trait Type: Sized + Eq + Clone + Debug {
         // equal to the output of the last gadget evaluation. Here we relax this assumption. This
         // should be OK, since it's possible to transform any circuit into one for which this is true.
         // (Needs security analysis.)
-        let validity = self.valid(&mut shim, input, joint_rand, num_shares)?;
+        let validity = self.valid(&mut shims, input, joint_rand, num_shares)?;
         verifier.push(validity);
 
         // Fill the buffer with the verifier message.
-        for idx in 0..shim.len() {
-            let r = query_rand[idx];
-            let gadget = shim[idx]
+        for (query_rand_val, shim) in query_rand[..shims.len()].iter().zip(shims.iter_mut()) {
+            let gadget = shim
                 .as_any()
                 .downcast_ref::<QueryShimGadget<Self::Field>>()
                 .unwrap();
 
             // Reconstruct the wire polynomials `f[0], ..., f[g_arity-1]` and evaluate each wire
-            // polynomial at query randomness `r`.
+            // polynomial at query randomness value.
             let m = (1 + gadget.calls()).next_power_of_two();
             let m_inv = Self::Field::from(
                 <Self::Field as FieldElementWithInteger>::Integer::try_from(m).unwrap(),
@@ -467,10 +466,10 @@ pub trait Type: Sized + Eq + Clone + Debug {
             for wire in 0..gadget.arity() {
                 discrete_fourier_transform(&mut f, &gadget.f_vals[wire], m)?;
                 discrete_fourier_transform_inv_finish(&mut f, m, m_inv);
-                verifier.push(poly_eval(&f, r));
+                verifier.push(poly_eval(&f, *query_rand_val));
             }
 
-            // Add the value of the gadget polynomial evaluated at `r`.
+            // Add the value of the gadget polynomial evaluated at the query randomness value.
             verifier.push(gadget.p_at_r);
         }
 
@@ -479,7 +478,6 @@ pub trait Type: Sized + Eq + Clone + Debug {
     }
 
     /// Returns true if the verifier message indicates that the input from which it was generated is valid.
-    #[allow(clippy::needless_range_loop)]
     fn decide(&self, verifier: &[Self::Field]) -> Result<bool, FlpError> {
         if verifier.len() != self.verifier_len() {
             return Err(FlpError::Decide(format!(
@@ -497,10 +495,10 @@ pub trait Type: Sized + Eq + Clone + Debug {
         // Check that each of the proof polynomials are well-formed.
         let mut gadgets = self.gadget();
         let mut verifier_len = 1;
-        for idx in 0..gadgets.len() {
-            let next_len = 1 + gadgets[idx].arity();
+        for gadget in gadgets.iter_mut() {
+            let next_len = 1 + gadget.arity();
 
-            let e = gadgets[idx].call(&verifier[verifier_len..verifier_len + next_len - 1])?;
+            let e = gadget.call(&verifier[verifier_len..verifier_len + next_len - 1])?;
             if e != verifier[verifier_len + next_len - 1] {
                 return Ok(false);
             }
@@ -607,10 +605,11 @@ impl<F: FftFriendlyFieldElement> ProveShimGadget<F> {
     fn new(inner: Box<dyn Gadget<F>>, prove_rand: &[F]) -> Result<Self, FlpError> {
         let mut f_vals = vec![vec![F::zero(); 1 + inner.calls()]; inner.arity()];
 
-        #[allow(clippy::needless_range_loop)]
-        for wire in 0..f_vals.len() {
+        for (prove_rand_val, wire_poly_vals) in
+            prove_rand[..f_vals.len()].iter().zip(f_vals.iter_mut())
+        {
             // Choose a random field element as the first point on the wire polynomial.
-            f_vals[wire][0] = prove_rand[wire];
+            wire_poly_vals[0] = *prove_rand_val;
         }
 
         Ok(Self {
@@ -623,9 +622,8 @@ impl<F: FftFriendlyFieldElement> ProveShimGadget<F> {
 
 impl<F: FftFriendlyFieldElement> Gadget<F> for ProveShimGadget<F> {
     fn call(&mut self, inp: &[F]) -> Result<F, FlpError> {
-        #[allow(clippy::needless_range_loop)]
-        for wire in 0..inp.len() {
-            self.f_vals[wire][self.ct] = inp[wire];
+        for (wire_poly_vals, inp_val) in self.f_vals[..inp.len()].iter_mut().zip(inp.iter()) {
+            wire_poly_vals[self.ct] = *inp_val;
         }
         self.ct += 1;
         self.inner.call(inp)
@@ -714,9 +712,8 @@ impl<F: FftFriendlyFieldElement> QueryShimGadget<F> {
 
 impl<F: FftFriendlyFieldElement> Gadget<F> for QueryShimGadget<F> {
     fn call(&mut self, inp: &[F]) -> Result<F, FlpError> {
-        #[allow(clippy::needless_range_loop)]
-        for wire in 0..inp.len() {
-            self.f_vals[wire][self.ct] = inp[wire];
+        for (wire_poly_vals, inp_val) in self.f_vals[..inp.len()].iter_mut().zip(inp.iter()) {
+            wire_poly_vals[self.ct] = *inp_val;
         }
         let outp = self.p_vals[self.ct * self.step];
         self.ct += 1;

--- a/src/polynomial.rs
+++ b/src/polynomial.rs
@@ -149,9 +149,8 @@ fn fft_interpolate_raw<F: FftFriendlyFieldElement>(
     );
     if invert {
         let n_inverse = F::from(F::Integer::try_from(n_points).unwrap()).inv();
-        #[allow(clippy::needless_range_loop)]
-        for i in 0..n_points {
-            out[i] *= n_inverse;
+        for out_val in out[0..n_points].iter_mut() {
+            *out_val *= n_inverse;
         }
     }
 }
@@ -373,13 +372,12 @@ mod tests {
             &mut mem.fft_memory,
         );
 
-        #[allow(clippy::needless_range_loop)]
-        for i in 0..count {
+        for (poly_coeff, root) in poly[..count].iter().zip(mem.roots_2n[..count].iter()) {
             let mut should_be = FieldPrio2::from(0);
-            for j in 0..count {
-                should_be = mem.roots_2n[i].pow(u32::try_from(j).unwrap()) * points[j] + should_be;
+            for (j, point_j) in points[..count].iter().enumerate() {
+                should_be = root.pow(u32::try_from(j).unwrap()) * *point_j + should_be;
             }
-            assert_eq!(should_be, poly[i]);
+            assert_eq!(should_be, *poly_coeff);
         }
     }
 }

--- a/src/vdaf/prio2/client.rs
+++ b/src/vdaf/prio2/client.rs
@@ -239,10 +239,13 @@ fn construct_proof<F: FftFriendlyFieldElement>(
 
     // set f_i = data_(i - 1)
     // set g_i = f_i - 1
-    #[allow(clippy::needless_range_loop)]
-    for i in 0..dimension {
-        mem.points_f[i + 1] = data[i];
-        mem.points_g[i + 1] = data[i] - F::one();
+    for ((f_coeff, g_coeff), data_val) in mem.points_f[1..1 + dimension]
+        .iter_mut()
+        .zip(mem.points_g[1..1 + dimension].iter_mut())
+        .zip(data[..dimension].iter())
+    {
+        *f_coeff = *data_val;
+        *g_coeff = *data_val - F::one();
     }
 
     // interpolate and evaluate at roots of unity


### PR DESCRIPTION
This rewrites various loops in Prio2 and Prio3 code to address ignored `clippy::needless_range_loop` lints. This improves some benchmarks by 2%-3%. None of the benchmarks regressed.