### PR TITLE
Change Prio3Count::Measurement to bool

### DIFF
--- a/benches/cycle_counts.rs
+++ b/benches/cycle_counts.rs
@@ -97,7 +97,7 @@ fn prio2_shard_and_prepare_1000() -> Prio2PrepareShare {
 
 fn prio3_client_count() -> Vec<Prio3InputShare<Field64, 16>> {
     let prio3 = Prio3::new_count(2).unwrap();
-    let measurement = 1;
+    let measurement = true;
     let nonce = [0; 16];
     prio3
         .shard(&black_box(measurement), &black_box(nonce))

--- a/benches/speed_tests.rs
+++ b/benches/speed_tests.rs
@@ -164,14 +164,14 @@ fn prio3(c: &mut Criterion) {
 
     c.bench_function("prio3count_shard", |b| {
         let vdaf = Prio3::new_count(num_shares).unwrap();
-        let measurement = black_box(1);
+        let measurement = black_box(true);
         let nonce = black_box([0u8; 16]);
         b.iter(|| vdaf.shard(&measurement, &nonce).unwrap());
     });
 
     c.bench_function("prio3count_prepare_init", |b| {
         let vdaf = Prio3::new_count(num_shares).unwrap();
-        let measurement = black_box(1);
+        let measurement = black_box(true);
         let nonce = black_box([0u8; 16]);
         let verify_key = black_box([0u8; 16]);
         let (public_share, input_shares) = vdaf.shard(&measurement, &nonce).unwrap();

--- a/binaries/src/bin/vdaf_message_sizes.rs
+++ b/binaries/src/bin/vdaf_message_sizes.rs
@@ -18,7 +18,7 @@ fn main() {
     let nonce = [0; 16];
 
     let prio3 = Prio3::new_count(num_shares).unwrap();
-    let measurement = 1;
+    let measurement = true;
     println!(
         "prio3 count share size = {}",
         vdaf_input_share_size::<Prio3Count, 16>(prio3.shard(&measurement, &nonce).unwrap())

--- a/src/flp.rs
+++ b/src/flp.rs
@@ -24,7 +24,7 @@
 //!
 //! // The prover chooses a measurement.
 //! let count = Count::new();
-//! let input: Vec<Field64> = count.encode_measurement(&0).unwrap();
+//! let input: Vec<Field64> = count.encode_measurement(&false).unwrap();
 //!
 //! // The prover and verifier agree on "joint randomness" used to generate and
 //! // check the proof. The application needs to ensure that the prover
@@ -176,7 +176,7 @@ pub trait Type: Sized + Eq + Clone + Debug {
     /// use prio::field::{random_vector, FieldElement, Field64};
     ///
     /// let count = Count::new();
-    /// let input: Vec<Field64> = count.encode_measurement(&1).unwrap();
+    /// let input: Vec<Field64> = count.encode_measurement(&true).unwrap();
     /// let joint_rand = random_vector(count.joint_rand_len()).unwrap();
     /// let v = count.valid(&mut count.gadget(), &input, &joint_rand, 1).unwrap();
     /// assert_eq!(v, Field64::zero());

--- a/src/vdaf/prio3.rs
+++ b/src/vdaf/prio3.rs
@@ -330,7 +330,7 @@ impl Prio3Average {
 /// let mut out_shares = vec![vec![]; num_shares.into()];
 /// let mut rng = thread_rng();
 /// let verify_key = rng.gen();
-/// let measurements = [0, 1, 1, 1, 0];
+/// let measurements = [false, true, true, true, false];
 /// for measurement in measurements {
 ///     // Shard
 ///     let nonce = rng.gen::<[u8; 16]>();
@@ -1594,24 +1594,27 @@ mod tests {
     fn test_prio3_count() {
         let prio3 = Prio3::new_count(2).unwrap();
 
-        assert_eq!(run_vdaf(&prio3, &(), [1, 0, 0, 1, 1]).unwrap(), 3);
+        assert_eq!(
+            run_vdaf(&prio3, &(), [true, false, false, true, true]).unwrap(),
+            3
+        );
 
         let mut nonce = [0; 16];
         let mut verify_key = [0; 16];
         thread_rng().fill(&mut verify_key[..]);
         thread_rng().fill(&mut nonce[..]);
 
-        let (public_share, input_shares) = prio3.shard(&0, &nonce).unwrap();
+        let (public_share, input_shares) = prio3.shard(&false, &nonce).unwrap();
         run_vdaf_prepare(&prio3, &verify_key, &(), &nonce, public_share, input_shares).unwrap();
 
-        let (public_share, input_shares) = prio3.shard(&1, &nonce).unwrap();
+        let (public_share, input_shares) = prio3.shard(&true, &nonce).unwrap();
         run_vdaf_prepare(&prio3, &verify_key, &(), &nonce, public_share, input_shares).unwrap();
 
-        test_serialization(&prio3, &1, &nonce).unwrap();
+        test_serialization(&prio3, &true, &nonce).unwrap();
 
         let prio3_extra_helper = Prio3::new_count(3).unwrap();
         assert_eq!(
-            run_vdaf(&prio3_extra_helper, &(), [1, 0, 0, 1, 1]).unwrap(),
+            run_vdaf(&prio3_extra_helper, &(), [true, false, false, true, true]).unwrap(),
             3,
         );
     }


### PR DESCRIPTION
This changes the `Measurement` associated type of `Prio3Count` from `u64` to `bool`. This will be a bit more ergonomic for clients and more strongly typed. Closes #302.