### PR TITLE
Add helpers to get 0/1 as integer associated types

### DIFF
--- a/src/field.rs
+++ b/src/field.rs
@@ -194,6 +194,12 @@ pub trait FieldElementWithInteger: FieldElement + From<Self::Integer> {
 
     /// Returns the prime modulus `p`.
     fn modulus() -> Self::Integer;
+
+    /// Returns the integer representation of the additive identity.
+    fn zero_integer() -> Self::Integer;
+
+    /// Returns the integer representation of the multiplicative identity.
+    fn one_integer() -> Self::Integer;
 }
 
 /// Methods common to all `FieldElementWithInteger` implementations that are private to the crate.
@@ -214,7 +220,7 @@ pub(crate) trait FieldElementWithIntegerExt: FieldElementWithInteger {
         // least significant bit, and shift input to the right by one bit.
         let mut i = *input;
 
-        let one = Self::Integer::from(Self::one());
+        let one = Self::one_integer();
         for bit in output.iter_mut() {
             let w = Self::from(i & one);
             *bit = w;
@@ -222,7 +228,7 @@ pub(crate) trait FieldElementWithIntegerExt: FieldElementWithInteger {
         }
 
         // If `i` is still not zero, this means that it cannot be encoded by `bits` bits.
-        if i != Self::Integer::from(Self::zero()) {
+        if i != Self::zero_integer() {
             return Err(FieldError::InputSizeMismatch);
         }
 
@@ -252,7 +258,7 @@ pub(crate) trait FieldElementWithIntegerExt: FieldElementWithInteger {
     ///
     /// This function errors if `2^input.len() - 1` does not fit into the field `Self`.
     fn decode_from_bitvector_representation(input: &[Self]) -> Result<Self, FieldError> {
-        let fi_one = Self::Integer::from(Self::one());
+        let fi_one = Self::one_integer();
 
         if !Self::valid_integer_bitlength(input.len()) {
             return Err(FieldError::ModulusOverflow);
@@ -285,7 +291,7 @@ pub(crate) trait FieldElementWithIntegerExt: FieldElementWithInteger {
         if bits >= 8 * Self::ENCODED_SIZE {
             return false;
         }
-        if Self::modulus() >> bits != Self::Integer::from(Self::zero()) {
+        if Self::modulus() >> bits != Self::zero_integer() {
             return true;
         }
         false
@@ -694,6 +700,14 @@ macro_rules! make_field {
 
             fn modulus() -> Self::Integer {
                 $fp.p as $int
+            }
+
+            fn zero_integer() -> Self::Integer {
+                0
+            }
+
+            fn one_integer() -> Self::Integer {
+                1
             }
         }
 

--- a/src/field.rs
+++ b/src/field.rs
@@ -194,12 +194,6 @@ pub trait FieldElementWithInteger: FieldElement + From<Self::Integer> {
 
     /// Returns the prime modulus `p`.
     fn modulus() -> Self::Integer;
-
-    /// Returns the integer representation of the additive identity.
-    fn zero_integer() -> Self::Integer;
-
-    /// Returns the integer representation of the multiplicative identity.
-    fn one_integer() -> Self::Integer;
 }
 
 /// Methods common to all `FieldElementWithInteger` implementations that are private to the crate.
@@ -296,9 +290,23 @@ pub(crate) trait FieldElementWithIntegerExt: FieldElementWithInteger {
         }
         false
     }
+
+    /// Returns the integer representation of the additive identity.
+    fn zero_integer() -> Self::Integer;
+
+    /// Returns the integer representation of the multiplicative identity.
+    fn one_integer() -> Self::Integer;
 }
 
-impl<F: FieldElementWithInteger> FieldElementWithIntegerExt for F {}
+impl<F: FieldElementWithInteger> FieldElementWithIntegerExt for F {
+    fn zero_integer() -> Self::Integer {
+        0usize.try_into().unwrap()
+    }
+
+    fn one_integer() -> Self::Integer {
+        1usize.try_into().unwrap()
+    }
+}
 
 /// Methods common to all `FieldElement` implementations that are private to the crate.
 pub(crate) trait FieldElementExt: FieldElement {
@@ -700,14 +708,6 @@ macro_rules! make_field {
 
             fn modulus() -> Self::Integer {
                 $fp.p as $int
-            }
-
-            fn zero_integer() -> Self::Integer {
-                0
-            }
-
-            fn one_integer() -> Self::Integer {
-                1
             }
         }
 

--- a/src/flp/types/fixedpoint_l2.rs
+++ b/src/flp/types/fixedpoint_l2.rs
@@ -250,7 +250,7 @@ where
     /// fixed point vector with `entries` entries.
     pub fn new(entries: usize) -> Result<Self, FlpError> {
         // (0) initialize constants
-        let fi_one = u128::from(Field128::one());
+        let fi_one = Field128::one_integer();
 
         // (I) Check that the fixed type is compatible.
         //
@@ -544,7 +544,7 @@ where
 
             // Chunks which are too short need to be extended with a share of the
             // encoded zero value, that is: 1/num_shares * (2^(n-1))
-            let fi_one = u128::from(Field128::one());
+            let fi_one = Field128::one_integer();
             let zero_enc = Field128::from(fi_one << (self.bits_per_entry - 1));
             let zero_enc_share = zero_enc * num_shares_inverse;
 


### PR DESCRIPTION
This adds new methods `zero_integer()` and `one_integer()` to `FieldElementWithInteger`. These replace an existing pattern of constructing zero or one with a round trip through the Montgomery representation, by constructing it as a field element first, and then converting it back. This preparatory work for addressing #643.

I considered and rejected creating a new trait for integers, and putting these methods there, because adding a new trait bound to the `Integer` associated type would be a breaking change. We could reconsider this API design the next time we make significant breaking changes.