### PR TITLE
Add a wasm-compat feature for getrandom

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -403,8 +403,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c4567c8db10ae91089c99af84c68c38da3ec2f087c3f82960bcdbf3656b6f4d7"
 dependencies = [
  "cfg-if",
+ "js-sys",
  "libc",
  "wasi",
+ "wasm-bindgen",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -56,6 +56,7 @@ experimental = ["bitvec", "fiat-crypto", "fixed", "num-bigint", "num-rational", 
 multithreaded = ["rayon"]
 crypto-dependencies = ["aes", "ctr", "hmac", "sha2"]
 test-util = ["hex", "serde_json", "zipf"]
+wasm-compat = ["getrandom/js"]
 
 [workspace]
 members = [".", "binaries"]

--- a/README.md
+++ b/README.md
@@ -75,5 +75,6 @@ This crate defines the following feature flags:
 |`experimental`|No|Certain experimental APIs are guarded by this feature.|❌|
 |`multithreaded`|No|Enables certain Prio3 VDAF implementations that use `rayon` for parallelization of gadget evaluations.|✅|
 |`test-util`|No|Enables test utilities for VDAF users and VDAF implementers.|❌|
+|`wasm-compat`|No|Enables the `getrandom/js` feature. This is necessary for `wasm32-unknown-unknown` targets, when in a JavaScript environment.|✅|
 
 Features that are not marked as "Semver stable" may undergo breaking changes in future patch releases, as an exception to semantic versioning.

--- a/supply-chain/imports.lock
+++ b/supply-chain/imports.lock
@@ -406,12 +406,6 @@ criteria = "safe-to-run"
 version = "1.4.0"
 aggregated-from = "https://chromium.googlesource.com/chromiumos/third_party/rust_crates/+/refs/heads/main/cargo-vet/audits.toml?format=TEXT"
 
-[[audits.google.audits.log]]
-who = "ChromeOS"
-criteria = "safe-to-run"
-version = "0.4.17"
-aggregated-from = "https://chromium.googlesource.com/chromiumos/third_party/rust_crates/+/refs/heads/main/cargo-vet/audits.toml?format=TEXT"
-
 [[audits.google.audits.same-file]]
 who = "Android Legacy"
 criteria = "safe-to-run"
@@ -507,6 +501,12 @@ aggregated-from = "https://hg.mozilla.org/mozilla-central/raw-file/tip/supply-ch
 who = "Simon Friedberger <simon@mozilla.com>"
 criteria = "safe-to-deploy"
 version = "0.4.3"
+aggregated-from = "https://hg.mozilla.org/mozilla-central/raw-file/tip/supply-chain/audits.toml"
+
+[[audits.mozilla.audits.log]]
+who = "Mike Hommey <mh+mozilla@glandium.org>"
+criteria = "safe-to-deploy"
+version = "0.4.17"
 aggregated-from = "https://hg.mozilla.org/mozilla-central/raw-file/tip/supply-chain/audits.toml"
 
 [[audits.mozilla.audits.num-integer]]


### PR DESCRIPTION
If you're using `prio` from wasm you have to include `getrandom = { version "*", feature = ["js"] }` in your cargo toml, even if you don't make use of `getrandom` in your code, just so you can activate the "js" feature. 

I think it would be nicer if prio let me activate the feature without this hack.

Stacked on top of #1058 