### PR TITLE
Renew wildcard audit of prio

### DIFF
--- a/supply-chain/audits.toml
+++ b/supply-chain/audits.toml
@@ -7,13 +7,14 @@ criteria = "safe-to-deploy"
 user-id = 101233
 start = "2020-09-28"
 end = "2024-03-23"
+renew = false
 
 [[wildcard-audits.prio]]
 who = "David Cook <dcook@divviup.org>"
 criteria = "safe-to-deploy"
 user-id = 213776
 start = "2020-09-28"
-end = "2024-03-23"
+end = "2025-02-12"
 
 [[audits.aes]]
 who = "Brandon Pitman <bran@bran.land>"


### PR DESCRIPTION
This renews the wildcard audit of prio crates published by @divviup-github-automation for another year. I did not renew the wildcard audit for crates published by `le-automaton`, since that isn't used anymore.