### PR TITLE
Experiment: alternate Prio3Count validity circuit

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -457,8 +457,10 @@ dependencies = [
 [[package]]
 name = "iai"
 version = "0.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "71a816c97c42258aa5834d07590b718b4c9a598944cd39a52dc25b351185d678"
+source = "git+https://github.com/sigaloid/iai?rev=d56a5971f6d5556cd9e9b92e7e0f753c9ce9cdc7#d56a5971f6d5556cd9e9b92e7e0f753c9ce9cdc7"
+dependencies = [
+ "cfg-if",
+]
 
 [[package]]
 name = "inout"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -83,3 +83,6 @@ rustdoc-args = ["--cfg", "docsrs"]
 
 [package.metadata.cargo-all-features]
 skip_optional_dependencies = true
+
+[patch.crates-io]
+iai = { git = "https://github.com/sigaloid/iai", rev = "d56a5971f6d5556cd9e9b92e7e0f753c9ce9cdc7" }

--- a/benches/cycle_counts.rs
+++ b/benches/cycle_counts.rs
@@ -102,6 +102,16 @@ fn prio3_client_count() -> Vec<Prio3InputShare<Field64, 16>> {
         .1
 }
 
+fn prio3_client_slim_count() -> Vec<Prio3InputShare<Field64, 16>> {
+    let prio3 = Prio3::new_slim_count(2).unwrap();
+    let measurement = true;
+    let nonce = [0; 16];
+    prio3
+        .shard(&black_box(measurement), &black_box(nonce))
+        .unwrap()
+        .1
+}
+
 fn prio3_client_histogram_10() -> Vec<Prio3InputShare<Field128, 16>> {
     let prio3 = Prio3::new_histogram(2, 10, 3).unwrap();
     let measurement = 9;
@@ -250,6 +260,7 @@ macro_rules! main_base {
             prng_1024,
             prng_4096,
             prio3_client_count,
+            prio3_client_slim_count,
             prio3_client_histogram_10,
             prio3_client_sum_32,
             prio3_client_count_vec_1000,

--- a/benches/speed_tests.rs
+++ b/benches/speed_tests.rs
@@ -181,6 +181,25 @@ fn prio3(c: &mut Criterion) {
         });
     });
 
