### PR TITLE
Fix infallible conversion Clippy lint

### DIFF
--- a/src/idpf.rs
+++ b/src/idpf.rs
@@ -954,7 +954,7 @@ impl IdpfCache for RingBufferCache {
 mod tests {
     use std::{
         collections::HashMap,
-        convert::{TryFrom, TryInto},
+        convert::TryInto,
         io::Cursor,
         ops::{Add, AddAssign, Sub},
         str::FromStr,
@@ -1571,16 +1571,16 @@ mod tests {
                     seed: [0xab; 16],
                     control_bits: [Choice::from(1), Choice::from(0)],
                     value: Poplar1IdpfValue::new([
-                        Field64::try_from(83261u64).unwrap(),
-                        Field64::try_from(125159u64).unwrap(),
+                        Field64::from(83261u64),
+                        Field64::from(125159u64),
                     ]),
                 },
                 IdpfCorrectionWord{
                     seed: [0xcd;16],
                     control_bits: [Choice::from(0), Choice::from(1)],
                     value: Poplar1IdpfValue::new([
-                        Field64::try_from(17614120u64).unwrap(),
-                        Field64::try_from(20674u64).unwrap(),
+                        Field64::from(17614120u64),
+                        Field64::from(20674u64),
                     ]),
                 },
             ]),


### PR DESCRIPTION
This fixes a Clippy lint surfaced with the latest Rust toolchain.