### PR TITLE
Fix up doc comment on try_from_random()

### DIFF
--- a/src/field.rs
+++ b/src/field.rs
@@ -101,8 +101,8 @@ pub trait FieldElement:
     fn inv(&self) -> Self;
 
     /// Interprets the next [`Self::ENCODED_SIZE`] bytes from the input slice as an element of the
-    /// field. The `m` most significant bits are cleared, where `m` is equal to the length of
-    /// [`Self::Integer`] in bits minus the length of the modulus in bits.
+    /// field. Any of the most significant bits beyond the bit length of the modulus will be
+    /// cleared, in order to minimize the amount of rejection sampling needed.
     ///
     /// # Errors
     ///
@@ -111,9 +111,9 @@ pub trait FieldElement:
     ///
     /// # Warnings
     ///
-    /// This function should only be used within [`prng::Prng`] to convert a random byte string into
-    /// a field element. Use [`Self::decode`] to deserialize field elements. Use
-    /// [`field::rand`] or [`prng::Prng`] to randomly generate field elements.
+    /// This function should only be used internally to convert a random byte string into
+    /// a field element. Use [`Decode::decode`] to deserialize field elements. Use
+    /// [`random_vector`] to randomly generate field elements.
     #[doc(hidden)]
     fn try_from_random(bytes: &[u8]) -> Result<Self, FieldError>;
 


### PR DESCRIPTION
This updates the doc comment for `FieldElement::try_from_random()`. Since it is marked with `#[doc(hidden)]`, rustdoc doesn't process it at all, and thus some of the links to other items became out of date.