+    c.bench_function("prio3slimcount_shard", |b| {
+        let vdaf = Prio3::new_slim_count(num_shares).unwrap();
+        let measurement = black_box(true);
+        let nonce = black_box([0u8; 16]);
+        b.iter(|| vdaf.shard(&measurement, &nonce).unwrap());
+    });
+
+    c.bench_function("prio3slimcount_prepare_init", |b| {
+        let vdaf = Prio3::new_slim_count(num_shares).unwrap();
+        let measurement = black_box(true);
+        let nonce = black_box([0u8; 16]);
+        let verify_key = black_box([0u8; 16]);
+        let (public_share, input_shares) = vdaf.shard(&measurement, &nonce).unwrap();
+        b.iter(|| {
+            vdaf.prepare_init(&verify_key, 0, &(), &nonce, &public_share, &input_shares[0])
+                .unwrap()
+        });
+    });
+
     let mut group = c.benchmark_group("prio3sum_shard");
     for bits in [8, 32] {
         group.bench_with_input(BenchmarkId::from_parameter(bits), &bits, |b, bits| {

--- a/binaries/src/bin/vdaf_message_sizes.rs
+++ b/binaries/src/bin/vdaf_message_sizes.rs
@@ -6,8 +6,8 @@ use prio::{
     vdaf::{
         prio2::Prio2,
         prio3::{
-            Prio3, Prio3Count, Prio3FixedPointBoundedL2VecSum, Prio3Histogram, Prio3Sum,
-            Prio3SumVec,
+            Prio3, Prio3Count, Prio3FixedPointBoundedL2VecSum, Prio3Histogram, Prio3SlimCount,
+            Prio3Sum, Prio3SumVec,
         },
         Client, Vdaf,
     },
@@ -22,6 +22,13 @@ fn main() {
     println!(
         "prio3 count share size = {}",
         vdaf_input_share_size::<Prio3Count, 16>(prio3.shard(&measurement, &nonce).unwrap())
+    );
+
+    let prio3 = Prio3::new_slim_count(num_shares).unwrap();
+    let measurement = true;
+    println!(
+        "prio3 slim count share size = {}",
+        vdaf_input_share_size::<Prio3SlimCount, 16>(prio3.shard(&measurement, &nonce).unwrap())
     );
 
     let length = 10;

--- a/src/flp/types.rs
+++ b/src/flp/types.rs
@@ -3,7 +3,7 @@
 //! A collection of [`Type`] implementations.
 
 use crate::field::{FftFriendlyFieldElement, FieldElementWithIntegerExt};
-use crate::flp::gadgets::{Mul, ParallelSumGadget, PolyEval};
+use crate::flp::gadgets::{Mul, ParallelSumGadget, PolyEval, Range2};
 use crate::flp::{FlpError, Gadget, Type};
 use crate::polynomial::poly_range_check;
 use std::convert::TryInto;
@@ -109,7 +109,7 @@ impl<F: FftFriendlyFieldElement> Type for Count<F> {
 /// aggregate result is the sum of the measurements (i.e., the total number of `1s`).
 #[derive(Clone, PartialEq, Eq)]
 pub struct SlimCount<F> {
-    range_checker: Vec<F>,
+    _phantom: PhantomData<F>,
 }
 
 impl<F> Debug for SlimCount<F> {
@@ -122,7 +122,7 @@ impl<F: FftFriendlyFieldElement> SlimCount<F> {
     /// Return a new [`SlimCount`] type instance.
     pub fn new() -> Self {
         Self {
-            range_checker: poly_range_check(0, 2),
+            _phantom: PhantomData,
         }
     }
 }
@@ -151,7 +151,7 @@ impl<F: FftFriendlyFieldElement> Type for SlimCount<F> {
     }
 
     fn gadget(&self) -> Vec<Box<dyn Gadget<F>>> {
-        vec![Box::new(PolyEval::new(self.range_checker.clone(), 1))]
+        vec![Box::new(Range2::new(1))]
     }
 
     fn valid(

--- a/src/vdaf/prio3.rs
+++ b/src/vdaf/prio3.rs
@@ -44,7 +44,7 @@ use crate::flp::gadgets::{Mul, ParallelSum};
 use crate::flp::types::fixedpoint_l2::{
     compatible_float::CompatibleFloat, FixedPointBoundedL2VecSum,
 };
-use crate::flp::types::{Average, Count, Histogram, Sum, SumVec};
+use crate::flp::types::{Average, Count, Histogram, SlimCount, Sum, SumVec};
 use crate::flp::Type;
 #[cfg(feature = "experimental")]
 use crate::flp::TypeWithNoise;
@@ -79,6 +79,17 @@ impl Prio3Count {
     /// Construct an instance of Prio3Count with the given number of aggregators.
     pub fn new_count(num_aggregators: u8) -> Result<Self, VdafError> {
         Prio3::new(num_aggregators, 1, 0x00000000, Count::new())
+    }
+}
+
+/// An alternate VDAF for the count type. Each measurement is an integer in `[0,2)` and the
+/// aggregate result is the sum.
+pub type Prio3SlimCount = Prio3<SlimCount<Field64>, XofTurboShake128, 16>;
+
+impl Prio3SlimCount {
+    /// Construct an instance of Prio3SlimCount with the given number of aggregators.
+    pub fn new_slim_count(num_aggregators: u8) -> Result<Self, VdafError> {
+        Prio3::new(num_aggregators, 1, 0x00000000, SlimCount::new())
     }
 }
 


### PR DESCRIPTION
This implements the idea from cfrg/draft-irtf-cfrg-vdaf#365 for benchmarking purposes. Thus far, I'm seeing a minimal to negligible speedup, and an input share savings of 8 bytes, or 10%.

```
prio3count_shard        time:   [14.123 µs 14.326 µs 14.652 µs]
Found 16 outliers among 100 measurements (16.00%)
  7 (7.00%) high mild
  9 (9.00%) high severe

prio3count_prepare_init time:   [7.1771 µs 7.2429 µs 7.3371 µs]
Found 14 outliers among 100 measurements (14.00%)
  5 (5.00%) high mild
  9 (9.00%) high severe

prio3slimcount_shard    time:   [14.415 µs 14.540 µs 14.698 µs]
Found 11 outliers among 100 measurements (11.00%)
  3 (3.00%) high mild
  8 (8.00%) high severe

prio3slimcount_prepare_init
                        time:   [7.1170 µs 7.1765 µs 7.2584 µs]
Found 10 outliers among 100 measurements (10.00%)
  3 (3.00%) high mild
  7 (7.00%) high severe
```

```
prio3_client_count
  Instructions:               45244
  L1 Accesses:                60594
  L2 Accesses:                   77
  RAM Accesses:                 316
  Estimated Cycles:           72039

prio3_client_slim_count
  Instructions:               44027
  L1 Accesses:                58945
  L2 Accesses:                   80
  RAM Accesses:                 314
  Estimated Cycles:           70335
```

```
prio3 count share size = 80
prio3 slim count share size = 72
```

Notably, my first try at implementing this using PolyEval resulted in a slight performance regression. I attributed this to the extra multiplications by the coefficients of the constant "x^2 - x + 0" polynomial inside the PolyEval gadget. I recovered this loss by implementing a specialized gadget, which just squared the input field element or polynomial and subtracted, but this still wasn't enough for a noticeable performance win over the status quo.