### PR TITLE
Fix unused field warnings, 0.15 backport

### DIFF
--- a/src/benchmarked.rs
+++ b/src/benchmarked.rs
@@ -9,7 +9,7 @@ use crate::fft::discrete_fourier_transform;
 use crate::field::FftFriendlyFieldElement;
 use crate::flp::gadgets::Mul;
 use crate::flp::FlpError;
-use crate::polynomial::{poly_fft, PolyAuxMemory};
+use crate::polynomial::{fft_get_roots, poly_fft, PolyFFTTempMemory};
 
 /// Sets `outp` to the Discrete Fourier Transform (DFT) using an iterative FFT algorithm.
 pub fn benchmarked_iterative_fft<F: FftFriendlyFieldElement>(outp: &mut [F], inp: &[F]) {
@@ -18,15 +18,9 @@ pub fn benchmarked_iterative_fft<F: FftFriendlyFieldElement>(outp: &mut [F], inp
 
 /// Sets `outp` to the Discrete Fourier Transform (DFT) using a recursive FFT algorithm.
 pub fn benchmarked_recursive_fft<F: FftFriendlyFieldElement>(outp: &mut [F], inp: &[F]) {
-    let mut mem = PolyAuxMemory::new(inp.len() / 2);
-    poly_fft(
-        outp,
-        inp,
-        &mem.roots_2n,
-        inp.len(),
-        false,
-        &mut mem.fft_memory,
-    )
+    let roots_2n = fft_get_roots(inp.len(), false);
+    let mut fft_memory = PolyFFTTempMemory::new(inp.len());
+    poly_fft(outp, inp, &roots_2n, inp.len(), false, &mut fft_memory)
 }
 
 /// Sets `outp` to `inp[0] * inp[1]`, where `inp[0]` and `inp[1]` are polynomials. This function

--- a/src/fft.rs
+++ b/src/fft.rs
@@ -126,7 +126,7 @@ fn bitrev(d: usize, x: usize) -> usize {
 mod tests {
     use super::*;
     use crate::field::{random_vector, split_vector, Field128, Field64, FieldElement, FieldPrio2};
-    use crate::polynomial::{poly_fft, PolyAuxMemory};
+    use crate::polynomial::{poly_fft, TestPolyAuxMemory};
 
     fn discrete_fourier_transform_then_inv_test<F: FftFriendlyFieldElement>() -> Result<(), FftError>
     {
@@ -163,7 +163,7 @@ mod tests {
     #[test]
     fn test_recursive_fft() {
         let size = 128;
-        let mut mem = PolyAuxMemory::new(size / 2);
+        let mut mem = TestPolyAuxMemory::new(size / 2);
 
         let inp = random_vector(size).unwrap();
         let mut want = vec![FieldPrio2::zero(); size];

--- a/src/polynomial.rs
+++ b/src/polynomial.rs
@@ -32,7 +32,6 @@ impl<F: FftFriendlyFieldElement> PolyFFTTempMemory<F> {
 pub struct PolyAuxMemory<F> {
     pub roots_2n: Vec<F>,
     pub roots_n_inverted: Vec<F>,
-    pub coeffs: Vec<F>,
     pub fft_memory: PolyFFTTempMemory<F>,
 }
 
@@ -41,7 +40,6 @@ impl<F: FftFriendlyFieldElement> PolyAuxMemory<F> {
         PolyAuxMemory {
             roots_2n: fft_get_roots(2 * n, false),
             roots_n_inverted: fft_get_roots(n, true),
-            coeffs: vec![F::zero(); 2 * n],
             fft_memory: PolyFFTTempMemory::new(2 * n),
         }
     }


### PR DESCRIPTION
This is a backport of #1077 to fix some new compiler warnings with rustc 1.79.0.