### PR TITLE
Prio2: split precomputations to fix warnings

### DIFF
--- a/src/benchmarked.rs
+++ b/src/benchmarked.rs
@@ -9,7 +9,7 @@ use crate::fft::discrete_fourier_transform;
 use crate::field::FftFriendlyFieldElement;
 use crate::flp::gadgets::Mul;
 use crate::flp::FlpError;
-use crate::polynomial::{poly_fft, PolyAuxMemory};
+use crate::polynomial::{fft_get_roots, poly_fft, PolyFFTTempMemory};
 
 /// Sets `outp` to the Discrete Fourier Transform (DFT) using an iterative FFT algorithm.
 pub fn benchmarked_iterative_fft<F: FftFriendlyFieldElement>(outp: &mut [F], inp: &[F]) {
@@ -18,15 +18,9 @@ pub fn benchmarked_iterative_fft<F: FftFriendlyFieldElement>(outp: &mut [F], inp
 
 /// Sets `outp` to the Discrete Fourier Transform (DFT) using a recursive FFT algorithm.
 pub fn benchmarked_recursive_fft<F: FftFriendlyFieldElement>(outp: &mut [F], inp: &[F]) {
-    let mut mem = PolyAuxMemory::new(inp.len() / 2);
-    poly_fft(
-        outp,
-        inp,
-        &mem.roots_2n,
-        inp.len(),
-        false,
-        &mut mem.fft_memory,
-    )
+    let roots_2n = fft_get_roots(inp.len(), false);
+    let mut fft_memory = PolyFFTTempMemory::new(inp.len());
+    poly_fft(outp, inp, &roots_2n, inp.len(), false, &mut fft_memory)
 }
 
 /// Sets `outp` to `inp[0] * inp[1]`, where `inp[0]` and `inp[1]` are polynomials. This function

--- a/src/fft.rs
+++ b/src/fft.rs
@@ -127,7 +127,7 @@ fn bitrev(d: usize, x: usize) -> usize {
 mod tests {
     use super::*;
     use crate::field::{random_vector, split_vector, Field128, Field64, FieldElement, FieldPrio2};
-    use crate::polynomial::{poly_fft, PolyAuxMemory};
+    use crate::polynomial::{poly_fft, TestPolyAuxMemory};
 
     fn discrete_fourier_transform_then_inv_test<F: FftFriendlyFieldElement>() -> Result<(), FftError>
     {
@@ -164,7 +164,7 @@ mod tests {
     #[test]
     fn test_recursive_fft() {
         let size = 128;
-        let mut mem = PolyAuxMemory::new(size / 2);
+        let mut mem = TestPolyAuxMemory::new(size / 2);
 
         let inp = random_vector(size).unwrap();
         let mut want = vec![FieldPrio2::zero(); size];

--- a/src/polynomial.rs
+++ b/src/polynomial.rs
@@ -32,7 +32,6 @@ impl<F: FftFriendlyFieldElement> PolyFFTTempMemory<F> {
 pub struct PolyAuxMemory<F> {
     pub roots_2n: Vec<F>,
     pub roots_n_inverted: Vec<F>,
-    pub coeffs: Vec<F>,
     pub fft_memory: PolyFFTTempMemory<F>,
 }
 
@@ -41,7 +40,6 @@ impl<F: FftFriendlyFieldElement> PolyAuxMemory<F> {
         PolyAuxMemory {
             roots_2n: fft_get_roots(2 * n, false),
             roots_n_inverted: fft_get_roots(n, true),
-            coeffs: vec![F::zero(); 2 * n],
             fft_memory: PolyFFTTempMemory::new(2 * n),
         }
     }

--- a/src/vdaf/prio2/client.rs
+++ b/src/vdaf/prio2/client.rs
@@ -49,6 +49,7 @@ pub(crate) struct ClientMemory<F> {
     evals_f: Vec<F>,
     evals_g: Vec<F>,
     poly_mem: PolyAuxMemory<F>,
+    coeffs: Vec<F>,
 }
 
 impl<F: FftFriendlyFieldElement> ClientMemory<F> {
@@ -73,6 +74,7 @@ impl<F: FftFriendlyFieldElement> ClientMemory<F> {
             evals_f: vec![F::zero(); 2 * n],
             evals_g: vec![F::zero(); 2 * n],
             poly_mem: PolyAuxMemory::new(n),
+            coeffs: vec![F::zero(); 2 * n],
         })
     }
 }
@@ -191,15 +193,28 @@ pub(crate) fn unpack_proof_mut<F: FftFriendlyFieldElement>(
     }
 }
 
+/// Interpolate a polynomial at the nth roots of unity, and then evaluate it at the 2nth roots of
+/// unity.
+///
+/// # Arguments
+///
+/// * `n` - The number of points to interpolate a polynomial through.
+/// * `points_in` - The values that the polynomial must take on when evaluated at the nth roots of
+///   unity. This must have length n.
+/// * `evals_out` - The values that the polynomial takes on when evaluated at the 2nth roots of
+///   unity. This must have length 2 * n.
+/// * `mem` - Precomputed roots of unity and scratch space for the FFT algorithm.
+/// * `coeffs` - Scratch space. This must have length 2 * n.
 fn interpolate_and_evaluate_at_2n<F: FftFriendlyFieldElement>(
     n: usize,
     points_in: &[F],
     evals_out: &mut [F],
     mem: &mut PolyAuxMemory<F>,
+    coeffs: &mut [F],
 ) {
     // interpolate through roots of unity
     poly_fft(
-        &mut mem.coeffs,
+        coeffs,
         points_in,
         &mem.roots_n_inverted,
         n,
@@ -209,7 +224,7 @@ fn interpolate_and_evaluate_at_2n<F: FftFriendlyFieldElement>(
     // evaluate at 2N roots of unity
     poly_fft(
         evals_out,
-        &mem.coeffs,
+        coeffs,
         &mem.roots_2n,
         2 * n,
         false,
@@ -253,8 +268,20 @@ fn construct_proof<F: FftFriendlyFieldElement>(
     }
 
     // interpolate and evaluate at roots of unity
-    interpolate_and_evaluate_at_2n(n, &mem.points_f, &mut mem.evals_f, &mut mem.poly_mem);
-    interpolate_and_evaluate_at_2n(n, &mem.points_g, &mut mem.evals_g, &mut mem.poly_mem);
+    interpolate_and_evaluate_at_2n(
+        n,
+        &mem.points_f,
+        &mut mem.evals_f,
+        &mut mem.poly_mem,
+        &mut mem.coeffs,
+    );
+    interpolate_and_evaluate_at_2n(
+        n,
+        &mem.points_g,
+        &mut mem.evals_g,
+        &mut mem.poly_mem,
+        &mut mem.coeffs,
+    );
 
     // calculate the proof polynomial as evals_f(r) * evals_g(r)
     // only add non-zero points

--- a/src/vdaf/prio2/client.rs
+++ b/src/vdaf/prio2/client.rs
@@ -6,7 +6,7 @@
 use crate::{
     codec::CodecError,
     field::FftFriendlyFieldElement,
-    polynomial::{poly_fft, PolyAuxMemory},
+    polynomial::{fft_get_roots, poly_fft, PolyFFTTempMemory},
     prng::{Prng, PrngError},
     vdaf::{
         xof::{Seed, SeedStreamAes128},
@@ -48,7 +48,9 @@ pub(crate) struct ClientMemory<F> {
     points_g: Vec<F>,
     evals_f: Vec<F>,
     evals_g: Vec<F>,
-    poly_mem: PolyAuxMemory<F>,
+    roots_2n: Vec<F>,
+    roots_n_inverted: Vec<F>,
+    fft_memory: PolyFFTTempMemory<F>,
     coeffs: Vec<F>,
 }
 
@@ -73,7 +75,9 @@ impl<F: FftFriendlyFieldElement> ClientMemory<F> {
             points_g: vec![F::zero(); n],
             evals_f: vec![F::zero(); 2 * n],
             evals_g: vec![F::zero(); 2 * n],
-            poly_mem: PolyAuxMemory::new(n),
+            roots_2n: fft_get_roots(2 * n, false),
+            roots_n_inverted: fft_get_roots(n, true),
+            fft_memory: PolyFFTTempMemory::new(2 * n),
             coeffs: vec![F::zero(); 2 * n],
         })
     }
@@ -203,33 +207,23 @@ pub(crate) fn unpack_proof_mut<F: FftFriendlyFieldElement>(
 ///   unity. This must have length n.
 /// * `evals_out` - The values that the polynomial takes on when evaluated at the 2nth roots of
 ///   unity. This must have length 2 * n.
-/// * `mem` - Precomputed roots of unity and scratch space for the FFT algorithm.
+/// * `roots_n_inverted` - Precomputed inverses of the nth roots of unity.
+/// * `roots_2n` - Precomputed 2nth roots of unity.
+/// * `fft_memory` - Scratch space for the FFT algorithm.
 /// * `coeffs` - Scratch space. This must have length 2 * n.
 fn interpolate_and_evaluate_at_2n<F: FftFriendlyFieldElement>(
     n: usize,
     points_in: &[F],
     evals_out: &mut [F],
-    mem: &mut PolyAuxMemory<F>,
+    roots_n_inverted: &[F],
+    roots_2n: &[F],
+    fft_memory: &mut PolyFFTTempMemory<F>,
     coeffs: &mut [F],
 ) {
     // interpolate through roots of unity
-    poly_fft(
-        coeffs,
-        points_in,
-        &mem.roots_n_inverted,
-        n,
-        true,
-        &mut mem.fft_memory,
-    );
+    poly_fft(coeffs, points_in, roots_n_inverted, n, true, fft_memory);
     // evaluate at 2N roots of unity
-    poly_fft(
-        evals_out,
-        coeffs,
-        &mem.roots_2n,
-        2 * n,
-        false,
-        &mut mem.fft_memory,
-    );
+    poly_fft(evals_out, coeffs, roots_2n, 2 * n, false, fft_memory);
 }
 
 /// Proof construction
@@ -272,14 +266,18 @@ fn construct_proof<F: FftFriendlyFieldElement>(
         n,
         &mem.points_f,
         &mut mem.evals_f,
-        &mut mem.poly_mem,
+        &mem.roots_n_inverted,
+        &mem.roots_2n,
+        &mut mem.fft_memory,
         &mut mem.coeffs,
     );
     interpolate_and_evaluate_at_2n(
         n,
         &mem.points_g,
         &mut mem.evals_g,
-        &mut mem.poly_mem,
+        &mem.roots_n_inverted,
+        &mem.roots_2n,
+        &mut mem.fft_memory,
         &mut mem.coeffs,
     );
 


### PR DESCRIPTION
This removes one precomputed array and moves another to a test-only struct. This fixes a lint with the 1.79.0 toolchain.