### PR TITLE
Remove PartialOrd and Ord from field elements

### DIFF
--- a/src/field.rs
+++ b/src/field.rs
@@ -405,7 +405,7 @@ macro_rules! make_field {
         ///
         /// As an invariant, this integer representing the field element in the Montgomery domain
         /// must be less than the field modulus, `p`.
-        #[derive(Clone, Copy, PartialOrd, Ord, Default)]
+        #[derive(Clone, Copy, Default)]
         pub struct $elem(u128);
 
         impl $elem {


### PR DESCRIPTION
This closes #810. The existing derived implementations were not meaningful, since they compared the Montgomery representation of field elements. The implementations are removed instead of fixing them because orderings of a cyclic group are not always meaningful. In cases where users want to perform the "natural" comparison between field elements, they should first project the field elements to integers, and then compare the integers directly. (Note that this projection, via `From<$int> for $elem`, does correctly map from the Montgomery representation to a residue class representative)