### PR TITLE
Add #[non_exhaustive] to error enums

### DIFF
--- a/src/codec.rs
+++ b/src/codec.rs
@@ -20,6 +20,7 @@ use std::{
 
 /// An error that occurred during decoding.
 #[derive(Debug, thiserror::Error)]
+#[non_exhaustive]
 pub enum CodecError {
     /// An I/O error.
     #[error("I/O error")]

--- a/src/dp.rs
+++ b/src/dp.rs
@@ -20,6 +20,7 @@ use serde::{Deserialize, Serialize};
 
 /// Errors propagated by methods in this module.
 #[derive(Debug, thiserror::Error)]
+#[non_exhaustive]
 pub enum DpError {
     /// Tried to use an invalid float as privacy parameter.
     #[error(

--- a/src/fft.rs
+++ b/src/fft.rs
@@ -10,6 +10,7 @@ use std::convert::TryFrom;
 
 /// An error returned by an FFT operation.
 #[derive(Debug, PartialEq, Eq, thiserror::Error)]
+#[non_exhaustive]
 pub enum FftError {
     /// The output is too small.
     #[error("output slice is smaller than specified size")]

--- a/src/field.rs
+++ b/src/field.rs
@@ -39,6 +39,7 @@ pub use field255::Field255;
 
 /// Possible errors from finite field operations.
 #[derive(Debug, thiserror::Error)]
+#[non_exhaustive]
 pub enum FieldError {
     /// Input sizes do not match.
     #[error("input sizes do not match")]

--- a/src/flp.rs
+++ b/src/flp.rs
@@ -61,6 +61,7 @@ pub mod types;
 
 /// Errors propagated by methods in this module.
 #[derive(Debug, thiserror::Error)]
+#[non_exhaustive]
 pub enum FlpError {
     /// Calling [`Type::prove`] returned an error.
     #[error("prove error: {0}")]

--- a/src/idpf.rs
+++ b/src/idpf.rs
@@ -30,6 +30,7 @@ use subtle::{Choice, ConditionallyNegatable, ConditionallySelectable, ConstantTi
 
 /// IDPF-related errors.
 #[derive(Debug, thiserror::Error)]
+#[non_exhaustive]
 pub enum IdpfError {
     /// Error from incompatible shares at different levels.
     #[error("tried to merge shares from incompatible levels")]

--- a/src/prng.rs
+++ b/src/prng.rs
@@ -19,6 +19,7 @@ const BUFFER_SIZE_IN_ELEMENTS: usize = 32;
 
 /// Errors propagated by methods in this module.
 #[derive(Debug, thiserror::Error)]
+#[non_exhaustive]
 pub enum PrngError {
     /// Failure when calling getrandom().
     #[error("getrandom: {0}")]

--- a/src/topology/ping_pong.rs
+++ b/src/topology/ping_pong.rs
@@ -15,6 +15,7 @@ use std::fmt::Debug;
 
 /// Errors emitted by this module.
 #[derive(Debug, thiserror::Error)]
+#[non_exhaustive]
 pub enum PingPongError {
     /// Error running prepare_init
     #[error("vdaf.prepare_init: {0}")]

--- a/src/vdaf.rs
+++ b/src/vdaf.rs
@@ -26,6 +26,7 @@ pub(crate) const VERSION: u8 = 7;
 
 /// Errors emitted by this module.
 #[derive(Debug, thiserror::Error)]
+#[non_exhaustive]
 pub enum VdafError {
     /// An error occurred.
     #[error("vdaf error: {0}")]


### PR DESCRIPTION
This adds the `#[non_exhaustive]` attribute to all enums that appear in public items. This is related to #424, and will generally let us add error variants freely going forward.