### PR TITLE
Make the Encode trait fallible

### DIFF
--- a/benches/cycle_counts.rs
+++ b/benches/cycle_counts.rs
@@ -241,7 +241,7 @@ fn idpf_codec() {
     .unwrap();
     let bits = 4;
     let public_share = IdpfPublicShare::<Poplar1IdpfValue<Field64>, Poplar1IdpfValue<Field255>>::get_decoded_with_param(&bits, &data).unwrap();
-    let encoded = public_share.get_encoded();
+    let encoded = public_share.get_encoded().unwrap();
     let _ = black_box(encoded.len());
 }
 

--- a/binaries/src/bin/vdaf_message_sizes.rs
+++ b/binaries/src/bin/vdaf_message_sizes.rs
@@ -89,9 +89,9 @@ fn main() {
 fn vdaf_input_share_size<V: Vdaf, const SEED_SIZE: usize>(
     shares: (V::PublicShare, Vec<V::InputShare>),
 ) -> usize {
-    let mut size = shares.0.get_encoded().len();
+    let mut size = shares.0.get_encoded().unwrap().len();
     for input_share in shares.1 {
-        size += input_share.get_encoded().len();
+        size += input_share.get_encoded().unwrap().len();
     }
 
     size

--- a/src/codec.rs
+++ b/src/codec.rs
@@ -34,6 +34,10 @@ pub enum CodecError {
     #[error("length prefix of encoded vector overflows buffer: {0}")]
     LengthPrefixTooBig(usize),
 
+    /// The byte length of a vector exceeded the range of its length prefix.
+    #[error("vector length exceeded range of length prefix")]
+    LengthPrefixOverflow,
+
     /// Custom errors from [`Decode`] implementations.
     #[error("other error: {0}")]
     Other(#[source] Box<dyn Error + 'static + Send + Sync>),
@@ -98,10 +102,10 @@ impl<D: Decode + ?Sized, T> ParameterizedDecode<T> for D {
 /// Describes how to encode objects into a byte sequence.
 pub trait Encode {
     /// Append the encoded form of this object to the end of `bytes`, growing the vector as needed.
-    fn encode(&self, bytes: &mut Vec<u8>);
+    fn encode(&self, bytes: &mut Vec<u8>) -> Result<(), CodecError>;
 
     /// Convenience method to encode a value into a new `Vec<u8>`.
-    fn get_encoded(&self) -> Vec<u8> {
+    fn get_encoded(&self) -> Result<Vec<u8>, CodecError> {
         self.get_encoded_with_param(&())
     }
 
@@ -117,17 +121,21 @@ pub trait ParameterizedEncode<P> {
     /// Append the encoded form of this object to the end of `bytes`, growing the vector as needed.
     /// `encoding_parameter` provides details of the wire encoding, used to control how the value
     /// is encoded.
-    fn encode_with_param(&self, encoding_parameter: &P, bytes: &mut Vec<u8>);
+    fn encode_with_param(
+        &self,
+        encoding_parameter: &P,
+        bytes: &mut Vec<u8>,
+    ) -> Result<(), CodecError>;
 
     /// Convenience method to encode a value into a new `Vec<u8>`.
-    fn get_encoded_with_param(&self, encoding_parameter: &P) -> Vec<u8> {
+    fn get_encoded_with_param(&self, encoding_parameter: &P) -> Result<Vec<u8>, CodecError> {
         let mut ret = if let Some(length) = self.encoded_len_with_param(encoding_parameter) {
             Vec::with_capacity(length)
         } else {
             Vec::new()
         };
-        self.encode_with_param(encoding_parameter, &mut ret);
-        ret
+        self.encode_with_param(encoding_parameter, &mut ret)?;
+        Ok(ret)
     }
 
     /// Returns an optional hint indicating how many bytes will be required to encode this value, or
@@ -140,7 +148,11 @@ pub trait ParameterizedEncode<P> {
 /// Provide a blanket implementation so that any [`Encode`] can be used as a
 /// `ParameterizedEncode<T>` for any `T`.
 impl<E: Encode + ?Sized, T> ParameterizedEncode<T> for E {
-    fn encode_with_param(&self, _encoding_parameter: &T, bytes: &mut Vec<u8>) {
+    fn encode_with_param(
+        &self,
+        _encoding_parameter: &T,
+        bytes: &mut Vec<u8>,
+    ) -> Result<(), CodecError> {
         self.encode(bytes)
     }
 
@@ -156,7 +168,9 @@ impl Decode for () {
 }
 
 impl Encode for () {
-    fn encode(&self, _bytes: &mut Vec<u8>) {}
+    fn encode(&self, _bytes: &mut Vec<u8>) -> Result<(), CodecError> {
+        Ok(())
+    }
 
     fn encoded_len(&self) -> Option<usize> {
         Some(0)
@@ -172,8 +186,9 @@ impl Decode for u8 {
 }
 
 impl Encode for u8 {
-    fn encode(&self, bytes: &mut Vec<u8>) {
+    fn encode(&self, bytes: &mut Vec<u8>) -> Result<(), CodecError> {
         bytes.push(*self);
+        Ok(())
     }
 
     fn encoded_len(&self) -> Option<usize> {
@@ -188,8 +203,9 @@ impl Decode for u16 {
 }
 
 impl Encode for u16 {
-    fn encode(&self, bytes: &mut Vec<u8>) {
+    fn encode(&self, bytes: &mut Vec<u8>) -> Result<(), CodecError> {
         bytes.extend_from_slice(&u16::to_be_bytes(*self));
+        Ok(())
     }
 
     fn encoded_len(&self) -> Option<usize> {
@@ -209,9 +225,10 @@ impl Decode for U24 {
 }
 
 impl Encode for U24 {
-    fn encode(&self, bytes: &mut Vec<u8>) {
+    fn encode(&self, bytes: &mut Vec<u8>) -> Result<(), CodecError> {
         // Encode lower three bytes of the u32 as u24
         bytes.extend_from_slice(&u32::to_be_bytes(self.0)[1..]);
+        Ok(())
     }
 
     fn encoded_len(&self) -> Option<usize> {
@@ -226,8 +243,9 @@ impl Decode for u32 {
 }
 
 impl Encode for u32 {
-    fn encode(&self, bytes: &mut Vec<u8>) {
+    fn encode(&self, bytes: &mut Vec<u8>) -> Result<(), CodecError> {
         bytes.extend_from_slice(&u32::to_be_bytes(*self));
+        Ok(())
     }
 
     fn encoded_len(&self) -> Option<usize> {
@@ -242,8 +260,9 @@ impl Decode for u64 {
 }
 
 impl Encode for u64 {
-    fn encode(&self, bytes: &mut Vec<u8>) {
+    fn encode(&self, bytes: &mut Vec<u8>) -> Result<(), CodecError> {
         bytes.extend_from_slice(&u64::to_be_bytes(*self));
+        Ok(())
     }
 
     fn encoded_len(&self) -> Option<usize> {
@@ -258,18 +277,19 @@ pub fn encode_u8_items<P, E: ParameterizedEncode<P>>(
     bytes: &mut Vec<u8>,
     encoding_parameter: &P,
     items: &[E],
-) {
+) -> Result<(), CodecError> {
     // Reserve space to later write length
     let len_offset = bytes.len();
     bytes.push(0);
 
     for item in items {
-        item.encode_with_param(encoding_parameter, bytes);
+        item.encode_with_param(encoding_parameter, bytes)?;
     }
 
-    let len = bytes.len() - len_offset - 1;
-    assert!(len <= usize::from(u8::MAX));
-    bytes[len_offset] = len as u8;
+    let len =
+        u8::try_from(bytes.len() - len_offset - 1).map_err(|_| CodecError::LengthPrefixOverflow)?;
+    bytes[len_offset] = len;
+    Ok(())
 }
 
 /// Decode `bytes` into a vector of `D` values, treating `bytes` as a [variable-length vector][1] of
@@ -293,20 +313,19 @@ pub fn encode_u16_items<P, E: ParameterizedEncode<P>>(
     bytes: &mut Vec<u8>,
     encoding_parameter: &P,
     items: &[E],
-) {
+) -> Result<(), CodecError> {
     // Reserve space to later write length
     let len_offset = bytes.len();
-    0u16.encode(bytes);
+    0u16.encode(bytes)?;
 
     for item in items {
-        item.encode_with_param(encoding_parameter, bytes);
+        item.encode_with_param(encoding_parameter, bytes)?;
     }
 
-    let len = bytes.len() - len_offset - 2;
-    assert!(len <= usize::from(u16::MAX));
-    for (offset, byte) in u16::to_be_bytes(len as u16).iter().enumerate() {
-        bytes[len_offset + offset] = *byte;
-    }
+    let len = u16::try_from(bytes.len() - len_offset - 2)
+        .map_err(|_| CodecError::LengthPrefixOverflow)?;
+    bytes[len_offset..len_offset + 2].copy_from_slice(&len.to_be_bytes());
+    Ok(())
 }
 
 /// Decode `bytes` into a vector of `D` values, treating `bytes` as a [variable-length vector][1] of
@@ -331,20 +350,22 @@ pub fn encode_u24_items<P, E: ParameterizedEncode<P>>(
     bytes: &mut Vec<u8>,
     encoding_parameter: &P,
     items: &[E],
-) {
+) -> Result<(), CodecError> {
     // Reserve space to later write length
     let len_offset = bytes.len();
-    U24(0).encode(bytes);
+    U24(0).encode(bytes)?;
 
     for item in items {
-        item.encode_with_param(encoding_parameter, bytes);
+        item.encode_with_param(encoding_parameter, bytes)?;
     }
 
-    let len = bytes.len() - len_offset - 3;
-    assert!(len <= 0xffffff);
-    for (offset, byte) in u32::to_be_bytes(len as u32)[1..].iter().enumerate() {
-        bytes[len_offset + offset] = *byte;
+    let len = u32::try_from(bytes.len() - len_offset - 3)
+        .map_err(|_| CodecError::LengthPrefixOverflow)?;
+    if len > 0xffffff {
+        return Err(CodecError::LengthPrefixOverflow);
     }
+    bytes[len_offset..len_offset + 3].copy_from_slice(&len.to_be_bytes()[1..]);
+    Ok(())
 }
 
 /// Decode `bytes` into a vector of `D` values, treating `bytes` as a [variable-length vector][1] of
@@ -369,20 +390,19 @@ pub fn encode_u32_items<P, E: ParameterizedEncode<P>>(
     bytes: &mut Vec<u8>,
     encoding_parameter: &P,
     items: &[E],
-) {
+) -> Result<(), CodecError> {
     // Reserve space to later write length
     let len_offset = bytes.len();
-    0u32.encode(bytes);
+    0u32.encode(bytes)?;
 
     for item in items {
-        item.encode_with_param(encoding_parameter, bytes);
+        item.encode_with_param(encoding_parameter, bytes)?;
     }
 
-    let len = bytes.len() - len_offset - 4;
-    let len: u32 = len.try_into().expect("Length too large");
-    for (offset, byte) in len.to_be_bytes().iter().enumerate() {
-        bytes[len_offset + offset] = *byte;
-    }
+    let len = u32::try_from(bytes.len() - len_offset - 4)
+        .map_err(|_| CodecError::LengthPrefixOverflow)?;
+    bytes[len_offset..len_offset + 4].copy_from_slice(&len.to_be_bytes());
+    Ok(())
 }
 
 /// Decode `bytes` into a vector of `D` values, treating `bytes` as a [variable-length vector][1] of
@@ -433,6 +453,7 @@ fn decode_items<P, D: ParameterizedDecode<P>>(
 
 #[cfg(test)]
 mod tests {
+    use std::io::ErrorKind;
 
     use super::*;
     use assert_matches::assert_matches;
@@ -440,7 +461,7 @@ mod tests {
     #[test]
     fn encode_nothing() {
         let mut bytes = vec![];
-        ().encode(&mut bytes);
+        ().encode(&mut bytes).unwrap();
         assert_eq!(bytes.len(), 0);
     }
 
@@ -449,7 +470,7 @@ mod tests {
         let value = 100u8;
 
         let mut bytes = vec![];
-        value.encode(&mut bytes);
+        value.encode(&mut bytes).unwrap();
         assert_eq!(bytes.len(), 1);
 
         let decoded = u8::decode(&mut Cursor::new(&bytes)).unwrap();
@@ -461,7 +482,7 @@ mod tests {
         let value = 1000u16;
 
         let mut bytes = vec![];
-        value.encode(&mut bytes);
+        value.encode(&mut bytes).unwrap();
         assert_eq!(bytes.len(), 2);
         // Check endianness of encoding
         assert_eq!(bytes, vec![3, 232]);
@@ -475,7 +496,7 @@ mod tests {
         let value = U24(1_000_000u32);
 
         let mut bytes = vec![];
-        value.encode(&mut bytes);
+        value.encode(&mut bytes).unwrap();
         assert_eq!(bytes.len(), 3);
         // Check endianness of encoding
         assert_eq!(bytes, vec![15, 66, 64]);
@@ -489,7 +510,7 @@ mod tests {
         let value = 134_217_728u32;
 
         let mut bytes = vec![];
-        value.encode(&mut bytes);
+        value.encode(&mut bytes).unwrap();
         assert_eq!(bytes.len(), 4);
         // Check endianness of encoding
         assert_eq!(bytes, vec![8, 0, 0, 0]);
@@ -503,7 +524,7 @@ mod tests {
         let value = 137_438_953_472u64;
 
         let mut bytes = vec![];
-        value.encode(&mut bytes);
+        value.encode(&mut bytes).unwrap();
         assert_eq!(bytes.len(), 8);
         // Check endianness of encoding
         assert_eq!(bytes, vec![0, 0, 0, 32, 0, 0, 0, 0]);
@@ -522,12 +543,12 @@ mod tests {
     }
 
     impl Encode for TestMessage {
-        fn encode(&self, bytes: &mut Vec<u8>) {
-            self.field_u8.encode(bytes);
-            self.field_u16.encode(bytes);
-            self.field_u24.encode(bytes);
-            self.field_u32.encode(bytes);
-            self.field_u64.encode(bytes);
+        fn encode(&self, bytes: &mut Vec<u8>) -> Result<(), CodecError> {
+            self.field_u8.encode(bytes)?;
+            self.field_u16.encode(bytes)?;
+            self.field_u24.encode(bytes)?;
+            self.field_u32.encode(bytes)?;
+            self.field_u64.encode(bytes)
         }
 
         fn encoded_len(&self) -> Option<usize> {
@@ -585,7 +606,7 @@ mod tests {
         };
 
         let mut bytes = vec![];
-        value.encode(&mut bytes);
+        value.encode(&mut bytes).unwrap();
         assert_eq!(bytes.len(), TestMessage::encoded_length());
         assert_eq!(value.encoded_len().unwrap(), TestMessage::encoded_length());
 
@@ -623,7 +644,7 @@ mod tests {
     fn roundtrip_variable_length_u8() {
         let values = messages_vec();
         let mut bytes = vec![];
-        encode_u8_items(&mut bytes, &(), &values);
+        encode_u8_items(&mut bytes, &(), &values).unwrap();
 
         assert_eq!(
             bytes.len(),
@@ -641,7 +662,7 @@ mod tests {
     fn roundtrip_variable_length_u16() {
         let values = messages_vec();
         let mut bytes = vec![];
-        encode_u16_items(&mut bytes, &(), &values);
+        encode_u16_items(&mut bytes, &(), &values).unwrap();
 
         assert_eq!(
             bytes.len(),
@@ -662,7 +683,7 @@ mod tests {
     fn roundtrip_variable_length_u24() {
         let values = messages_vec();
         let mut bytes = vec![];
-        encode_u24_items(&mut bytes, &(), &values);
+        encode_u24_items(&mut bytes, &(), &values).unwrap();
 
         assert_eq!(
             bytes.len(),
@@ -683,7 +704,7 @@ mod tests {
     fn roundtrip_variable_length_u32() {
         let values = messages_vec();
         let mut bytes = Vec::new();
-        encode_u32_items(&mut bytes, &(), &values);
+        encode_u32_items(&mut bytes, &(), &values).unwrap();
 
         assert_eq!(bytes.len(), 4 + 3 * TestMessage::encoded_length());
 
@@ -695,6 +716,21 @@ mod tests {
 
         let decoded = decode_u32_items(&(), &mut Cursor::new(&bytes)).unwrap();
         assert_eq!(values, decoded);
+    }
+
+    #[test]
+    fn decode_too_short() {
+        let values = messages_vec();
+        let mut bytes = Vec::new();
+        encode_u32_items(&mut bytes, &(), &values).unwrap();
+
+        let error =
+            decode_u32_items::<_, TestMessage>(&(), &mut Cursor::new(&bytes[..3])).unwrap_err();
+        assert_matches!(error, CodecError::Io(e) => assert_eq!(e.kind(), ErrorKind::UnexpectedEof));
+
+        let error =
+            decode_u32_items::<_, TestMessage>(&(), &mut Cursor::new(&bytes[..4])).unwrap_err();
+        assert_matches!(error, CodecError::LengthPrefixTooBig(_));
     }
 
     #[test]
@@ -725,11 +761,56 @@ mod tests {
 
     #[test]
     fn length_hint_correctness() {
-        assert_eq!(().encoded_len().unwrap(), ().get_encoded().len());
-        assert_eq!(0u8.encoded_len().unwrap(), 0u8.get_encoded().len());
-        assert_eq!(0u16.encoded_len().unwrap(), 0u16.get_encoded().len());
-        assert_eq!(U24(0).encoded_len().unwrap(), U24(0).get_encoded().len());
-        assert_eq!(0u32.encoded_len().unwrap(), 0u32.get_encoded().len());
-        assert_eq!(0u64.encoded_len().unwrap(), 0u64.get_encoded().len());
+        assert_eq!(().encoded_len().unwrap(), ().get_encoded().unwrap().len());
+        assert_eq!(0u8.encoded_len().unwrap(), 0u8.get_encoded().unwrap().len());
+        assert_eq!(
+            0u16.encoded_len().unwrap(),
+            0u16.get_encoded().unwrap().len()
+        );
+        assert_eq!(
+            U24(0).encoded_len().unwrap(),
+            U24(0).get_encoded().unwrap().len()
+        );
+        assert_eq!(
+            0u32.encoded_len().unwrap(),
+            0u32.get_encoded().unwrap().len()
+        );
+        assert_eq!(
+            0u64.encoded_len().unwrap(),
+            0u64.get_encoded().unwrap().len()
+        );
+    }
+
+    #[test]
+    fn get_decoded_leftover() {
+        let encoded_good = [1, 2, 3, 4];
+        assert_matches!(u32::get_decoded(&encoded_good).unwrap(), 0x01020304u32);
+
+        let encoded_bad = [1, 2, 3, 4, 5];
+        let error = u32::get_decoded(&encoded_bad).unwrap_err();
+        assert_matches!(error, CodecError::BytesLeftOver(1));
+    }
+
+    #[test]
+    fn encoded_len_backwards_compatibility() {
+        struct MyMessage;
+
+        impl Encode for MyMessage {
+            fn encode(&self, bytes: &mut Vec<u8>) -> Result<(), CodecError> {
+                bytes.extend_from_slice(b"Hello, world");
+                Ok(())
+            }
+        }
+
+        assert_eq!(MyMessage.encoded_len(), None);
+
+        assert_eq!(MyMessage.get_encoded().unwrap(), b"Hello, world");
+    }
+
+    #[test]
+    fn encode_length_prefix_overflow() {
+        let mut bytes = Vec::new();
+        let error = encode_u8_items(&mut bytes, &(), &[1u8; u8::MAX as usize + 1]).unwrap_err();
+        assert_matches!(error, CodecError::LengthPrefixOverflow);
     }
 }

--- a/src/field/field255.rs
+++ b/src/field/field255.rs
@@ -271,8 +271,9 @@ impl<'de> Deserialize<'de> for Field255 {
 }
 
 impl Encode for Field255 {
-    fn encode(&self, bytes: &mut Vec<u8>) {
+    fn encode(&self, bytes: &mut Vec<u8>) -> Result<(), CodecError> {
         bytes.extend_from_slice(&<[u8; Self::ENCODED_SIZE]>::from(*self));
+        Ok(())
     }
 
     fn encoded_len(&self) -> Option<usize> {
@@ -429,7 +430,7 @@ mod tests {
     #[test]
     fn encode_endianness() {
         let mut one_encoded = Vec::new();
-        Field255::one().encode(&mut one_encoded);
+        Field255::one().encode(&mut one_encoded).unwrap();
         assert_eq!(
             one_encoded,
             [

--- a/src/prng.rs
+++ b/src/prng.rs
@@ -167,7 +167,7 @@ mod tests {
         let random_data = extract_share_from_seed::<FieldPrio2>(len, &seed);
 
         let mut random_bytes = Vec::new();
-        encode_fieldvec(&random_data, &mut random_bytes);
+        encode_fieldvec(&random_data, &mut random_bytes).unwrap();
 
         let mut hasher = Sha256::new();
         hasher.update(&random_bytes);

--- a/src/vdaf/dummy.rs
+++ b/src/vdaf/dummy.rs
@@ -191,7 +191,7 @@ impl vdaf::Client<16> for Vdaf {
 pub struct InputShare(pub u8);
 
 impl Encode for InputShare {
-    fn encode(&self, bytes: &mut Vec<u8>) {
+    fn encode(&self, bytes: &mut Vec<u8>) -> Result<(), CodecError> {
         self.0.encode(bytes)
     }
 
@@ -211,7 +211,7 @@ impl Decode for InputShare {
 pub struct AggregationParam(pub u8);
 
 impl Encode for AggregationParam {
-    fn encode(&self, bytes: &mut Vec<u8>) {
+    fn encode(&self, bytes: &mut Vec<u8>) -> Result<(), CodecError> {
         self.0.encode(bytes)
     }
 
@@ -237,8 +237,8 @@ impl Decode for OutputShare {
 }
 
 impl Encode for OutputShare {
-    fn encode(&self, bytes: &mut Vec<u8>) {
-        self.0.encode(bytes);
+    fn encode(&self, bytes: &mut Vec<u8>) -> Result<(), CodecError> {
+        self.0.encode(bytes)
     }
 
     fn encoded_len(&self) -> Option<usize> {
@@ -254,9 +254,9 @@ pub struct PrepareState {
 }
 
 impl Encode for PrepareState {
-    fn encode(&self, bytes: &mut Vec<u8>) {
-        self.input_share.encode(bytes);
-        self.current_round.encode(bytes);
+    fn encode(&self, bytes: &mut Vec<u8>) -> Result<(), CodecError> {
+        self.input_share.encode(bytes)?;
+        self.current_round.encode(bytes)
     }
 
     fn encoded_len(&self) -> Option<usize> {
@@ -308,7 +308,7 @@ impl Decode for AggregateShare {
 }
 
 impl Encode for AggregateShare {
-    fn encode(&self, bytes: &mut Vec<u8>) {
+    fn encode(&self, bytes: &mut Vec<u8>) -> Result<(), CodecError> {
         self.0.encode(bytes)
     }
 

--- a/src/vdaf/prio2.rs
+++ b/src/vdaf/prio2.rs
@@ -187,8 +187,8 @@ impl ConstantTimeEq for Prio2PrepareState {
 }
 
 impl Encode for Prio2PrepareState {
-    fn encode(&self, bytes: &mut Vec<u8>) {
-        self.0.encode(bytes);
+    fn encode(&self, bytes: &mut Vec<u8>) -> Result<(), CodecError> {
+        self.0.encode(bytes)
     }
 
     fn encoded_len(&self) -> Option<usize> {
@@ -216,10 +216,10 @@ impl<'a> ParameterizedDecode<(&'a Prio2, usize)> for Prio2PrepareState {
 pub struct Prio2PrepareShare(v2_server::VerificationMessage<FieldPrio2>);
 
 impl Encode for Prio2PrepareShare {
-    fn encode(&self, bytes: &mut Vec<u8>) {
-        self.0.f_r.encode(bytes);
-        self.0.g_r.encode(bytes);
-        self.0.h_r.encode(bytes);
+    fn encode(&self, bytes: &mut Vec<u8>) -> Result<(), CodecError> {
+        self.0.f_r.encode(bytes)?;
+        self.0.g_r.encode(bytes)?;
+        self.0.h_r.encode(bytes)
     }
 
     fn encoded_len(&self) -> Option<usize> {
@@ -437,7 +437,7 @@ mod tests {
                 )
                 .unwrap();
 
-            let encoded_prepare_state = prepare_state.get_encoded();
+            let encoded_prepare_state = prepare_state.get_encoded().unwrap();
             let decoded_prepare_state = Prio2PrepareState::get_decoded_with_param(
                 &(&prio2, agg_id),
                 &encoded_prepare_state,
@@ -449,7 +449,7 @@ mod tests {
                 encoded_prepare_state.len()
             );
 
-            let encoded_prepare_share = prepare_share.get_encoded();
+            let encoded_prepare_share = prepare_share.get_encoded().unwrap();
             let decoded_prepare_share =
                 Prio2PrepareShare::get_decoded_with_param(&prepare_state, &encoded_prepare_share)
                     .expect("failed to decode prepare share");

--- a/src/vdaf/prio2/server.rs
+++ b/src/vdaf/prio2/server.rs
@@ -295,8 +295,8 @@ mod tests {
 
         let vdaf = Prio2::new(dim).unwrap();
         let (_, shares) = vdaf.shard(&data, &[0; 16]).unwrap();
-        let share1_original = shares[0].get_encoded();
-        let share2 = shares[1].get_encoded();
+        let share1_original = shares[0].get_encoded().unwrap();
+        let share2 = shares[1].get_encoded().unwrap();
 
         let mut share1_field: Vec<FieldPrio2> = assert_matches!(
             Share::get_decoded_with_param(&ShareDecodingParameter::<32>::Leader(proof_length(dim)), &share1_original),
@@ -316,7 +316,9 @@ mod tests {
         };
 
         // reserialize altered share1
-        let share1_modified = Share::<FieldPrio2, 32>::Leader(share1_field).get_encoded();
+        let share1_modified = Share::<FieldPrio2, 32>::Leader(share1_field)
+            .get_encoded()
+            .unwrap();
 
         let mut prng = Prng::from_prio2_seed(&random());
         let eval_at = vdaf.choose_eval_at(&mut prng);

--- a/src/vdaf/prio2/test_vector.rs
+++ b/src/vdaf/prio2/test_vector.rs
@@ -55,7 +55,9 @@ mod base64 {
     };
     use assert_matches::assert_matches;
     use base64::{engine::Engine, prelude::BASE64_STANDARD};
-    use serde::{de::Error, Deserialize, Deserializer, Serialize, Serializer};
+    use serde::{
+        de::Error as _, ser::Error as _, Deserialize, Deserializer, Serialize, Serializer,
+    };
 
     pub fn serialize_bytes<S: Serializer>(v: &[Vec<u8>], s: S) -> Result<S::Ok, S::Error> {
         let base64_vec = v
@@ -68,24 +70,28 @@ mod base64 {
     pub fn deserialize_bytes<'de, D: Deserializer<'de>>(d: D) -> Result<Vec<Vec<u8>>, D::Error> {
         <Vec<String>>::deserialize(d)?
             .iter()
-            .map(|s| BASE64_STANDARD.decode(s.as_bytes()).map_err(Error::custom))
+            .map(|s| {
+                BASE64_STANDARD
+                    .decode(s.as_bytes())
+                    .map_err(D::Error::custom)
+            })
             .collect()
     }
 
     pub fn serialize_field<S: Serializer>(v: &[FieldPrio2], s: S) -> Result<S::Ok, S::Error> {
         let mut bytes = Vec::new();
-        encode_fieldvec(v, &mut bytes);
+        encode_fieldvec(v, &mut bytes).map_err(S::Error::custom)?;
         String::serialize(&BASE64_STANDARD.encode(&bytes), s)
     }
 
     pub fn deserialize_field<'de, D: Deserializer<'de>>(d: D) -> Result<Vec<FieldPrio2>, D::Error> {
         let bytes = BASE64_STANDARD
             .decode(String::deserialize(d)?.as_bytes())
-            .map_err(Error::custom)?;
+            .map_err(D::Error::custom)?;
         let decoding_parameter =
             ShareDecodingParameter::<32>::Leader(bytes.len() / FieldPrio2::ENCODED_SIZE);
         let share = Share::<FieldPrio2, 32>::get_decoded_with_param(&decoding_parameter, &bytes)
-            .map_err(Error::custom)?;
+            .map_err(D::Error::custom)?;
         assert_matches!(share, Share::Leader(vec) => Ok(vec))
     }
 }

--- a/src/vdaf/prio3_test.rs
+++ b/src/vdaf/prio3_test.rs
@@ -88,7 +88,7 @@ where
             "#{test_num}"
         );
         assert_eq!(
-            input_shares[agg_id].get_encoded(),
+            input_shares[agg_id].get_encoded().unwrap(),
             want.as_ref(),
             "#{test_num}"
         )
@@ -112,14 +112,18 @@ where
                 .unwrap_or_else(|e| err!(test_num, e, "decode test vector (prep share)")),
             "#{test_num}"
         );
-        assert_eq!(prep_shares[i].get_encoded(), want.as_ref(), "#{test_num}");
+        assert_eq!(
+            prep_shares[i].get_encoded().unwrap(),
+            want.as_ref(),
+            "#{test_num}"
+        );
     }
 
     let inbound = prio3
         .prepare_shares_to_prepare_message(&(), prep_shares)
         .unwrap_or_else(|e| err!(test_num, e, "prep preprocess"));
     assert_eq!(t.prep_messages.len(), 1);
-    assert_eq!(inbound.get_encoded(), t.prep_messages[0].as_ref());
+    assert_eq!(inbound.get_encoded().unwrap(), t.prep_messages[0].as_ref());
 
     let mut out_shares = Vec::new();
     for state in states.iter_mut() {
@@ -132,7 +136,11 @@ where
     }
 
     for (got, want) in out_shares.iter().zip(t.out_shares.iter()) {
-        let got: Vec<Vec<u8>> = got.as_ref().iter().map(|x| x.get_encoded()).collect();
+        let got: Vec<Vec<u8>> = got
+            .as_ref()
+            .iter()
+            .map(|x| x.get_encoded().unwrap())
+            .collect();
         assert_eq!(got.len(), want.len());
         for (got_elem, want_elem) in got.iter().zip(want.iter()) {
             assert_eq!(got_elem.as_slice(), want_elem.as_ref());
@@ -169,7 +177,7 @@ where
         .collect::<Vec<_>>();
 
     for (got, want) in aggregate_shares.iter().zip(t.agg_shares.iter()) {
-        let got = got.get_encoded();
+        let got = got.get_encoded().unwrap();
         assert_eq!(got.as_slice(), want.as_ref());
     }
 

--- a/src/vdaf/xof.rs
+++ b/src/vdaf/xof.rs
@@ -82,8 +82,9 @@ impl<const SEED_SIZE: usize> ConstantTimeEq for Seed<SEED_SIZE> {
 }
 
 impl<const SEED_SIZE: usize> Encode for Seed<SEED_SIZE> {
-    fn encode(&self, bytes: &mut Vec<u8>) {
+    fn encode(&self, bytes: &mut Vec<u8>) -> Result<(), CodecError> {
         bytes.extend_from_slice(&self.0[..]);
+        Ok(())
     }
 
     fn encoded_len(&self) -> Option<usize> {


### PR DESCRIPTION
This implements and resolves #675. `Encode::encode` and friends may now return an error. Specifically, an error is returned from code in this library if a vector of sub-messages is too long for a given size of length prefix.