### PR TITLE
Add workflow for automatically generating release

### DIFF
--- a/.github/workflows/make-release.yml
+++ b/.github/workflows/make-release.yml
@@ -45,10 +45,12 @@ jobs:
       - run: cargo set-version --package prio --bump patch
       - run: git diff
       - name: Push changes
+        env:
+          ACTOR: '${{ github.actor }}'
         run: |
           git config user.email "divviup-github-automation@divviup.org"
           git config user.name "divviup-github-automation"
-          git commit -am "Bump libprio-rs patch version, triggered by @${{ github.actor }}"
+          git commit -am "Bump libprio-rs patch version, triggered by @$ACTOR"
           git push
 
   # This job is kept separate from the previous one to enable retrying it without
@@ -71,11 +73,13 @@ jobs:
           toolchain: stable
 
       - name: Create release
+        env:
+          GH_TOKEN: '${{ secrets.INAHGA_TEST }}'
+          TARGET_BRANCH: '${{ matrix.target_branch }}'
+          FIRST_BRANCH: '${{ fromJSON(inputs.target_branch)[0] }}'
         run: |
           # Determine the workspace version.
-          VERSION=$(cargo metadata --no-deps --format-version 1 | jq -er '.packages[0].version')
-          TARGET_BRANCH="${{ matrix.target_branch }}"
-          FIRST_BRANCH="${{ fromJSON(inputs.target_branch)[0] }}"
+          VERSION=$(cargo metadata --no-deps | jq -er '.packages[0].version')
 
           LATEST=
           if [ "$TARGET_BRANCH" == "$FIRST_BRANCH" ]; then
@@ -88,5 +92,3 @@ jobs:
               --generate-notes \
               --target "$TARGET_BRANCH" \
               $LATEST
-        env:
-          GH_TOKEN: '${{ secrets.DIVVIUP_GITHUB_AUTOMATION_RELEASE_PAT }}'

--- a/.github/workflows/make-release.yml
+++ b/.github/workflows/make-release.yml
@@ -1,0 +1,92 @@
+name: make-release
+
+on:
+  workflow_dispatch:
+    inputs:
+      target_branch:
+        description: >-
+          JSON array of branches to target. The first branch in the array will
+          be marked as the latest release.
+        required: false
+        type: string
+        default: '["main","release/0.15","release/0.12"]'
+
+jobs:
+  bump-version:
+    strategy:
+      matrix:
+        target_branch: ${{ fromJSON(inputs.target_branch) }}
+    runs-on: ubuntu-latest
+    env:
+      CARGO_EDIT_VERSION: 0.12.2
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          ref: '${{ matrix.target_branch }}'
+          token: '${{ secrets.DIVVIUP_GITHUB_AUTOMATION_RELEASE_PAT }}'
+
+      - name: Install Rust toolchain
+        uses: dtolnay/rust-toolchain@stable
+
+      - name: Cache cargo edit
+        uses: actions/cache@v4
+        with:
+          path: ${{ runner.tool_cache }}/cargo-edit
+          key: cargo-edit-${{ env.CARGO_EDIT_VERSION }}
+      - name: Add the tool cache directory to the search path
+        run: echo "${{ runner.tool_cache }}/cargo-edit/bin/" >>$GITHUB_PATH
+      - name: Ensure cargo-edit is installed
+        run: |
+          cargo install \
+            --root ${{ runner.tool_cache }}/cargo-edit \
+            --version ${{ env.CARGO_EDIT_VERSION }} \
+            cargo-edit
+      
+      - run: cargo set-version --package prio --bump patch
+      - run: git diff
+      - name: Push changes
+        run: |
+          git config user.email "divviup-github-automation@divviup.org"
+          git config user.name "divviup-github-automation"
+          git commit -am "Bump libprio-rs patch version, triggered by @${{ github.actor }}"
+          git push
+
+  # This job is kept separate from the previous one to enable retrying it without
+  # bumping the version number again.
+  make-release:
+    strategy:
+      matrix:
+        target_branch: ${{ fromJSON(inputs.target_branch) }}
+    runs-on: ubuntu-latest
+    needs: [bump-version]
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          ref: '${{ matrix.target_branch }}'
+          token: '${{ secrets.DIVVIUP_GITHUB_AUTOMATION_RELEASE_PAT }}'
+
+      - name: Install Rust toolchain
+        uses: dtolnay/rust-toolchain@master
+        with:
+          toolchain: stable
+
+      - name: Create release
+        run: |
+          # Determine the workspace version.
+          VERSION=$(cargo metadata --no-deps --format-version 1 | jq -er '.packages[0].version')
+          TARGET_BRANCH="${{ matrix.target_branch }}"
+          FIRST_BRANCH="${{ fromJSON(inputs.target_branch)[0] }}"
+
+          LATEST=
+          if [ "$TARGET_BRANCH" == "$FIRST_BRANCH" ]; then
+              LATEST="--latest=true"
+          else
+              LATEST="--latest=false"
+          fi
+
+          gh release create "$VERSION" \
+              --generate-notes \
+              --target "$TARGET_BRANCH" \
+              $LATEST
+        env:
+          GH_TOKEN: '${{ secrets.DIVVIUP_GITHUB_AUTOMATION_RELEASE_PAT }}'

--- a/.github/workflows/make-release.yml
+++ b/.github/workflows/make-release.yml
@@ -74,7 +74,7 @@ jobs:
 
       - name: Create release
         env:
-          GH_TOKEN: '${{ secrets.INAHGA_TEST }}'
+          GH_TOKEN: '${{ secrets.DIVVIUP_GITHUB_AUTOMATION_RELEASE_PAT }}'
           TARGET_BRANCH: '${{ matrix.target_branch }}'
           FIRST_BRANCH: '${{ fromJSON(inputs.target_branch)[0] }}'
         run: |


### PR DESCRIPTION
Similar to https://github.com/divviup/janus/pull/2585, with small changes to the default target branches, and to only target the `prio` crate.