### PR TITLE
Remove dependency on itertools

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -205,7 +205,7 @@ dependencies = [
  "clap",
  "criterion-plot",
  "is-terminal",
- "itertools 0.10.5",
+ "itertools",
  "num-traits",
  "once_cell",
  "oorandom",
@@ -226,7 +226,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6b50826342786a51a89e2da3a28f1c32b06e387201bc2d19791f622c673706b1"
 dependencies = [
  "cast",
- "itertools 0.10.5",
+ "itertools",
 ]
 
 [[package]]
@@ -500,15 +500,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "itertools"
-version = "0.11.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b1c173a5686ce8bfa551b3563d0c2170bf24ca44da99c7ca4bfdab5418c3fe57"
-dependencies = [
- "either",
-]
-
-[[package]]
 name = "itoa"
 version = "1.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -760,7 +751,6 @@ dependencies = [
  "hex-literal",
  "hmac",
  "iai",
- "itertools 0.11.0",
  "modinverse",
  "num-bigint",
  "num-integer",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -42,7 +42,6 @@ fixed-macro = "1.2.0"
 hex = { version = "0.4.3", features = ["serde"] }
 hex-literal = "0.4.1"
 iai = "0.1"
-itertools = "0.11.0"
 modinverse = "0.1.0"
 num-bigint = "0.4.4"
 once_cell = "1.18.0"

--- a/src/vdaf.rs
+++ b/src/vdaf.rs
@@ -665,10 +665,7 @@ where
     for<'a> T: ParameterizedDecode<(&'a V, &'a V::AggregationParam)>,
 {
     // Generate an arbitrary vector of field elements.
-    let g = F::one() + F::one();
-    let vec: Vec<F> = itertools::iterate(F::one(), |&v| g * v)
-        .take(length)
-        .collect();
+    let vec: Vec<F> = crate::field::random_vector(length).unwrap();
 
     // Serialize the field element vector into a vector of bytes.
     let mut bytes = Vec::with_capacity(vec.len() * F::ENCODED_SIZE);


### PR DESCRIPTION
This removes our dependency on the itertools crate. The most recent version includes a lot of changes due to newly applying rustfmt across the project (see #833). Removing this dependency would be easier than auditing the changes, since we only use one item from it in a test.