### PR TITLE
Fix Clippy lints

### DIFF
--- a/src/field.rs
+++ b/src/field.rs
@@ -944,8 +944,6 @@ pub(crate) mod test_utils {
         type TryIntoU64Error: std::error::Error;
         type TestInteger: Integer + From<Self> + Clone;
 
-        fn pow(&self, exp: Self::TestInteger) -> Self;
-
         fn modulus() -> Self::TestInteger;
     }
 
@@ -956,10 +954,6 @@ pub(crate) mod test_utils {
         type IntegerTryFromError = <F::Integer as Integer>::TryFromUsizeError;
         type TryIntoU64Error = <F::Integer as Integer>::TryIntoU64Error;
         type TestInteger = F::Integer;
-
-        fn pow(&self, exp: Self::TestInteger) -> Self {
-            <F as FieldElementWithInteger>::pow(self, exp)
-        }
 
         fn modulus() -> Self::TestInteger {
             <F as FieldElementWithInteger>::modulus()

--- a/src/field/field255.rs
+++ b/src/field/field255.rs
@@ -395,10 +395,6 @@ mod tests {
         type IntegerTryFromError = <Self::TestInteger as TryFrom<usize>>::Error;
         type TryIntoU64Error = <Self::TestInteger as TryInto<u64>>::Error;
 
-        fn pow(&self, _exp: Self::TestInteger) -> Self {
-            unimplemented!("Field255::pow() is not implemented because it's not needed yet")
-        }
-
         fn modulus() -> Self::TestInteger {
             MODULUS.clone()
         }

--- a/src/flp/gadgets.rs
+++ b/src/flp/gadgets.rs
@@ -436,10 +436,7 @@ fn gadget_call_poly_check<F: FftFriendlyFieldElement, G: Gadget<F>>(
     gadget: &G,
     outp: &[F],
     inp: &[Vec<F>],
-) -> Result<(), FlpError>
-where
-    G: Gadget<F>,
-{
+) -> Result<(), FlpError> {
     gadget_call_check(gadget, inp.len())?;
 
     for i in 1..inp.len() {

--- a/src/flp/types/fixedpoint_l2.rs
+++ b/src/flp/types/fixedpoint_l2.rs
@@ -736,9 +736,9 @@ mod tests {
         );
     }
 
-    fn test_fixed<F: Fixed>(fp_vec: Vec<F>, enc_vec: Vec<u128>)
+    fn test_fixed<F>(fp_vec: Vec<F>, enc_vec: Vec<u128>)
     where
-        F: CompatibleFloat,
+        F: Fixed + CompatibleFloat,
     {
         let n: usize = (F::INT_NBITS + F::FRAC_NBITS).try_into().unwrap();
 

--- a/src/vdaf/dummy.rs
+++ b/src/vdaf/dummy.rs
@@ -70,26 +70,21 @@ impl Vdaf {
     }
 
     /// Provide an alternate implementation of [`vdaf::Aggregator::prepare_init`].
-    pub fn with_prep_init_fn<F: Fn(&AggregationParam) -> Result<(), VdafError>>(
-        mut self,
-        f: F,
-    ) -> Self
+    pub fn with_prep_init_fn<F>(mut self, f: F) -> Self
     where
-        F: 'static + Send + Sync,
+        F: Fn(&AggregationParam) -> Result<(), VdafError> + Send + Sync + 'static,
     {
         self.prep_init_fn = Arc::new(f);
         self
     }
 
     /// Provide an alternate implementation of [`vdaf::Aggregator::prepare_next`].
-    pub fn with_prep_step_fn<
-        F: Fn(&PrepareState) -> Result<PrepareTransition<Self, 0, 16>, VdafError>,
-    >(
-        mut self,
-        f: F,
-    ) -> Self
+    pub fn with_prep_step_fn<F>(mut self, f: F) -> Self
     where
-        F: 'static + Send + Sync,
+        F: Fn(&PrepareState) -> Result<PrepareTransition<Self, 0, 16>, VdafError>
+            + Send
+            + Sync
+            + 'static,
     {
         self.prep_step_fn = Arc::new(f);
         self


### PR DESCRIPTION
This fixes some new warnings that come up with the 1.78.0 toolchain.