### PR TITLE
test-util: Add a method for running Prio3 test vectors

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,6 +18,7 @@ ctr = { version = "0.9.2", optional = true }
 fiat-crypto = { version = "0.2.5", optional = true }
 fixed = { version = "1.23", optional = true }
 getrandom = { version = "0.2.11", features = ["std"] }
+hex = { version = "0.4.3", features = ["serde"], optional = true }
 hmac = { version = "0.12.1", optional = true }
 num-bigint = { version = "0.4.4", optional = true, features = ["rand", "serde"] }
 num-integer = { version = "0.1.45", optional = true }
@@ -28,6 +29,7 @@ rand = { version = "0.8", optional = true }
 rand_core = "0.6.4"
 rayon = { version = "1.8.0", optional = true }
 serde = { version = "1.0", features = ["derive"] }
+serde_json = { version = "1.0", optional = true }
 sha2 = { version = "0.10.8", optional = true }
 sha3 = "0.10.8"
 subtle = "2.5.0"
@@ -39,7 +41,6 @@ base64 = "0.21.5"
 cfg-if = "1.0.0"
 criterion = "0.5"
 fixed-macro = "1.2.0"
-hex = { version = "0.4.3", features = ["serde"] }
 hex-literal = "0.4.1"
 iai = "0.1"
 modinverse = "0.1.0"
@@ -47,7 +48,6 @@ num-bigint = "0.4.4"
 once_cell = "1.18.0"
 prio = { path = ".", features = ["crypto-dependencies", "test-util"] }
 rand = "0.8"
-serde_json = "1.0"
 statrs = "0.16.0"
 zipf = "7.0.1"
 
@@ -57,7 +57,7 @@ experimental = ["bitvec", "fiat-crypto", "fixed", "num-bigint", "num-rational", 
 multithreaded = ["rayon"]
 prio2 = ["crypto-dependencies", "hmac", "sha2"]
 crypto-dependencies = ["aes", "ctr"]
-test-util = ["rand"]
+test-util = ["hex", "rand", "serde_json"]
 
 [workspace]
 members = [".", "binaries"]

--- a/src/vdaf.rs
+++ b/src/vdaf.rs
@@ -712,6 +712,6 @@ pub mod poplar1;
 #[cfg_attr(docsrs, doc(cfg(feature = "prio2")))]
 pub mod prio2;
 pub mod prio3;
-#[cfg(test)]
-mod prio3_test;
+#[cfg(any(test, feature = "test-util"))]
+pub mod prio3_test;
 pub mod xof;

--- a/supply-chain/imports.lock
+++ b/supply-chain/imports.lock
@@ -503,6 +503,12 @@ criteria = "safe-to-deploy"
 delta = "0.1.19 -> 0.2.6"
 aggregated-from = "https://hg.mozilla.org/mozilla-central/raw-file/tip/supply-chain/audits.toml"
 
+[[audits.mozilla.audits.hex]]
+who = "Simon Friedberger <simon@mozilla.com>"
+criteria = "safe-to-deploy"
+version = "0.4.3"
+aggregated-from = "https://hg.mozilla.org/mozilla-central/raw-file/tip/supply-chain/audits.toml"
+
 [[audits.mozilla.audits.libc]]
 who = "Mike Hommey <mh+mozilla@glandium.org>"
 criteria = "safe-to-deploy"


### PR DESCRIPTION
It's useful to be able to test non-standard Prio3 variants implemented elsewhere.