### PR TITLE
CI runs only on divviup repository

### DIFF
--- a/.github/workflows/ci-build.yml
+++ b/.github/workflows/ci-build.yml
@@ -12,6 +12,7 @@ env:
 
 jobs:
   docs:
+    if: github.repository_owner == 'divviup'
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v4
@@ -23,6 +24,7 @@ jobs:
         RUSTDOCFLAGS: -Dwarnings
 
   build-binaries:
+    if: github.repository_owner == 'divviup'
     strategy:
       matrix:
         rust-toolchain: [
@@ -44,6 +46,7 @@ jobs:
       run: cargo clippy --package prio-binaries
 
   build-crate:
+    if: github.repository_owner == 'divviup'
     strategy:
       matrix:
         rust-toolchain: [

--- a/.github/workflows/publish-crate.yml
+++ b/.github/workflows/publish-crate.yml
@@ -6,6 +6,7 @@ on:
 
 jobs:
   crate:
+    if: github.repository_owner == 'divviup'
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v4

--- a/.github/workflows/supply-chain.yml
+++ b/.github/workflows/supply-chain.yml
@@ -13,6 +13,7 @@ on:
 
 jobs:
   vet:
+    if: github.repository_owner == 'divviup'
     name: Vet Dependencies
     runs-on: ubuntu-latest
     env:


### PR DESCRIPTION
This prevents from running CI jobs in forks (which may have CI limitations).

