### PR TITLE
Reimplement bitrev() using a compiler intrinsic

### DIFF
--- a/benches/speed_tests.rs
+++ b/benches/speed_tests.rs
@@ -86,7 +86,7 @@ pub fn dp_noise(c: &mut Criterion) {
 /// for small polynomials. The result is used to pick the `FFT_THRESHOLD` constant in
 /// `src/flp/gadgets.rs`.
 fn poly_mul(c: &mut Criterion) {
-    let test_sizes = [1_usize, 30, 60, 90, 120, 150];
+    let test_sizes = [1_usize, 30, 60, 90, 120, 150, 255];
 
     let mut group = c.benchmark_group("poly_mul");
     for size in test_sizes {

--- a/src/fft.rs
+++ b/src/fft.rs
@@ -48,9 +48,13 @@ pub fn discrete_fourier_transform<F: FftFriendlyFieldElement>(
         return Err(FftError::SizeInvalid);
     }
 
-    for (i, outp_val) in outp[..size].iter_mut().enumerate() {
-        let j = bitrev(d, i);
-        *outp_val = if j < inp.len() { inp[j] } else { F::zero() };
+    if d > 0 {
+        for (i, outp_val) in outp[..size].iter_mut().enumerate() {
+            let j = bitrev(d, i);
+            *outp_val = if j < inp.len() { inp[j] } else { F::zero() };
+        }
+    } else {
+        outp[0] = inp[0];
     }
 
     let mut w: F;
@@ -116,11 +120,7 @@ pub(crate) fn discrete_fourier_transform_inv_finish<F: FftFriendlyFieldElement>(
 
 // bitrev returns the first d bits of x in reverse order. (Thanks, OEIS! https://oeis.org/A030109)
 fn bitrev(d: usize, x: usize) -> usize {
-    let mut y = 0;
-    for i in 0..d {
-        y += ((x >> i) & 1) << (d - i);
-    }
-    y >> 1
+    x.reverse_bits() >> (usize::BITS - d as u32)
 }
 
 #[cfg(test)]

--- a/src/flp/gadgets.rs
+++ b/src/flp/gadgets.rs
@@ -17,7 +17,7 @@ use std::marker::PhantomData;
 
 /// For input polynomials larger than or equal to this threshold, gadgets will use FFT for
 /// polynomial multiplication. Otherwise, the gadget uses direct multiplication.
-const FFT_THRESHOLD: usize = 60;
+const FFT_THRESHOLD: usize = 30;
 
 /// An arity-2 gadget that multiples its inputs.
 #[derive(Clone, Debug, Eq, PartialEq)]


### PR DESCRIPTION
I noticed that `bitrev()` was taking up a few percent of a profile when doing preparation of shares from a large Prio3 instance. This PR reimplements that function using the `reverse_bits()` compiler intrinsic. On x86_64, `reverse_bits()` gets compiled down to a `bswap`, then a sequence of ANDs with masks, shifts, and ORs, which swap nibbles, then pairs of bits, then bits. On ARM architectures, it compiles to an `rbit`. Note that I had to add a special case for when the NTT size is 1, and `d` is 0, to avoid an overflow from a too-large shift.

Benchmark results are below, using an x86_64 processor. I see up to 10% improvement in polynomial multiplication itself, and 5%-8% improvements in Prio3 with medium to larger circuit sizes. (both in Criterion and Cachegrind)

<details><summary>Benchmark results</summary>

<pre><font color="#26A269"><b>   Compiling</b></font> prio v0.16.2 (/home/david/Code/ppm/libprio-rs)
<font color="#26A269"><b>    Finished</b></font> bench [optimized] target(s) in 19.51s
<font color="#26A269"><b>     Running</b></font> benches/cycle_counts.rs (target/release/deps/cycle_counts-5133e5cd3f206d1f)
prng_16
  Instructions:               21517 (No change)
  L1 Accesses:                29649 (-0.013489%)
  L2 Accesses:                   45 (+15.38462%)
  RAM Accesses:                 125 (-1.574803%)
  Estimated Cycles:           34249 (-0.128306%)

prng_256
  Instructions:              137292 (No change)
  L1 Accesses:               188741 (+0.000530%)
  L2 Accesses:                   51 (+2.000000%)
  RAM Accesses:                 196 (-1.010101%)
  Estimated Cycles:          195856 (-0.032666%)

prng_1024
  Instructions:              524154 (No change)
  L1 Accesses:               720583 (+0.000278%)
  L2 Accesses:                   81 (-1.219512%)
  RAM Accesses:                 389 (-0.256410%)
  Estimated Cycles:          734603 (-0.005173%)

prng_4096
  Instructions:             2073325 (No change)
  L1 Accesses:              2850432 (No change)
  L2 Accesses:                  144 (+1.408451%)
  RAM Accesses:                1157 (-0.172563%)
  Estimated Cycles:         2891647 (-0.002075%)

prio3_client_count
  Instructions:               64313 (+0.024885%)
  L1 Accesses:                81632 (+0.009801%)
  L2 Accesses:                   79 (+9.722222%)
  RAM Accesses:                 374 (-1.319261%)
  Estimated Cycles:           95117 (-0.138584%)

prio3_client_histogram_10
  Instructions:              241092 (-0.238344%)
  L1 Accesses:               299063 (-0.287405%)
  L2 Accesses:                  119 (+2.586207%)
  RAM Accesses:                 544 (+0.184162%)
  Estimated Cycles:          318698 (-0.254139%)

prio3_client_sum_32
  Instructions:              305448 (-0.562544%)
  L1 Accesses:               385120 (-0.501728%)
  L2 Accesses:                   98 (-3.921569%)
  RAM Accesses:                 560 (-0.884956%)
  Estimated Cycles:          405210 (-0.524614%)

prio3_client_count_vec_1000
  Instructions:            10196188 (-9.572059%)
  L1 Accesses:             12644489 (-8.968731%)
  L2 Accesses:                 4182 (-0.095557%)
  RAM Accesses:                3036 (-0.393701%)
  Estimated Cycles:        12771659 (-8.890224%)

<font color="#26A269"><b>     Running</b></font> benches/speed_tests.rs (target/release/deps/speed_tests-bed856efc3eab923)
<font color="#26A269">prio3count_shard</font>        time:   [19.276 µs <b>19.287 µs</b> 19.301 µs]
                        change: [-0.2032% +0.3423% +1.0869%] (p = 0.30 &gt; 0.05)
                        No change in performance detected.
<font color="#A2734C">Found 14 outliers among 100 measurements (14.00%)</font>
  4 (4.00%) high mild
  10 (10.00%) high severe

<font color="#26A269">prio3count_prepare_init</font> time:   [12.983 µs <b>12.984 µs</b> 12.986 µs]
                        change: [-0.0255% +0.0508% +0.1105%] (p = 0.15 &gt; 0.05)
                        No change in performance detected.
<font color="#A2734C">Found 8 outliers among 100 measurements (8.00%)</font>
  5 (5.00%) low mild
  2 (2.00%) high mild
  1 (1.00%) high severe

<font color="#26A269">prio3sum_shard/8</font>        time:   [54.570 µs <b>54.576 µs</b> 54.584 µs]
                        change: [-0.8920% -0.4923% -0.0951%] (p = 0.00 &lt; 0.05)
                        Change within noise threshold.
<font color="#A2734C">Found 14 outliers among 100 measurements (14.00%)</font>
  2 (2.00%) low mild
  6 (6.00%) high mild
  6 (6.00%) high severe
<font color="#26A269">prio3sum_shard/32</font>       time:   [114.73 µs <b>114.75 µs</b> 114.76 µs]
                        change: [-3.7436% <font color="#26A269"><b>-3.4195%</b></font> -3.1721%] (p = 0.00 &lt; 0.05)
                        Performance has <font color="#26A269">improved</font>.
<font color="#A2734C">Found 8 outliers among 100 measurements (8.00%)</font>
  5 (5.00%) high mild
  3 (3.00%) high severe

<font color="#26A269">prio3sum_prepare_init/8</font> time:   [36.645 µs <b>36.652 µs</b> 36.659 µs]
                        change: [-1.4062% <font color="#26A269"><b>-1.3453%</b></font> -1.2875%] (p = 0.00 &lt; 0.05)
                        Performance has <font color="#26A269">improved</font>.
<font color="#A2734C">Found 12 outliers among 100 measurements (12.00%)</font>
  2 (2.00%) low mild
  6 (6.00%) high mild
  4 (4.00%) high severe
<font color="#26A269">prio3sum_prepare_init/32</font>
                        time:   [63.930 µs <b>63.946 µs</b> 63.962 µs]
                        change: [-3.7192% <font color="#26A269"><b>-3.5769%</b></font> -3.4687%] (p = 0.00 &lt; 0.05)
                        Performance has <font color="#26A269">improved</font>.
<font color="#A2734C">Found 6 outliers among 100 measurements (6.00%)</font>
  3 (3.00%) low mild
  1 (1.00%) high mild
  2 (2.00%) high severe

<font color="#26A269">prio3sumvec_shard/serial/10</font>
                        time:   [64.299 µs <b>64.307 µs</b> 64.316 µs]
                        change: [-0.1328% +0.1674% +0.4105%] (p = 0.25 &gt; 0.05)
                        No change in performance detected.
<font color="#A2734C">Found 6 outliers among 100 measurements (6.00%)</font>
  1 (1.00%) low mild
  3 (3.00%) high mild
  2 (2.00%) high severe
<font color="#26A269">prio3sumvec_shard/serial/100</font>
                        time:   [190.84 µs <b>191.07 µs</b> 191.58 µs]
                        change: [-1.0428% -0.9358% -0.7647%] (p = 0.00 &lt; 0.05)
                        Change within noise threshold.
<font color="#A2734C">Found 6 outliers among 100 measurements (6.00%)</font>
  1 (1.00%) high mild
  5 (5.00%) high severe
<font color="#26A269">prio3sumvec_shard/serial/1000</font>
                        time:   [2.5150 ms <b>2.5154 ms</b> 2.5158 ms]
                        change: [-6.7462% <font color="#26A269"><b>-6.7235%</b></font> -6.7008%] (p = 0.00 &lt; 0.05)
                        Performance has <font color="#26A269">improved</font>.
<font color="#A2734C">Found 1 outliers among 100 measurements (1.00%)</font>
  1 (1.00%) high mild

<font color="#26A269">prio3sumvec_prepare_init/serial/10</font>
                        time:   [47.060 µs <b>47.076 µs</b> 47.098 µs]
                        change: [-0.5761% -0.4134% -0.2983%] (p = 0.00 &lt; 0.05)
                        Change within noise threshold.
<font color="#A2734C">Found 10 outliers among 100 measurements (10.00%)</font>
  1 (1.00%) low mild
  5 (5.00%) high mild
  4 (4.00%) high severe
<font color="#26A269">prio3sumvec_prepare_init/serial/100</font>
                        time:   [97.600 µs <b>97.623 µs</b> 97.649 µs]
                        change: [-2.5127% <font color="#26A269"><b>-2.4355%</b></font> -2.3505%] (p = 0.00 &lt; 0.05)
                        Performance has <font color="#26A269">improved</font>.
<font color="#A2734C">Found 8 outliers among 100 measurements (8.00%)</font>
  1 (1.00%) low severe
  4 (4.00%) high mild
  3 (3.00%) high severe
<font color="#26A269">prio3sumvec_prepare_init/serial/1000</font>
                        time:   [819.02 µs <b>819.21 µs</b> 819.41 µs]
                        change: [-5.5935% <font color="#26A269"><b>-5.5392%</b></font> -5.4859%] (p = 0.00 &lt; 0.05)
                        Performance has <font color="#26A269">improved</font>.
<font color="#A2734C">Found 9 outliers among 100 measurements (9.00%)</font>
  1 (1.00%) low mild
  4 (4.00%) high mild
  4 (4.00%) high severe

<font color="#26A269">prio3histogram_shard/serial/10</font>
                        time:   [72.620 µs <b>72.632 µs</b> 72.646 µs]
                        change: [-0.2647% -0.1418% -0.0611%] (p = 0.00 &lt; 0.05)
                        Change within noise threshold.
<font color="#A2734C">Found 7 outliers among 100 measurements (7.00%)</font>
  2 (2.00%) high mild
  5 (5.00%) high severe
<font color="#26A269">prio3histogram_shard/serial/100</font>
                        time:   [196.55 µs <b>196.58 µs</b> 196.61 µs]
                        change: [-2.2466% <font color="#26A269"><b>-1.8212%</b></font> -1.5246%] (p = 0.00 &lt; 0.05)
                        Performance has <font color="#26A269">improved</font>.
<font color="#A2734C">Found 5 outliers among 100 measurements (5.00%)</font>
  1 (1.00%) low severe
  1 (1.00%) low mild
  2 (2.00%) high mild
  1 (1.00%) high severe
<font color="#26A269">prio3histogram_shard/serial/1000</font>
                        time:   [2.5097 ms <b>2.5152 ms</b> 2.5238 ms]
                        change: [-6.4880% <font color="#26A269"><b>-6.2815%</b></font> -5.9588%] (p = 0.00 &lt; 0.05)
                        Performance has <font color="#26A269">improved</font>.
<font color="#A2734C">Found 2 outliers among 100 measurements (2.00%)</font>
  2 (2.00%) high severe
<font color="#26A269">prio3histogram_shard/serial/10000</font>
                        time:   [18.602 ms <b>18.606 ms</b> 18.611 ms]
                        change: [-8.1314% <font color="#26A269"><b>-7.9196%</b></font> -7.7908%] (p = 0.00 &lt; 0.05)
                        Performance has <font color="#26A269">improved</font>.
<font color="#A2734C">Found 4 outliers among 100 measurements (4.00%)</font>
  2 (2.00%) low mild
  2 (2.00%) high mild
Benchmarking prio3histogram_shard/serial/100000: Warming up for 3.0000 s
Warning: Unable to complete 100 samples in 15.0s. You may wish to increase target time to 27.8s, or reduce sample count to 50.
<font color="#26A269">prio3histogram_shard/serial/100000</font>
                        time:   [278.10 ms <b>278.21 ms</b> 278.33 ms]
                        change: [-8.5075% <font color="#26A269"><b>-8.4507%</b></font> -8.3957%] (p = 0.00 &lt; 0.05)
                        Performance has <font color="#26A269">improved</font>.
<font color="#A2734C">Found 2 outliers among 100 measurements (2.00%)</font>
  1 (1.00%) high mild
  1 (1.00%) high severe

<font color="#26A269">prio3histogram_prepare_init/serial/10</font>
                        time:   [56.264 µs <b>56.277 µs</b> 56.290 µs]
                        change: [-0.3958% -0.2657% -0.1852%] (p = 0.00 &lt; 0.05)
                        Change within noise threshold.
<font color="#A2734C">Found 4 outliers among 100 measurements (4.00%)</font>
  4 (4.00%) high mild
<font color="#26A269">prio3histogram_prepare_init/serial/100</font>
                        time:   [107.71 µs <b>107.82 µs</b> 107.93 µs]
                        change: [-2.0976% <font color="#26A269"><b>-1.8083%</b></font> -1.4433%] (p = 0.00 &lt; 0.05)
                        Performance has <font color="#26A269">improved</font>.
<font color="#A2734C">Found 6 outliers among 100 measurements (6.00%)</font>
  1 (1.00%) high mild
  5 (5.00%) high severe
<font color="#26A269">prio3histogram_prepare_init/serial/1000</font>
                        time:   [836.84 µs <b>837.61 µs</b> 839.04 µs]
                        change: [-5.2016% <font color="#26A269"><b>-5.1105%</b></font> -4.9614%] (p = 0.00 &lt; 0.05)
                        Performance has <font color="#26A269">improved</font>.
<font color="#A2734C">Found 4 outliers among 100 measurements (4.00%)</font>
  1 (1.00%) low mild
  1 (1.00%) high mild
  2 (2.00%) high severe
<font color="#26A269">prio3histogram_prepare_init/serial/10000</font>
                        time:   [5.9908 ms <b>5.9930 ms</b> 5.9952 ms]
                        change: [-5.3161% <font color="#26A269"><b>-5.2600%</b></font> -5.2020%] (p = 0.00 &lt; 0.05)
                        Performance has <font color="#26A269">improved</font>.
<font color="#A2734C">Found 3 outliers among 100 measurements (3.00%)</font>
  3 (3.00%) high mild
<font color="#26A269">prio3histogram_prepare_init/serial/100000</font>
                        time:   [82.276 ms <b>82.345 ms</b> 82.432 ms]
                        change: [-7.1225% <font color="#26A269"><b>-7.0078%</b></font> -6.8815%] (p = 0.00 &lt; 0.05)
                        Performance has <font color="#26A269">improved</font>.
<font color="#A2734C">Found 6 outliers among 100 measurements (6.00%)</font>
  5 (5.00%) high mild
  1 (1.00%) high severe

<font color="#26A269">rand/16</font>                 time:   [5.5245 µs <b>5.5253 µs</b> 5.5267 µs]
                        change: [-1.4011% <font color="#26A269"><b>-1.2693%</b></font> -1.1788%] (p = 0.00 &lt; 0.05)
                        Performance has <font color="#26A269">improved</font>.
<font color="#A2734C">Found 8 outliers among 100 measurements (8.00%)</font>
  1 (1.00%) low mild
  5 (5.00%) high mild
  2 (2.00%) high severe
<font color="#26A269">rand/256</font>                time:   [29.580 µs <b>29.584 µs</b> 29.587 µs]
                        change: [-0.4399% -0.0590% +0.1605%] (p = 0.81 &gt; 0.05)
                        No change in performance detected.
<font color="#A2734C">Found 10 outliers among 100 measurements (10.00%)</font>
  1 (1.00%) low severe
  3 (3.00%) high mild
  6 (6.00%) high severe
<font color="#26A269">rand/1024</font>               time:   [106.01 µs <b>106.04 µs</b> 106.07 µs]
                        change: [-1.2403% -0.9535% -0.4947%] (p = 0.00 &lt; 0.05)
                        Change within noise threshold.
<font color="#A2734C">Found 12 outliers among 100 measurements (12.00%)</font>
  5 (5.00%) high mild
  7 (7.00%) high severe
<font color="#26A269">rand/4096</font>               time:   [412.71 µs <b>412.80 µs</b> 412.90 µs]
                        change: [-1.6381% <font color="#26A269"><b>-1.3841%</b></font> -1.1943%] (p = 0.00 &lt; 0.05)
                        Performance has <font color="#26A269">improved</font>.
<font color="#A2734C">Found 4 outliers among 100 measurements (4.00%)</font>
  3 (3.00%) high mild
  1 (1.00%) high severe

<font color="#26A269">poly_mul/fft/1</font>          time:   [649.81 ns <b>650.02 ns</b> 650.24 ns]
                        change: [+0.7407% +0.8303% +0.9173%] (p = 0.00 &lt; 0.05)
                        Change within noise threshold.
<font color="#A2734C">Found 12 outliers among 100 measurements (12.00%)</font>
  1 (1.00%) low severe
  3 (3.00%) low mild
  3 (3.00%) high mild
  5 (5.00%) high severe
<font color="#26A269">poly_mul/direct/1</font>       time:   [165.30 ns <b>165.35 ns</b> 165.41 ns]
                        change: [+0.7426% +0.8280% +0.9389%] (p = 0.00 &lt; 0.05)
                        Change within noise threshold.
<font color="#A2734C">Found 4 outliers among 100 measurements (4.00%)</font>
  2 (2.00%) low mild
  2 (2.00%) high severe
<font color="#26A269">poly_mul/fft/30</font>         time:   [21.775 µs <b>21.782 µs</b> 21.789 µs]
                        change: [-8.9807% <font color="#26A269"><b>-8.8200%</b></font> -8.7044%] (p = 0.00 &lt; 0.05)
                        Performance has <font color="#26A269">improved</font>.
<font color="#A2734C">Found 6 outliers among 100 measurements (6.00%)</font>
  1 (1.00%) low severe
  3 (3.00%) low mild
  1 (1.00%) high mild
  1 (1.00%) high severe
<font color="#26A269">poly_mul/direct/30</font>      time:   [25.078 µs <b>25.104 µs</b> 25.128 µs]
                        change: [+0.5286% +0.8276% +1.2733%] (p = 0.00 &lt; 0.05)
                        Change within noise threshold.
<font color="#A2734C">Found 5 outliers among 100 measurements (5.00%)</font>
  1 (1.00%) high mild
  4 (4.00%) high severe
<font color="#26A269">poly_mul/fft/60</font>         time:   [49.830 µs <b>49.845 µs</b> 49.861 µs]
                        change: [-8.3666% <font color="#26A269"><b>-7.9938%</b></font> -7.5635%] (p = 0.00 &lt; 0.05)
                        Performance has <font color="#26A269">improved</font>.
<font color="#A2734C">Found 8 outliers among 100 measurements (8.00%)</font>
  1 (1.00%) low mild
  5 (5.00%) high mild
  2 (2.00%) high severe
<font color="#26A269">poly_mul/direct/60</font>      time:   [100.17 µs <b>100.27 µs</b> 100.45 µs]
                        change: [+0.4895% +0.5770% +0.6764%] (p = 0.00 &lt; 0.05)
                        Change within noise threshold.
<font color="#A2734C">Found 9 outliers among 100 measurements (9.00%)</font>
  1 (1.00%) low mild
  4 (4.00%) high mild
  4 (4.00%) high severe
<font color="#26A269">poly_mul/fft/90</font>         time:   [111.28 µs <b>111.30 µs</b> 111.33 µs]
                        change: [-10.544% <font color="#26A269"><b>-10.388%</b></font> -10.279%] (p = 0.00 &lt; 0.05)
                        Performance has <font color="#26A269">improved</font>.
<font color="#A2734C">Found 8 outliers among 100 measurements (8.00%)</font>
  1 (1.00%) low severe
  5 (5.00%) low mild
  2 (2.00%) high severe
<font color="#26A269">poly_mul/direct/90</font>      time:   [400.21 µs <b>400.26 µs</b> 400.31 µs]
                        change: [+0.3027% +0.3377% +0.3648%] (p = 0.00 &lt; 0.05)
                        Change within noise threshold.
<font color="#A2734C">Found 7 outliers among 100 measurements (7.00%)</font>
  1 (1.00%) low mild
  4 (4.00%) high mild
  2 (2.00%) high severe
<font color="#26A269">poly_mul/fft/120</font>        time:   [111.28 µs <b>111.30 µs</b> 111.32 µs]
                        change: [-10.633% <font color="#26A269"><b>-10.225%</b></font> -9.7366%] (p = 0.00 &lt; 0.05)
                        Performance has <font color="#26A269">improved</font>.
<font color="#A2734C">Found 10 outliers among 100 measurements (10.00%)</font>
  1 (1.00%) low mild
  1 (1.00%) high mild
  8 (8.00%) high severe
<font color="#26A269">poly_mul/direct/120</font>     time:   [399.55 µs <b>399.59 µs</b> 399.63 µs]
                        change: [-1.4389% -0.7539% -0.1834%] (p = 0.01 &lt; 0.05)
                        Change within noise threshold.
<font color="#A2734C">Found 9 outliers among 100 measurements (9.00%)</font>
  1 (1.00%) low severe
  3 (3.00%) low mild
  4 (4.00%) high mild
  1 (1.00%) high severe
<font color="#26A269">poly_mul/fft/150</font>        time:   [247.55 µs <b>247.59 µs</b> 247.63 µs]
                        change: [-10.495% <font color="#26A269"><b>-10.454%</b></font> -10.403%] (p = 0.00 &lt; 0.05)
                        Performance has <font color="#26A269">improved</font>.
<font color="#A2734C">Found 3 outliers among 100 measurements (3.00%)</font>
  1 (1.00%) low severe
  1 (1.00%) low mild
  1 (1.00%) high severe
Benchmarking poly_mul/direct/150: Warming up for 3.0000 s
Warning: Unable to complete 100 samples in 5.0s. You may wish to increase target time to 8.0s, enable flat sampling, or reduce sample count to 50.
<font color="#26A269">poly_mul/direct/150</font>     time:   [1.5928 ms <b>1.5929 ms</b> 1.5931 ms]
                        change: [-0.4093% -0.0877% +0.0911%] (p = 0.73 &gt; 0.05)
                        No change in performance detected.
<font color="#A2734C">Found 10 outliers among 100 measurements (10.00%)</font>
  1 (1.00%) low severe
  2 (2.00%) low mild
  6 (6.00%) high mild
  1 (1.00%) high severe
<font color="#26A269">poly_mul/fft/255</font>        time:   [247.58 µs <b>247.63 µs</b> 247.69 µs]
                        change: [-11.234% <font color="#26A269"><b>-10.678%</b></font> -10.386%] (p = 0.00 &lt; 0.05)
                        Performance has <font color="#26A269">improved</font>.
<font color="#A2734C">Found 4 outliers among 100 measurements (4.00%)</font>
  1 (1.00%) low mild
  3 (3.00%) high mild
Benchmarking poly_mul/direct/255: Warming up for 3.0000 s
Warning: Unable to complete 100 samples in 5.0s. You may wish to increase target time to 8.0s, enable flat sampling, or reduce sample count to 50.
<font color="#26A269">poly_mul/direct/255</font>     time:   [1.5928 ms <b>1.5929 ms</b> 1.5931 ms]
                        change: [-0.0085% +0.0561% +0.1053%] (p = 0.04 &lt; 0.05)
                        Change within noise threshold.
<font color="#A2734C">Found 11 outliers among 100 measurements (11.00%)</font>
  2 (2.00%) low severe
  2 (2.00%) low mild
  4 (4.00%) high mild
  3 (3.00%) high severe
</pre>

</details>

Based on the benchmark results, I also lowered the `FFT_THRESHOLD` constant to change when we cut over between the different polynomial multiplication implementations. Note that even before this change, previous optimizations had moved the break-even point to around 30.