### PR TITLE
bt: Implementing binary tree backed by a vector.

### DIFF
--- a/src/bt.rs
+++ b/src/bt.rs
@@ -317,7 +317,9 @@ impl<V: Decode> Decode for BinaryTree<V> {
                         parent_index,
                     });
 
-                    let Some(node) = item.parent_index else { continue };
+                    let Some(node) = item.parent_index else {
+                        continue;
+                    };
                     if item.is_left {
                         tree.nodes[node].left = parent_index;
                     } else {

--- a/src/bt.rs
+++ b/src/bt.rs
@@ -228,7 +228,6 @@ impl<V> BinaryTree<V> {
     pub fn get_node_at(&self, node_ref: NodeRef, path: &Path) -> Option<NodeRef> {
         self.is_valid_node_ref(node_ref).then_some(())?;
 
-        let new_index = self.nodes.len();
         let mut node = (!self.nodes.is_empty()).then_some(node_ref.0);
         for bit in path.iter() {
             let next = &self.nodes[node?];
@@ -301,7 +300,7 @@ impl<V: Decode> Decode for BinaryTree<V> {
     fn decode(bytes: &mut Cursor<&[u8]>) -> Result<Self, CodecError> {
         #[derive(Default)]
         struct Item {
-            index: Option<usize>,
+            parent_index: Option<usize>,
             is_left: bool,
         }
 
@@ -313,23 +312,23 @@ impl<V: Decode> Decode for BinaryTree<V> {
             match NodeMarker::decode(bytes)? {
                 NodeMarker::Leaf => (),
                 NodeMarker::Inner => {
-                    let index = Some(tree.nodes.len());
+                    let parent_index = Some(tree.nodes.len());
                     tree.nodes.push(Node::new(V::decode(bytes)?));
 
                     stack.push(Item {
                         is_left: false,
-                        index,
+                        parent_index,
                     });
                     stack.push(Item {
                         is_left: true,
-                        index,
+                        parent_index,
                     });
 
-                    let Some(node) = item.index else { continue };
+                    let Some(node) = item.parent_index else { continue };
                     if item.is_left {
-                        tree.nodes[node].left = index;
+                        tree.nodes[node].left = parent_index;
                     } else {
-                        tree.nodes[node].right = index;
+                        tree.nodes[node].right = parent_index;
                     }
                 }
             }


### PR DESCRIPTION
Related to #947.

Using a vector of nodes to represent an append-only binary tree.

E.g. This is the representation of a tree with three nodes. 
```mermaid
flowchart TB
    A --> B
    A --> C
```
In-memory storage:

|NodeRef| Node | Left | Right |
|--|--|--|--|
|0| A | 1 | 2|
|1| B | None  | None |
|2| C | None  | None |

Encoded representation: Nodes are serialized in a pre-order ordering.

The table of nodes starts with `NODES_CAPACITY=256` nodes pre-allocated in order to reduce frequent allocations.

## Benchmark Comparison

Code for the benchmark comparison: https://github.com/armfazh/libprio-rs/pull/3

**Task:** Insert `NUM_PATHS=1000` random paths of length N.

Old: Uses canonical pointers data structure (main).
New: Uses a table (`Vec`) to store nodes (this PR).

Root: Traverses the tree from the root node.
Node: Traverses the tree from the last node inserted. 

See **new** timings [below](https://github.com/divviup/libprio-rs/pull/1080#issuecomment-2225410553) in the thread of comments.
