### PR TITLE
Benchmark Poplar1 preparation with different IDPF evaluation caches

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -423,6 +423,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "hashbrown"
+version = "0.14.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e5274423e17b7c9fc20b6e7e208532f9b19825d82dfd615708b70edd83df41f1"
+
+[[package]]
 name = "hermit-abi"
 version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -746,6 +752,7 @@ dependencies = [
  "fixed",
  "fixed-macro",
  "getrandom",
+ "hashbrown",
  "hex",
  "hex-literal",
  "hmac",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,6 +18,7 @@ ctr = { version = "0.9.2", optional = true }
 fiat-crypto = { version = "0.2.8", optional = true }
 fixed = { version = "1.27", optional = true }
 getrandom = { version = "0.2.15", features = ["std"] }
+hashbrown = { version = "0.14.5", optional = true, default-features = false, features = ["raw"] }
 hex = { version = "0.4.3", features = ["serde"], optional = true }
 hmac = { version = "0.12.1", optional = true }
 num-bigint = { version = "0.4.4", optional = true, features = ["rand", "serde"] }
@@ -52,7 +53,7 @@ statrs = "0.16.0"
 
 [features]
 default = ["crypto-dependencies"]
-experimental = ["bitvec", "fiat-crypto", "fixed", "num-bigint", "num-rational", "num-traits", "num-integer", "num-iter"]
+experimental = ["bitvec", "fiat-crypto", "fixed", "num-bigint", "num-rational", "num-traits", "num-integer", "num-iter", "hashbrown"]
 multithreaded = ["rayon"]
 crypto-dependencies = ["aes", "ctr", "hmac", "sha2"]
 test-util = ["hex", "serde_json", "zipf"]

--- a/benches/speed_tests.rs
+++ b/benches/speed_tests.rs
@@ -18,7 +18,7 @@ use prio::bt::BinaryTree;
 #[cfg(feature = "experimental")]
 use prio::dp::distributions::DiscreteGaussian;
 #[cfg(feature = "experimental")]
-use prio::idpf::{test_utils::generate_zipf_distributed_batch, HashMapCache, IdpfCache};
+use prio::idpf::test_utils::generate_zipf_distributed_batch;
 #[cfg(feature = "experimental")]
 use prio::vdaf::prio2::Prio2;
 use prio::{
@@ -31,7 +31,10 @@ use prio::{
 use prio::{
     field::{Field255, Field64},
     flp::types::fixedpoint_l2::FixedPointBoundedL2VecSum,
-    idpf::{Idpf, IdpfInput, RingBufferCache},
+    idpf::{
+        HashMapCache, HashMapCacheA, HashMapCacheB, Idpf, IdpfCache, IdpfInput, RingBufferCache,
+        RingBufferCacheA, RingBufferCacheB,
+    },
     vdaf::poplar1::{Poplar1, Poplar1AggregationParam, Poplar1IdpfValue},
 };
 #[cfg(feature = "experimental")]
@@ -778,18 +781,24 @@ fn poplar1(c: &mut Criterion) {
 
     let mut group = c.benchmark_group("poplar1_prepare_cached");
     type BoxedCacheConstructor = fn() -> Box<dyn IdpfCache>;
-    let cache_impls: [(&'static str, BoxedCacheConstructor); 5] = [
-        ("ringbuffer_10", || -> Box<dyn IdpfCache> {
-            Box::new(RingBufferCache::new(10))
-        }),
+    let cache_impls: [(&'static str, BoxedCacheConstructor); 7] = [
         ("ringbuffer_100", || -> Box<dyn IdpfCache> {
             Box::new(RingBufferCache::new(100))
         }),
-        ("ringbuffer_1000", || -> Box<dyn IdpfCache> {
-            Box::new(RingBufferCache::new(1000))
+        ("ringbuffer_a_100", || -> Box<dyn IdpfCache> {
+            Box::new(RingBufferCacheA::new(100))
+        }),
+        ("ringbuffer_b_100", || -> Box<dyn IdpfCache> {
+            Box::new(RingBufferCacheB::new(100))
         }),
         ("hashmap", || -> Box<dyn IdpfCache> {
             Box::new(HashMapCache::new())
+        }),
+        ("hashmap_a", || -> Box<dyn IdpfCache> {
+            Box::new(HashMapCacheA::new())
+        }),
+        ("hashmap_b", || -> Box<dyn IdpfCache> {
+            Box::new(HashMapCacheB::new())
         }),
         ("binarytree", || -> Box<dyn IdpfCache> {
             let mut tree = Box::<BinaryTree<_>>::default();

--- a/src/bt.rs
+++ b/src/bt.rs
@@ -58,6 +58,8 @@ use std::io::Cursor;
 use bitvec::slice::BitSlice;
 
 use crate::codec::{CodecError, Decode, Encode, ParameterizedDecode};
+#[cfg(feature = "crypto-dependencies")]
+use crate::idpf::IdpfCache;
 
 /// Errors triggered by binary tree operations.
 #[derive(Debug, thiserror::Error)]
@@ -392,6 +394,18 @@ impl Decode for CodecMarker {
             1u8 => Ok(CodecMarker::Inner),
             _ => Err(CodecError::UnexpectedValue),
         }
+    }
+}
+
+#[cfg(feature = "crypto-dependencies")]
+impl IdpfCache for BinaryTree<([u8; 16], u8)> {
+    fn get(&self, input: &BitSlice) -> Option<([u8; 16], u8)> {
+        self.get(input).cloned()
+    }
+
+    fn insert(&mut self, input: &BitSlice, values: &([u8; 16], u8)) {
+        // Fail silently if the value cannot be inserted because not all parent nodes exist.
+        let _ = self.insert(input, *values);
     }
 }
 

--- a/src/idpf.rs
+++ b/src/idpf.rs
@@ -23,9 +23,9 @@ use bitvec::{
 use hashbrown::raw::RawTable;
 use rand_core::RngCore;
 use std::{
-    collections::{HashMap, VecDeque},
+    collections::{hash_map::DefaultHasher, HashMap, VecDeque},
     fmt::Debug,
-    hash::{DefaultHasher, Hash, Hasher},
+    hash::{Hash, Hasher},
     io::{Cursor, Read},
     iter::zip,
     ops::{Add, AddAssign, Index, Sub},

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -16,7 +16,7 @@
 
 pub mod benchmarked;
 #[cfg(feature = "experimental")]
-mod bt;
+pub mod bt;
 pub mod codec;
 #[cfg(feature = "experimental")]
 #[cfg_attr(docsrs, doc(cfg(feature = "experimental")))]

--- a/supply-chain/audits.toml
+++ b/supply-chain/audits.toml
@@ -769,6 +769,12 @@ user-id = 189 # Andrew Gallant (BurntSushi)
 start = "2019-06-09"
 end = "2024-06-08"
 
+[[trusted.hashbrown]]
+criteria = "safe-to-deploy"
+user-id = 2915 # Amanieu d'Antras (Amanieu)
+start = "2019-04-02"
+end = "2025-05-10"
+
 [[trusted.itoa]]
 criteria = "safe-to-deploy"
 user-id = 3618 # David Tolnay (dtolnay)

--- a/supply-chain/imports.lock
+++ b/supply-chain/imports.lock
@@ -8,6 +8,13 @@ user-id = 189
 user-login = "BurntSushi"
 user-name = "Andrew Gallant"
 
+[[publisher.hashbrown]]
+version = "0.14.5"
+when = "2024-04-28"
+user-id = 2915
+user-login = "Amanieu"
+user-name = "Amanieu d'Antras"
+
 [[publisher.itoa]]
 version = "1.0.3"
 when = "2022-08-03"


### PR DESCRIPTION
This adds a new category of benchmark that evaluates a Poplar1 report at every level with a realistic set of aggregation parameters. This is repeated with multiple different IDPF evaluation caches, and done by reusing the cache across multiple preparations at different levels, rather than discarding the cache between preparations. Several different cache implementations are used, including the existing ones, some optimizations on top of those inspired by #706, and the binary tree introduced in #978. Here are the results I got:

<details><summary>Criterion output</summary>
<pre><font color="#26A269">poplar1_prepare_cached/ringbuffer_100/16</font>
                        time:   [3.0772 ms <b>3.0802 ms</b> 3.0836 ms]
                        change: [-16.725% <font color="#26A269"><b>-14.487%</b></font> -12.335%] (p = 0.00 &lt; 0.05)
                        Performance has <font color="#26A269">improved</font>.
<font color="#A2734C">Found 11 outliers among 100 measurements (11.00%)</font>
  4 (4.00%) high mild
  7 (7.00%) high severe
<font color="#26A269">poplar1_prepare_cached/ringbuffer_a_100/16</font>
                        time:   [2.7827 ms <b>2.7839 ms</b> 2.7860 ms]
<font color="#A2734C">Found 13 outliers among 100 measurements (13.00%)</font>
  1 (1.00%) low mild
  4 (4.00%) high mild
  8 (8.00%) high severe
<font color="#26A269">poplar1_prepare_cached/ringbuffer_b_100/16</font>
                        time:   [3.3041 ms <b>3.3049 ms</b> 3.3059 ms]
<font color="#A2734C">Found 4 outliers among 100 measurements (4.00%)</font>
  3 (3.00%) high mild
  1 (1.00%) high severe
<font color="#26A269">poplar1_prepare_cached/hashmap/16</font>
                        time:   [2.8163 ms <b>2.8181 ms</b> 2.8210 ms]
                        change: [-1.3160% -0.9884% -0.7324%] (p = 0.00 &lt; 0.05)
                        Change within noise threshold.
<font color="#A2734C">Found 8 outliers among 100 measurements (8.00%)</font>
  3 (3.00%) high mild
  5 (5.00%) high severe
<font color="#26A269">poplar1_prepare_cached/hashmap_a/16</font>
                        time:   [2.7674 ms <b>2.7685 ms</b> 2.7700 ms]
<font color="#A2734C">Found 10 outliers among 100 measurements (10.00%)</font>
  4 (4.00%) high mild
  6 (6.00%) high severe
<font color="#26A269">poplar1_prepare_cached/hashmap_b/16</font>
                        time:   [2.8382 ms <b>2.8391 ms</b> 2.8406 ms]
<font color="#A2734C">Found 9 outliers among 100 measurements (9.00%)</font>
  1 (1.00%) low mild
  6 (6.00%) high mild
  2 (2.00%) high severe
<font color="#26A269">poplar1_prepare_cached/binarytree/16</font>
                        time:   [2.5032 ms <b>2.5060 ms</b> 2.5098 ms]
                        change: [+0.7524% +0.9031% +1.0655%] (p = 0.00 &lt; 0.05)
                        Change within noise threshold.
<font color="#A2734C">Found 15 outliers among 100 measurements (15.00%)</font>
  11 (11.00%) high mild
  4 (4.00%) high severe
<font color="#26A269">poplar1_prepare_cached/ringbuffer_100/128</font>
                        time:   [26.897 ms <b>26.904 ms</b> 26.912 ms]
                        change: [-0.7460% -0.6385% -0.5527%] (p = 0.00 &lt; 0.05)
                        Change within noise threshold.
<font color="#A2734C">Found 5 outliers among 100 measurements (5.00%)</font>
  5 (5.00%) high severe
<font color="#26A269">poplar1_prepare_cached/ringbuffer_a_100/128</font>
                        time:   [24.263 ms <b>24.267 ms</b> 24.274 ms]
<font color="#A2734C">Found 2 outliers among 100 measurements (2.00%)</font>
  1 (1.00%) high mild
  1 (1.00%) high severe
<font color="#26A269">poplar1_prepare_cached/ringbuffer_b_100/128</font>
                        time:   [28.462 ms <b>28.481 ms</b> 28.507 ms]
<font color="#A2734C">Found 3 outliers among 100 measurements (3.00%)</font>
  3 (3.00%) high severe
<font color="#26A269">poplar1_prepare_cached/hashmap/128</font>
                        time:   [31.600 ms <b>31.611 ms</b> 31.627 ms]
                        change: [-2.5733% <font color="#26A269"><b>-2.0554%</b></font> -1.6271%] (p = 0.00 &lt; 0.05)
                        Performance has <font color="#26A269">improved</font>.
<font color="#A2734C">Found 5 outliers among 100 measurements (5.00%)</font>
  4 (4.00%) high mild
  1 (1.00%) high severe
<font color="#26A269">poplar1_prepare_cached/hashmap_a/128</font>
                        time:   [24.320 ms <b>24.337 ms</b> 24.364 ms]
<font color="#A2734C">Found 5 outliers among 100 measurements (5.00%)</font>
  2 (2.00%) high mild
  3 (3.00%) high severe
<font color="#26A269">poplar1_prepare_cached/hashmap_b/128</font>
                        time:   [25.436 ms <b>25.457 ms</b> 25.491 ms]
<font color="#A2734C">Found 5 outliers among 100 measurements (5.00%)</font>
  2 (2.00%) high mild
  3 (3.00%) high severe
<font color="#26A269">poplar1_prepare_cached/binarytree/128</font>
                        time:   [25.584 ms <b>25.599 ms</b> 25.617 ms]
                        change: [-0.3466% -0.2297% -0.1171%] (p = 0.00 &lt; 0.05)
                        Change within noise threshold.
<font color="#A2734C">Found 1 outliers among 100 measurements (1.00%)</font>
  1 (1.00%) high severe
<font color="#26A269">poplar1_prepare_cached/ringbuffer_100/256</font>
                        time:   [54.242 ms <b>54.264 ms</b> 54.298 ms]
                        change: [-1.1951% -0.9858% -0.8324%] (p = 0.00 &lt; 0.05)
                        Change within noise threshold.
<font color="#A2734C">Found 6 outliers among 100 measurements (6.00%)</font>
  1 (1.00%) low mild
  3 (3.00%) high mild
  2 (2.00%) high severe
<font color="#26A269">poplar1_prepare_cached/ringbuffer_a_100/256</font>
                        time:   [48.952 ms <b>48.972 ms</b> 49.003 ms]
<font color="#A2734C">Found 5 outliers among 100 measurements (5.00%)</font>
  3 (3.00%) high mild
  2 (2.00%) high severe
<font color="#26A269">poplar1_prepare_cached/ringbuffer_b_100/256</font>
                        time:   [56.317 ms <b>56.513 ms</b> 56.784 ms]
<font color="#A2734C">Found 11 outliers among 100 measurements (11.00%)</font>
  2 (2.00%) high mild
  9 (9.00%) high severe
<font color="#26A269">poplar1_prepare_cached/hashmap/256</font>
                        time:   [78.971 ms <b>78.981 ms</b> 78.993 ms]
                        change: [-1.8087% <font color="#26A269"><b>-1.5994%</b></font> -1.4575%] (p = 0.00 &lt; 0.05)
                        Performance has <font color="#26A269">improved</font>.
<font color="#A2734C">Found 2 outliers among 100 measurements (2.00%)</font>
  1 (1.00%) high mild
  1 (1.00%) high severe
<font color="#26A269">poplar1_prepare_cached/hashmap_a/256</font>
                        time:   [49.691 ms <b>49.709 ms</b> 49.735 ms]
<font color="#A2734C">Found 2 outliers among 100 measurements (2.00%)</font>
  2 (2.00%) high severe
<font color="#26A269">poplar1_prepare_cached/hashmap_b/256</font>
                        time:   [53.904 ms <b>53.916 ms</b> 53.929 ms]
<font color="#A2734C">Found 2 outliers among 100 measurements (2.00%)</font>
  2 (2.00%) high severe
<font color="#26A269">poplar1_prepare_cached/binarytree/256</font>
                        time:   [64.081 ms <b>64.094 ms</b> 64.108 ms]
                        change: [-0.1716% -0.0872% -0.0107%] (p = 0.03 &lt; 0.05)
                        Change within noise threshold.
<font color="#A2734C">Found 1 outliers among 100 measurements (1.00%)</font>
  1 (1.00%) high mild
</pre>
</details>

The as-is `HashMapCache` performs the worst, as laid out by #706. The two best-performing caches are variants of `HashMapCache` and `RingBufferCache` that copy inputs into a new `BitVec`, normalize alignment and uninitialized bits, and compare or hash raw storage slices. I tried also writing variants that didn't copy to a new `BitVec`, but used different comparison routines. (for equality, destructuring the `Domain` of the bit slice; for hashing, iterating over machine word-sized chunks of the bit slice, and hashing a usize at a time) Neither of these performed as well as the corresponding variant that just copies into a new `BitVec`. The binary tree cache came out between the original `HashMapCache` and the rest, looking at the 256 bit case. Its curve is notably a different shape than the rest. If the Poplar1 implementation were more tightly integrated with the binary tree, it would probably perform better. For example, the initial traversal up the IDPF tree looking for a cached node, doing multiple lookups on the BinaryTree, could be replaced with a single traversal down the BinaryTree. Additionally, insertions would be faster if Poplar1 hung onto a node reference, and walked down one pointer as it inserted new nodes.

This PR contains one commit that would be worth cherry-picking and landing on its own immediately: an efficiency improvement to the existing Poplar1 benchmarks. Based on the results above, I think it would make sense to apply the normalization optimization to `HashMapCache`, and start using that in Poplar1. There's also an API design question here: how do we want to expose the IDPF evaluation cache, and side effects on it, in VDAFs that use IDPFs? Should we keep using a mutable reference to the cache, or should we use a `&` reference and require interior mutability? Should there be a new trait related to `Aggregator` that allows for this sort of cache argument, or is it sufficient to expose a cache-aware version of prepare_init and not provide a trait for it? Would the cache interface be easier to use and implement correctly if the nonce were an argument in get and insert calls as well?