### PR TITLE
Remove deprecated methods

### DIFF
--- a/src/topology/ping_pong.rs
+++ b/src/topology/ping_pong.rs
@@ -416,15 +416,7 @@ pub trait PingPongTopology<const VERIFY_KEY_SIZE: usize, const NONCE_SIZE: usize
     ///
     /// `inbound` must not be `PingPongMessage::Initialize` or the function will fail.
     ///
-    /// # Notes
-    ///
-    /// The specification of this function in [VDAF] takes the aggregation parameter. This version
-    /// does not, because [`crate::vdaf::Aggregator::prepare_preprocess`] does not take the
-    /// aggregation parameter. This may change in the future if/when [#670][issue] is addressed.
-    ///
-    ///
     /// [VDAF]: https://datatracker.ietf.org/doc/html/draft-irtf-cfrg-vdaf-07#section-5.8
-    /// [issue]: https://github.com/divviup/libprio-rs/issues/670
     fn leader_continued(
         &self,
         leader_state: Self::State,
@@ -459,15 +451,7 @@ pub trait PingPongTopology<const VERIFY_KEY_SIZE: usize, const NONCE_SIZE: usize
     ///
     /// `inbound` must not be `PingPongMessage::Initialize` or the function will fail.
     ///
-    /// # Notes
-    ///
-    /// The specification of this function in [VDAF] takes the aggregation parameter. This version
-    /// does not, because [`crate::vdaf::Aggregator::prepare_preprocess`] does not take the
-    /// aggregation parameter. This may change in the future if/when [#670][issue] is addressed.
-    ///
-    ///
     /// [VDAF]: https://datatracker.ietf.org/doc/html/draft-irtf-cfrg-vdaf-07#section-5.8
-    /// [issue]: https://github.com/divviup/libprio-rs/issues/670
     fn helper_continued(
         &self,
         helper_state: Self::State,

--- a/src/vdaf.rs
+++ b/src/vdaf.rs
@@ -263,58 +263,12 @@ pub trait Aggregator<const VERIFY_KEY_SIZE: usize, const NONCE_SIZE: usize>: Vda
     ///
     /// Implements `Vdaf.prep_shares_to_prep` from [VDAF].
     ///
-    /// # Notes
-    ///
-    /// [`Self::prepare_shares_to_prepare_message`] is preferable since its name better matches the
-    /// specification.
-    ///
-    /// [VDAF]: https://datatracker.ietf.org/doc/html/draft-irtf-cfrg-vdaf-07#section-5.2
-    #[deprecated(
-        since = "0.15.0",
-        note = "Use Vdaf::prepare_shares_to_prepare_message instead"
-    )]
-    fn prepare_preprocess<M: IntoIterator<Item = Self::PrepareShare>>(
-        &self,
-        agg_param: &Self::AggregationParam,
-        inputs: M,
-    ) -> Result<Self::PrepareMessage, VdafError> {
-        self.prepare_shares_to_prepare_message(agg_param, inputs)
-    }
-
-    /// Preprocess a round of preparation shares into a single input to [`Self::prepare_next`].
-    ///
-    /// Implements `Vdaf.prep_shares_to_prep` from [VDAF].
-    ///
     /// [VDAF]: https://datatracker.ietf.org/doc/html/draft-irtf-cfrg-vdaf-07#section-5.2
     fn prepare_shares_to_prepare_message<M: IntoIterator<Item = Self::PrepareShare>>(
         &self,
         agg_param: &Self::AggregationParam,
         inputs: M,
     ) -> Result<Self::PrepareMessage, VdafError>;
-
-    /// Compute the next state transition from the current state and the previous round of input
-    /// messages. If this returns [`PrepareTransition::Continue`], then the returned
-    /// [`Self::PrepareShare`] should be combined with the other Aggregators' `PrepareShare`s from
-    /// this round and passed into another call to this method. This continues until this method
-    /// returns [`PrepareTransition::Finish`], at which point the returned output share may be
-    /// aggregated. If the method returns an error, the aggregator should consider its input share
-    /// invalid and not attempt to process it any further.
-    ///
-    /// Implements `Vdaf.prep_next` from [VDAF].
-    ///
-    /// # Notes
-    ///
-    /// [`Self::prepare_next`] is preferable since its name better matches the specification.
-    ///
-    /// [VDAF]: https://datatracker.ietf.org/doc/html/draft-irtf-cfrg-vdaf-07#section-5.2
-    #[deprecated(since = "0.15.0", note = "Use Vdaf::prepare_next")]
-    fn prepare_step(
-        &self,
-        state: Self::PrepareState,
-        input: Self::PrepareMessage,
-    ) -> Result<PrepareTransition<Self, VERIFY_KEY_SIZE, NONCE_SIZE>, VdafError> {
-        self.prepare_next(state, input)
-    }
 
     /// Compute the next state transition from the current state and the previous round of input
     /// messages. If this returns [`PrepareTransition::Continue`], then the returned

--- a/src/vdaf/dummy.rs
+++ b/src/vdaf/dummy.rs
@@ -76,7 +76,7 @@ impl Vdaf {
         self
     }
 
-    /// Provide an alternate implementation of [`vdaf::Aggregator::prepare_step`].
+    /// Provide an alternate implementation of [`vdaf::Aggregator::prepare_next`].
     pub fn with_prep_step_fn<
         F: Fn(&PrepareState) -> Result<PrepareTransition<Self, 0, 16>, VdafError>,
     >(

--- a/src/vdaf/prio3.rs
+++ b/src/vdaf/prio3.rs
@@ -316,7 +316,7 @@ impl Prio3Average {
 ///     let prep_msg = vdaf.prepare_shares_to_prepare_message(&(), prep_shares).unwrap();
 ///
 ///     for (agg_id, state) in prep_states.into_iter().enumerate() {
-///         let out_share = match vdaf.prepare_step(state, prep_msg.clone()).unwrap() {
+///         let out_share = match vdaf.prepare_next(state, prep_msg.clone()).unwrap() {
 ///             PrepareTransition::Finish(out_share) => out_share,
 ///             _ => panic!("unexpected transition"),
 ///         };


### PR DESCRIPTION
This removes two deprecated methods, fixes doctests, and cleans up some related outdated comments. Closes #745.