### PR TITLE
Re-audit zipf for safe-to-deploy

### DIFF
--- a/supply-chain/audits.toml
+++ b/supply-chain/audits.toml
@@ -694,6 +694,11 @@ criteria = "safe-to-run"
 version = "7.0.0"
 
 [[audits.zipf]]
+who = "David Cook <dcook@divviup.org>"
+criteria = "safe-to-deploy"
+version = "7.0.1"
+
+[[audits.zipf]]
 who = "Tim Geoghegan <timg@divviup.org>"
 criteria = "safe-to-run"
 delta = "7.0.0 -> 7.0.1"


### PR DESCRIPTION
This supports #956.