### PR TITLE
Implement Distribution trait with field elements

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,7 +25,7 @@ num-integer = { version = "0.1.46", optional = true }
 num-iter = { version = "0.1.44", optional = true }
 num-rational = { version = "0.4.1", optional = true, features = ["serde"] }
 num-traits = { version = "0.2.18", optional = true }
-rand = { version = "0.8", optional = true }
+rand = "0.8"
 rand_core = "0.6.4"
 rayon = { version = "1.10.0", optional = true }
 serde = { version = "1.0", features = ["derive"] }
@@ -48,15 +48,14 @@ modinverse = "0.1.0"
 num-bigint = "0.4.4"
 once_cell = "1.19.0"
 prio = { path = ".", features = ["crypto-dependencies", "test-util"] }
-rand = "0.8"
 statrs = "0.16.0"
 
 [features]
 default = ["crypto-dependencies"]
-experimental = ["bitvec", "fiat-crypto", "fixed", "num-bigint", "num-rational", "num-traits", "num-integer", "num-iter", "rand"]
+experimental = ["bitvec", "fiat-crypto", "fixed", "num-bigint", "num-rational", "num-traits", "num-integer", "num-iter"]
 multithreaded = ["rayon"]
 crypto-dependencies = ["aes", "ctr", "hmac", "sha2"]
-test-util = ["hex", "rand", "serde_json", "zipf"]
+test-util = ["hex", "serde_json", "zipf"]
 
 [workspace]
 members = [".", "binaries"]

--- a/src/idpf.rs
+++ b/src/idpf.rs
@@ -25,7 +25,7 @@ use std::{
     fmt::Debug,
     io::{Cursor, Read},
     iter::zip,
-    ops::{Add, AddAssign, ControlFlow, Index, Sub},
+    ops::{Add, AddAssign, Index, Sub},
 };
 use subtle::{Choice, ConditionallyNegatable, ConditionallySelectable, ConstantTimeEq};
 
@@ -184,20 +184,7 @@ where
     where
         S: RngCore,
     {
-        // This is analogous to `Prng::get()`, but does not make use of a persistent buffer of
-        // output.
-        let mut buffer = [0u8; 64];
-        assert!(
-            buffer.len() >= F::ENCODED_SIZE,
-            "field is too big for buffer"
-        );
-        loop {
-            seed_stream.fill_bytes(&mut buffer[..F::ENCODED_SIZE]);
-            match F::from_random_rejection(&buffer[..F::ENCODED_SIZE]) {
-                ControlFlow::Break(x) => return x,
-                ControlFlow::Continue(()) => continue,
-            }
-        }
+        F::generate_random(seed_stream)
     }
 
     fn zero(_: &()) -> Self {


### PR DESCRIPTION
This PR moves the body of our `IdpfValue` implementation for field elements to a private method, and re-exposes it via `Distribution<$elem> for Standard` impls. This will let users write `seed_stream.gen()` to get one random field element. As a result, we now unconditionally depend on the `rand` crate, to access its `distributions` module.

This closes #995. cc @cjpatton