### PR TITLE
Eliminate prio2 Cargo feature

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -55,7 +55,6 @@ zipf = "7.0.1"
 default = ["crypto-dependencies"]
 experimental = ["bitvec", "fiat-crypto", "fixed", "num-bigint", "num-rational", "num-traits", "num-integer", "num-iter", "rand"]
 multithreaded = ["rayon"]
-prio2 = ["crypto-dependencies"]
 crypto-dependencies = ["aes", "ctr", "hmac", "sha2"]
 test-util = ["hex", "rand", "serde_json"]
 

--- a/README.md
+++ b/README.md
@@ -75,4 +75,3 @@ This crate defines the following feature flags:
 |`crypto-dependencies`|Yes|Enables dependencies on various RustCrypto crates, and uses them to implement `XofTurboShake128` to support VDAFs.|
 |`experimental`|No|Certain experimental APIs are guarded by this feature. They may undergo breaking changes in future patch releases, as an exception to semantic versioning.|
 |`multithreaded`|No|Enables certain Prio3 VDAF implementations that use `rayon` for parallelization of gadget evaluations.|
-|`prio2`|No|Enables the Prio v2 API, and a VDAF based on the Prio2 system.|

--- a/benches/cycle_counts.rs
+++ b/benches/cycle_counts.rs
@@ -5,15 +5,12 @@ use iai::black_box;
 #[cfg(feature = "experimental")]
 use prio::{
     codec::{Decode, Encode, ParameterizedDecode},
-    field::{Field255, FieldElement},
+    field::{Field255, FieldElement, FieldPrio2},
     idpf::{Idpf, IdpfInput, IdpfPublicShare, RingBufferCache},
-    vdaf::{poplar1::Poplar1IdpfValue, xof::Seed},
-};
-#[cfg(feature = "prio2")]
-use prio::{
-    field::FieldPrio2,
     vdaf::{
+        poplar1::Poplar1IdpfValue,
         prio2::{Prio2, Prio2PrepareShare},
+        xof::Seed,
         Aggregator, Share,
     },
 };
@@ -45,7 +42,7 @@ fn prng_4096() -> Vec<Field128> {
     prng(4096)
 }
 
