### PR TITLE
Add public bitvector helpers

### DIFF
--- a/src/flp/types.rs
+++ b/src/flp/types.rs
@@ -146,7 +146,7 @@ impl<F: FftFriendlyFieldElement> Type for Sum<F> {
     type Field = F;
 
     fn encode_measurement(&self, summand: &F::Integer) -> Result<Vec<F>, FlpError> {
-        let v = F::encode_into_bitvector_representation(*summand, self.bits)?.collect();
+        let v = F::encode_as_bitvector(*summand, self.bits)?.collect();
         Ok(v)
     }
 
@@ -174,7 +174,7 @@ impl<F: FftFriendlyFieldElement> Type for Sum<F> {
 
     fn truncate(&self, input: Vec<F>) -> Result<Vec<F>, FlpError> {
         self.truncate_call_check(&input)?;
-        let res = F::decode_from_bitvector_representation(&input)?;
+        let res = F::decode_bitvector(&input)?;
         Ok(vec![res])
     }
 
@@ -245,7 +245,7 @@ impl<F: FftFriendlyFieldElement> Type for Average<F> {
     type Field = F;
 
     fn encode_measurement(&self, summand: &F::Integer) -> Result<Vec<F>, FlpError> {
-        let v = F::encode_into_bitvector_representation(*summand, self.bits)?.collect();
+        let v = F::encode_as_bitvector(*summand, self.bits)?.collect();
         Ok(v)
     }
 
@@ -279,7 +279,7 @@ impl<F: FftFriendlyFieldElement> Type for Average<F> {
 
     fn truncate(&self, input: Vec<F>) -> Result<Vec<F>, FlpError> {
         self.truncate_call_check(&input)?;
-        let res = F::decode_from_bitvector_representation(&input)?;
+        let res = F::decode_bitvector(&input)?;
         Ok(vec![res])
     }
 
@@ -596,9 +596,7 @@ where
                     self.bits
                 )));
             }
-            flattened.extend(F::encode_into_bitvector_representation(
-                *summand, self.bits,
-            )?);
+            flattened.extend(F::encode_as_bitvector(*summand, self.bits)?);
         }
 
         Ok(flattened)
@@ -641,7 +639,7 @@ where
         self.truncate_call_check(&input)?;
         let mut unflattened = Vec::with_capacity(self.len);
         for chunk in input.chunks(self.bits) {
-            unflattened.push(F::decode_from_bitvector_representation(chunk)?);
+            unflattened.push(F::decode_bitvector(chunk)?);
         }
         Ok(unflattened)
     }

--- a/src/flp/types/fixedpoint_l2.rs
+++ b/src/flp/types/fixedpoint_l2.rs
@@ -419,12 +419,12 @@ where
         // Encode the integer entries bitwise, and write them into the `encoded`
         // vector.
         let mut encoded: Vec<Field128> =
-            vec![Field128::zero(); self.bits_per_entry * self.entries + self.bits_for_norm];
-        for (l, entry) in integer_entries.clone().enumerate() {
-            Field128::fill_with_bitvector_representation(
-                &entry,
-                &mut encoded[l * self.bits_per_entry..(l + 1) * self.bits_per_entry],
-            )?;
+            Vec::with_capacity(self.bits_per_entry * self.entries + self.bits_for_norm);
+        for entry in integer_entries.clone() {
+            encoded.extend(Field128::encode_into_bitvector_representation(
+                entry,
+                self.bits_per_entry,
+            )?);
         }
 
         // (II) Vector norm.
@@ -434,10 +434,10 @@ where
         let norm_int = u128::from(norm);
 
         // Write the norm into the `entries` vector.
-        Field128::fill_with_bitvector_representation(
-            &norm_int,
-            &mut encoded[self.range_norm_begin..self.range_norm_end],
-        )?;
+        encoded.extend(Field128::encode_into_bitvector_representation(
+            norm_int,
+            self.bits_for_norm,
+        )?);
 
         Ok(encoded)
     }

--- a/src/flp/types/fixedpoint_l2.rs
+++ b/src/flp/types/fixedpoint_l2.rs
@@ -421,10 +421,7 @@ where
         let mut encoded: Vec<Field128> =
             Vec::with_capacity(self.bits_per_entry * self.entries + self.bits_for_norm);
         for entry in integer_entries.clone() {
-            encoded.extend(Field128::encode_into_bitvector_representation(
-                entry,
-                self.bits_per_entry,
-            )?);
+            encoded.extend(Field128::encode_as_bitvector(entry, self.bits_per_entry)?);
         }
 
         // (II) Vector norm.
@@ -434,10 +431,7 @@ where
         let norm_int = u128::from(norm);
 
         // Write the norm into the `entries` vector.
-        encoded.extend(Field128::encode_into_bitvector_representation(
-            norm_int,
-            self.bits_for_norm,
-        )?);
+        encoded.extend(Field128::encode_as_bitvector(norm_int, self.bits_for_norm)?);
 
         Ok(encoded)
     }
@@ -535,7 +529,7 @@ where
         // decode the bit-encoded entries into elements in the range [0,2^n):
         let decoded_entries: Result<Vec<_>, _> = input[0..self.entries * self.bits_per_entry]
             .chunks(self.bits_per_entry)
-            .map(Field128::decode_from_bitvector_representation)
+            .map(Field128::decode_bitvector)
             .collect();
 
         // run parallel sum gadget on the decoded entries
@@ -567,7 +561,7 @@ where
         // The submitted norm is also decoded from its bit-encoding, and
         // compared with the computed norm.
         let submitted_norm_enc = &input[self.range_norm_begin..self.range_norm_end];
-        let submitted_norm = Field128::decode_from_bitvector_representation(submitted_norm_enc)?;
+        let submitted_norm = Field128::decode_bitvector(submitted_norm_enc)?;
 
         let norm_check = computed_norm - submitted_norm;
 
@@ -586,7 +580,7 @@ where
             let start = i_entry * self.bits_per_entry;
             let end = (i_entry + 1) * self.bits_per_entry;
 
-            let decoded = Field128::decode_from_bitvector_representation(&input[start..end])?;
+            let decoded = Field128::decode_bitvector(&input[start..end])?;
             decoded_vector.push(decoded);
         }
         Ok(decoded_vector)


### PR DESCRIPTION
This is stacked on #819.

This closes #643, by adding encoding and decoding methods for bitvector representations of integers. Internal uses of `fill_with_bitvector_representation()` and the existing `encode_into_bitvector_representation()` are rewritten to use the new iterator-based method.