### PR TITLE
Replace division of constant 1 with inverse

### DIFF
--- a/src/flp/types.rs
+++ b/src/flp/types.rs
@@ -422,7 +422,7 @@ where
         )?;
 
         // Check that the elements of `input` sum to 1.
-        let mut sum_check = -(F::one() / F::from(F::valid_integer_try_from(num_shares)?));
+        let mut sum_check = -F::from(F::valid_integer_try_from(num_shares)?).inv();
         for val in input.iter() {
             sum_check += *val;
         }

--- a/src/flp/types/fixedpoint_l2.rs
+++ b/src/flp/types/fixedpoint_l2.rs
@@ -488,7 +488,7 @@ where
         self.valid_call_check(input, joint_rand)?;
 
         let f_num_shares = Field128::from(Field128::valid_integer_try_from::<usize>(num_shares)?);
-        let num_shares_inverse = Field128::one() / f_num_shares;
+        let num_shares_inverse = f_num_shares.inv();
 
         // Ensure that all submitted field elements are either 0 or 1.
         // This is done for:


### PR DESCRIPTION
This replaces division of one by another field element with a call to `inv()`. This saves one multiplication.