-#[cfg(feature = "prio2")]
+#[cfg(feature = "experimental")]
 fn prio2_client(size: usize) -> Vec<Share<FieldPrio2, 32>> {
     let prio2 = Prio2::new(size).unwrap();
     let input = vec![0u32; size];
@@ -53,22 +50,22 @@ fn prio2_client(size: usize) -> Vec<Share<FieldPrio2, 32>> {
     prio2.shard(&black_box(input), &black_box(nonce)).unwrap().1
 }
 
-#[cfg(feature = "prio2")]
+#[cfg(feature = "experimental")]
 fn prio2_client_10() -> Vec<Share<FieldPrio2, 32>> {
     prio2_client(10)
 }
 
-#[cfg(feature = "prio2")]
+#[cfg(feature = "experimental")]
 fn prio2_client_100() -> Vec<Share<FieldPrio2, 32>> {
     prio2_client(100)
 }
 
-#[cfg(feature = "prio2")]
+#[cfg(feature = "experimental")]
 fn prio2_client_1000() -> Vec<Share<FieldPrio2, 32>> {
     prio2_client(1000)
 }
 
-#[cfg(feature = "prio2")]
+#[cfg(feature = "experimental")]
 fn prio2_shard_and_prepare(size: usize) -> Prio2PrepareShare {
     let prio2 = Prio2::new(size).unwrap();
     let input = vec![0u32; size];
@@ -80,17 +77,17 @@ fn prio2_shard_and_prepare(size: usize) -> Prio2PrepareShare {
         .1
 }
 
-#[cfg(feature = "prio2")]
+#[cfg(feature = "experimental")]
 fn prio2_shard_and_prepare_10() -> Prio2PrepareShare {
     prio2_shard_and_prepare(10)
 }
 
-#[cfg(feature = "prio2")]
+#[cfg(feature = "experimental")]
 fn prio2_shard_and_prepare_100() -> Prio2PrepareShare {
     prio2_shard_and_prepare(100)
 }
 
-#[cfg(feature = "prio2")]
+#[cfg(feature = "experimental")]
 fn prio2_shard_and_prepare_1000() -> Prio2PrepareShare {
     prio2_shard_and_prepare(1000)
 }
@@ -261,34 +258,10 @@ macro_rules! main_base {
     };
 }
 
-#[cfg(feature = "prio2")]
-macro_rules! main_add_prio2 {
-    ( $( $func_name:ident ),* $(,)* ) => {
-        main_base!(
-            prio2_client_10,
-            prio2_client_100,
-            prio2_client_1000,
-            prio2_shard_and_prepare_10,
-            prio2_shard_and_prepare_100,
-            prio2_shard_and_prepare_1000,
-            $( $func_name, )*
-        );
-    };
-}
-
-#[cfg(not(feature = "prio2"))]
-macro_rules! main_add_prio2 {
-    ( $( $func_name:ident ),* $(,)* ) => {
-        main_base!(
-            $( $func_name, )*
-        );
-    };
-}
-
 #[cfg(feature = "multithreaded")]
 macro_rules! main_add_multithreaded {
     ( $( $func_name:ident ),* $(,)* ) => {
-        main_add_prio2!(
+        main_base!(
             prio3_client_count_vec_multithreaded_1000,
             $( $func_name, )*
         );
@@ -298,7 +271,7 @@ macro_rules! main_add_multithreaded {
 #[cfg(not(feature = "multithreaded"))]
 macro_rules! main_add_multithreaded {
     ( $( $func_name:ident ),* $(,)* ) => {
-        main_add_prio2!(
+        main_base!(
             $( $func_name, )*
         );
     };
@@ -308,6 +281,12 @@ macro_rules! main_add_multithreaded {
 macro_rules! main_add_experimental {
     ( $( $func_name:ident ),* $(,)* ) => {
         main_add_multithreaded!(
+            prio2_client_10,
+            prio2_client_100,
+            prio2_client_1000,
+            prio2_shard_and_prepare_10,
+            prio2_shard_and_prepare_100,
+            prio2_shard_and_prepare_1000,
             idpf_codec,
             idpf_poplar_gen_8,
             idpf_poplar_gen_128,

--- a/benches/speed_tests.rs
+++ b/benches/speed_tests.rs
@@ -15,7 +15,7 @@ use num_rational::Ratio;
 use num_traits::ToPrimitive;
 #[cfg(feature = "experimental")]
 use prio::dp::distributions::DiscreteGaussian;
-#[cfg(feature = "prio2")]
+#[cfg(feature = "experimental")]
 use prio::vdaf::prio2::Prio2;
 use prio::{
     benchmarked::*,
@@ -116,7 +116,7 @@ fn poly_mul(c: &mut Criterion) {
 }
 
 /// Benchmark prio2.
-#[cfg(feature = "prio2")]
+#[cfg(feature = "experimental")]
 fn prio2(c: &mut Criterion) {
     let mut group = c.benchmark_group("prio2_shard");
     for input_length in [10, 100, 1_000] {
@@ -864,13 +864,9 @@ fn poplar1_generate_zipf_distributed_batch(
     (samples, prefix_tree)
 }
 
-#[cfg(all(feature = "prio2", feature = "experimental"))]
+#[cfg(feature = "experimental")]
 criterion_group!(benches, poplar1, prio3, prio2, poly_mul, prng, idpf, dp_noise);
-#[cfg(all(not(feature = "prio2"), feature = "experimental"))]
-criterion_group!(benches, poplar1, prio3, poly_mul, prng, idpf, dp_noise);
-#[cfg(all(feature = "prio2", not(feature = "experimental")))]
-criterion_group!(benches, prio3, prio2, prng, poly_mul);
-#[cfg(all(not(feature = "prio2"), not(feature = "experimental")))]
+#[cfg(not(feature = "experimental"))]
 criterion_group!(benches, prio3, prng, poly_mul);
 
 criterion_main!(benches);

--- a/binaries/Cargo.toml
+++ b/binaries/Cargo.toml
@@ -10,4 +10,4 @@ repository = "https://github.com/divviup/libprio-rs"
 base64 = "0.21.6"
 fixed = "1.23"
 fixed-macro = "1.2.0"
-prio = { path = "..", features = ["prio2", "experimental"] }
+prio = { path = "..", features = ["experimental"] }

--- a/src/flp.rs
+++ b/src/flp.rs
@@ -545,6 +545,7 @@ pub trait Type: Sized + Eq + Clone + Debug {
 
 /// A type which supports adding noise to aggregate shares for Server Differential Privacy.
 #[cfg(feature = "experimental")]
+#[cfg_attr(docsrs, doc(cfg(feature = "experimental")))]
 pub trait TypeWithNoise<S>: Type
 where
     S: DifferentialPrivacyStrategy,
@@ -749,11 +750,13 @@ pub(crate) fn gadget_poly_len(gadget_degree: usize, wire_poly_len: usize) -> usi
 
 /// Utilities for testing FLPs.
 #[cfg(feature = "test-util")]
+#[cfg_attr(docsrs, doc(cfg(feature = "test-util")))]
 pub mod test_utils {
     use super::*;
     use crate::field::{random_vector, FieldElement, FieldElementWithInteger};
 
     /// Various tests for an FLP.
+    #[cfg_attr(docsrs, doc(cfg(feature = "test-util")))]
     pub struct FlpTest<'a, T: Type> {
         /// The FLP.
         pub flp: &'a T,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -17,6 +17,7 @@
 pub mod benchmarked;
 pub mod codec;
 #[cfg(feature = "experimental")]
+#[cfg_attr(docsrs, doc(cfg(feature = "experimental")))]
 pub mod dp;
 mod fft;
 pub mod field;

--- a/src/polynomial.rs
+++ b/src/polynomial.rs
@@ -3,7 +3,7 @@
 
 //! Functions for polynomial interpolation and evaluation
 
-#[cfg(feature = "prio2")]
+#[cfg(all(feature = "crypto-dependencies", feature = "experimental"))]
 use crate::fft::{discrete_fourier_transform, discrete_fourier_transform_inv_finish};
 use crate::field::FftFriendlyFieldElement;
 
@@ -204,7 +204,7 @@ pub fn poly_mul<F: FftFriendlyFieldElement>(p: &[F], q: &[F]) -> Vec<F> {
     out
 }
 
-#[cfg(feature = "prio2")]
+#[cfg(all(feature = "crypto-dependencies", feature = "experimental"))]
 #[inline]
 pub fn poly_interpret_eval<F: FftFriendlyFieldElement>(
     points: &[F],

--- a/src/vdaf.rs
+++ b/src/vdaf.rs
@@ -72,18 +72,6 @@ pub enum Share<F, const SEED_SIZE: usize> {
     Helper(Seed<SEED_SIZE>),
 }
 
-impl<F: Clone, const SEED_SIZE: usize> Share<F, SEED_SIZE> {
-    /// Truncate the Leader's share to the given length. If this is the Helper's share, then this
-    /// method clones the input without modifying it.
-    #[cfg(feature = "prio2")]
-    pub(crate) fn truncated(&self, len: usize) -> Self {
-        match self {
-            Self::Leader(ref data) => Self::Leader(data[..len].to_vec()),
-            Self::Helper(ref seed) => Self::Helper(seed.clone()),
-        }
-    }
-}
-
 impl<F: ConstantTimeEq, const SEED_SIZE: usize> PartialEq for Share<F, SEED_SIZE> {
     fn eq(&self, other: &Self) -> bool {
         self.ct_eq(other).into()
@@ -719,8 +707,11 @@ pub mod dummy;
     doc(cfg(all(feature = "crypto-dependencies", feature = "experimental")))
 )]
 pub mod poplar1;
-#[cfg(feature = "prio2")]
-#[cfg_attr(docsrs, doc(cfg(feature = "prio2")))]
+#[cfg(all(feature = "crypto-dependencies", feature = "experimental"))]
+#[cfg_attr(
+    docsrs,
+    doc(cfg(all(feature = "crypto-dependencies", feature = "experimental")))
+)]
 pub mod prio2;
 pub mod prio3;
 #[cfg(any(test, feature = "test-util"))]

--- a/src/vdaf.rs
+++ b/src/vdaf.rs
@@ -288,6 +288,7 @@ pub trait Aggregator<const VERIFY_KEY_SIZE: usize, const NONCE_SIZE: usize>: Vda
 
 /// Aggregator that implements differential privacy with Aggregator-side noise addition.
 #[cfg(feature = "experimental")]
+#[cfg_attr(docsrs, doc(cfg(feature = "experimental")))]
 pub trait AggregatorWithNoise<
     const VERIFY_KEY_SIZE: usize,
     const NONCE_SIZE: usize,
@@ -700,6 +701,7 @@ mod tests {
 }
 
 #[cfg(feature = "test-util")]
+#[cfg_attr(docsrs, doc(cfg(feature = "test-util")))]
 pub mod dummy;
 #[cfg(all(feature = "crypto-dependencies", feature = "experimental"))]
 #[cfg_attr(
@@ -715,5 +717,6 @@ pub mod poplar1;
 pub mod prio2;
 pub mod prio3;
 #[cfg(any(test, feature = "test-util"))]
+#[cfg_attr(docsrs, doc(cfg(feature = "test-util")))]
 pub mod prio3_test;
 pub mod xof;

--- a/src/vdaf/prio2.rs
+++ b/src/vdaf/prio2.rs
@@ -88,8 +88,13 @@ impl Prio2 {
         )
         .map_err(|e| VdafError::Uncategorized(e.to_string()))?;
 
+        let truncated_share = match input_share {
+            Share::Leader(data) => Share::Leader(data[..self.input_len].to_vec()),
+            Share::Helper(seed) => Share::Helper(seed.clone()),
+        };
+
         Ok((
-            Prio2PrepareState(input_share.truncated(self.input_len)),
+            Prio2PrepareState(truncated_share),
             Prio2PrepareShare(verifier_share),
         ))
     }

--- a/src/vdaf/prio3_test.rs
+++ b/src/vdaf/prio3_test.rs
@@ -194,6 +194,7 @@ where
 /// This version allows customizing the deserialization of measurements, via an additional type
 /// parameter.
 #[cfg(feature = "test-util")]
+#[cfg_attr(docsrs, doc(cfg(feature = "test-util")))]
 pub fn check_test_vec_custom_de<MS, MP, A, T, P, const SEED_SIZE: usize>(
     test_vec_json_str: &str,
     new_vdaf: impl Fn(&HashMap<String, serde_json::Value>, u8) -> Prio3<T, P, SEED_SIZE>,
@@ -213,6 +214,7 @@ pub fn check_test_vec_custom_de<MS, MP, A, T, P, const SEED_SIZE: usize>(
 /// Evaluate a Prio3 test vector. The instance of Prio3 is constructed from the `new_vdaf` callback,
 /// which takes in the VDAF parameters encoded by the test vectors and the number of shares.
 #[cfg(feature = "test-util")]
+#[cfg_attr(docsrs, doc(cfg(feature = "test-util")))]
 pub fn check_test_vec<M, A, T, P, const SEED_SIZE: usize>(
     test_vec_json_str: &str,
     new_vdaf: impl Fn(&HashMap<String, serde_json::Value>, u8) -> Prio3<T, P, SEED_SIZE>,

--- a/src/vdaf/xof.rs
+++ b/src/vdaf/xof.rs
@@ -452,6 +452,7 @@ impl RngCore for SeedStreamFixedKeyAes128 {
 
 /// XOF based on HMAC-SHA256 and AES128. This XOF is not part of the VDAF spec.
 #[cfg(feature = "crypto-dependencies")]
+#[cfg_attr(docsrs, doc(cfg(feature = "crypto-dependencies")))]
 #[derive(Clone, Debug)]
 pub struct XofHmacSha256Aes128(Hmac<Sha256>);
 


### PR DESCRIPTION
This implements #902. I also inlined one Prio2-specific method that lived in `src/vdaf.rs` and was called once, and did a pass to update `doc(cfg)` attributes that were missing throughout the codebase.