### PR TITLE
Creating a 32-bit implementation for Fp32

### DIFF
--- a/documentation/field_parameters.sage
+++ b/documentation/field_parameters.sage
@@ -102,11 +102,11 @@ class Field:
 
 FIELDS = [
     Field(
-        "FieldPrio2, u128",
+        "FieldPrio2, u32",
         2 ^ 20 * 4095 + 1,
         3925978153,
-        2 ^ 64,
-        2 ^ 128,
+        2 ^ 32,
+        2 ^ 32,
     ),
     Field(
         "Field64, u128",

--- a/src/field.rs
+++ b/src/field.rs
@@ -9,7 +9,8 @@
 
 use crate::{
     codec::{CodecError, Decode, Encode},
-    fp::{FP128, FP32},
+    fp::FP128,
+    fp32::FP32,
     fp64::FP64,
     prng::{Prng, PrngError},
 };
@@ -815,9 +816,9 @@ impl Integer for u128 {
 }
 
 make_field!(
-    /// Same as Field32, but encoded in little endian for compatibility with Prio v2.
+    /// `GF(4293918721)`, a 32-bit field.
     FieldPrio2,
-    u128,
+    u32,
     u32,
     FP32,
     4,

--- a/src/fp32.rs
+++ b/src/fp32.rs
@@ -1,36 +1,36 @@
 // SPDX-License-Identifier: MPL-2.0
 
-//! Finite field arithmetic for any field GF(p) for which p < 2^64.
+//! Finite field arithmetic for any field GF(p) for which p < 2^32.
 
-use crate::fp::{hi64, lo64, MAX_ROOTS};
+use crate::fp::{hi32, lo32, MAX_ROOTS};
 
-/// This structure represents the parameters of a finite field GF(p) for which p < 2^64.
+/// This structure represents the parameters of a finite field GF(p) for which p < 2^32.
 ///
 /// See also [`FieldParameters`](crate::fp::FieldParameters).
 #[derive(Debug, PartialEq, Eq)]
-pub(crate) struct FieldParameters64 {
+pub(crate) struct FieldParameters32 {
     /// The prime modulus `p`.
-    pub p: u64,
-    /// `mu = -p^(-1) mod 2^64`.
-    pub mu: u64,
-    /// `r2 = (2^64)^2 mod p`.
-    pub r2: u64,
+    pub p: u32,
+    /// `mu = -p^(-1) mod 2^32`.
+    pub mu: u32,
+    /// `r2 = (2^32)^2 mod p`.
+    pub r2: u32,
     /// The `2^num_roots`-th -principal root of unity. This element is used to generate the
     /// elements of `roots`.
-    pub g: u64,
+    pub g: u32,
     /// The number of principal roots of unity in `roots`.
     pub num_roots: usize,
     /// Equal to `2^b - 1`, where `b` is the length of `p` in bits.
-    pub bit_mask: u64,
+    pub bit_mask: u32,
     /// `roots[l]` is the `2^l`-th principal root of unity, i.e., `roots[l]` has order `2^l` in the
     /// multiplicative group. `roots[0]` is equal to one by definition.
-    pub roots: [u64; MAX_ROOTS + 1],
+    pub roots: [u32; MAX_ROOTS + 1],
 }
 
-impl FieldParameters64 {
+impl FieldParameters32 {
     /// Addition. The result will be in [0, p), so long as both x and y are as well.
     #[inline(always)]
-    pub fn add(&self, x: u64, y: u64) -> u64 {
+    pub fn add(&self, x: u32, y: u32) -> u32 {
         //   0,x
         // + 0,y
         // =====
@@ -41,22 +41,22 @@ impl FieldParameters64 {
         // ========
         // b1,s1,s0
         let (s0, b0) = z.overflowing_sub(self.p);
-        let (_s1, b1) = (carry as u64).overflowing_sub(b0 as u64);
+        let (_s1, b1) = (carry as u32).overflowing_sub(b0 as u32);
         // if b1 == 1: return z
         // else:       return s0
-        let m = 0u64.wrapping_sub(b1 as u64);
+        let m = 0u32.wrapping_sub(b1 as u32);
         (z & m) | (s0 & !m)
     }
 
     /// Subtraction. The result will be in [0, p), so long as both x and y are as well.
     #[inline(always)]
-    pub fn sub(&self, x: u64, y: u64) -> u64 {
+    pub fn sub(&self, x: u32, y: u32) -> u32 {
         //        x
         // -      y
         // ========
         //    b0,z0
         let (z0, b0) = x.overflowing_sub(y);
-        let m = 0u64.wrapping_sub(b0 as u64);
+        let m = 0u32.wrapping_sub(b0 as u32);
         //      z0
         // +     p
         // ========
@@ -76,7 +76,7 @@ impl FieldParameters64 {
     ///
     /// [montgomery]: https://www.ams.org/journals/mcom/1985-44-170/S0025-5718-1985-0777282-X/S0025-5718-1985-0777282-X.pdf
     #[inline(always)]
-    pub fn mul(&self, x: u64, y: u64) -> u64 {
+    pub fn mul(&self, x: u32, y: u32) -> u32 {
         let mut zz = [0; 2];
 
         // Integer multiplication
@@ -86,12 +86,12 @@ impl FieldParameters64 {
         // *   y
         // =====
         // z1,z0
-        let result = (x as u128) * (y as u128);
-        zz[0] = lo64(result) as u64;
-        zz[1] = hi64(result) as u64;
+        let result = (x as u64) * (y as u64);
+        zz[0] = lo32(result) as u32;
+        zz[1] = hi32(result) as u32;
 
         // Montgomery Reduction
-        // z = z + p * mu*(z mod 2^64), where mu = (-p)^(-1) mod 2^64.
+        // z = z + p * mu*(z mod 2^32), where mu = (-p)^(-1) mod 2^32.
 
         // z1,z0
         // +   p
@@ -99,14 +99,14 @@ impl FieldParameters64 {
         // =====
         // z1, 0
         let w = self.mu.wrapping_mul(zz[0]);
-        let result = (self.p as u128) * (w as u128);
-        let hi = hi64(result);
-        let lo = lo64(result) as u64;
+        let result = (self.p as u64) * (w as u64);
+        let hi = hi32(result);
+        let lo = lo32(result) as u32;
         let (result, carry) = zz[0].overflowing_add(lo);
         zz[0] = result;
-        let result = zz[1] as u128 + hi + carry as u128;
-        zz[1] = lo64(result) as u64;
-        let cc = hi64(result) as u64;
+        let result = zz[1] as u64 + hi + carry as u64;
+        zz[1] = lo32(result) as u32;
+        let cc = hi32(result) as u32;
 
         // z = (z1)
         let prod = zz[1];
@@ -119,18 +119,18 @@ impl FieldParameters64 {
         // ========
         // b1,s1,s0
         let (s0, b0) = prod.overflowing_sub(self.p);
-        let (_s1, b1) = cc.overflowing_sub(b0 as u64);
+        let (_s1, b1) = cc.overflowing_sub(b0 as u32);
         // if b1 == 1: return z
         // else:       return s0
-        let mask = 0u64.wrapping_sub(b1 as u64);
+        let mask = 0u32.wrapping_sub(b1 as u32);
         (prod & mask) | (s0 & !mask)
     }
 
     /// Modular exponentiation, i.e., `x^exp (mod p)` where `p` is the modulus. Note that the
     /// runtime of this algorithm is linear in the bit length of `exp`.
-    pub fn pow(&self, x: u64, exp: u64) -> u64 {
+    pub fn pow(&self, x: u32, exp: u32) -> u32 {
         let mut t = self.montgomery(1);
-        for i in (0..64 - exp.leading_zeros()).rev() {
+        for i in (0..32 - exp.leading_zeros()).rev() {
             t = self.mul(t, t);
             if (exp >> i) & 1 != 0 {
                 t = self.mul(t, x);
@@ -142,13 +142,13 @@ impl FieldParameters64 {
     /// Modular inversion, i.e., x^-1 (mod p) where `p` is the modulus. Note that the runtime of
     /// this algorithm is linear in the bit length of `p`.
     #[inline(always)]
-    pub fn inv(&self, x: u64) -> u64 {
+    pub fn inv(&self, x: u32) -> u32 {
         self.pow(x, self.p - 2)
     }
 
     /// Negation, i.e., `-x (mod p)` where `p` is the modulus.
     #[inline(always)]
-    pub fn neg(&self, x: u64) -> u64 {
+    pub fn neg(&self, x: u32) -> u32 {
         self.sub(0, x)
     }
 
@@ -159,10 +159,10 @@ impl FieldParameters64 {
     /// ```text
     /// let integer = 1; // Standard integer representation
     /// let elem = fp.montgomery(integer); // Internal representation in the Montgomery domain
-    /// assert_eq!(elem, 2564090464);
+    /// assert_eq!(elem, 1048575);
     /// ```
     #[inline(always)]
-    pub fn montgomery(&self, x: u64) -> u64 {
+    pub fn montgomery(&self, x: u32) -> u32 {
         modp(self.mul(x, self.r2), self.p)
     }
 
@@ -170,52 +170,34 @@ impl FieldParameters64 {
     ///
     /// #Example usage
     /// ```text
-    /// let elem = 2564090464; // Internal representation in the Montgomery domain
+    /// let elem = 1048575; // Internal representation in the Montgomery domain
     /// let integer = fp.residue(elem); // Standard integer representation
     /// assert_eq!(integer, 1);
     /// ```
     #[inline(always)]
-    pub fn residue(&self, x: u64) -> u64 {
+    pub fn residue(&self, x: u32) -> u32 {
         modp(self.mul(x, 1), self.p)
     }
 }
 
 #[inline(always)]
-fn modp(x: u64, p: u64) -> u64 {
+fn modp(x: u32, p: u32) -> u32 {
     let (z, carry) = x.overflowing_sub(p);
-    let m = 0u64.wrapping_sub(carry as u64);
+    let m = 0u32.wrapping_sub(carry as u32);
     z.wrapping_add(m & p)
 }
 
-pub(crate) const FP64: FieldParameters64 = FieldParameters64 {
-    p: 18446744069414584321, // 64-bit prime
-    mu: 18446744069414584319,
-    r2: 18446744065119617025,
-    g: 15733474329512464024,
-    num_roots: 32,
-    bit_mask: 18446744073709551615,
+pub(crate) const FP32: FieldParameters32 = FieldParameters32 {
+    p: 4293918721, // 32-bit prime
+    mu: 4293918719,
+    r2: 266338049,
+    g: 3903828692,
+    num_roots: 20,
+    bit_mask: 4294967295,
     roots: [
-        4294967295,
-        18446744065119617026,
-        18446744069414518785,
-        18374686475393433601,
-        268435456,
-        18446673700670406657,
-        18446744069414584193,
-        576460752303421440,
-        16576810576923738718,
-        6647628942875889800,
-        10087739294013848503,
-        2135208489130820273,
-        10781050935026037169,
-        3878014442329970502,
-        1205735313231991947,
-        2523909884358325590,
-        13797134855221748930,
-        12267112747022536458,
-        430584883067102937,
-        10135969988448727187,
-        6815045114074884550,
+        1048575, 4292870146, 1189722990, 3984864191, 2523259768, 2828840154, 1658715539,
+        1534972560, 3732920810, 3229320047, 2836564014, 2170197442, 3760663902, 2144268387,
+        3849278021, 1395394315, 574397626, 125025876, 3755041587, 2680072542, 3903828692,
     ],
 };
 
@@ -229,7 +211,7 @@ mod tests {
 
     use super::*;
 
-    impl TestFieldParameters for FieldParameters64 {
+    impl TestFieldParameters for FieldParameters32 {
         fn p(&self) -> u128 {
             self.p.into()
         }
@@ -239,7 +221,7 @@ mod tests {
         }
 
         fn base(&self) -> u128 {
-            1u128 << 64
+            1u128 << 32
         }
 
         fn r2(&self) -> u128 {
@@ -247,7 +229,7 @@ mod tests {
         }
 
         fn mu(&self) -> u64 {
-            self.mu
+            self.mu as u64
         }
 
         fn bit_mask(&self) -> u128 {
@@ -263,35 +245,35 @@ mod tests {
         }
 
         fn montgomery(&self, x: u128) -> u128 {
-            FieldParameters64::montgomery(self, x.try_into().unwrap()).into()
+            FieldParameters32::montgomery(self, x.try_into().unwrap()).into()
         }
 
         fn residue(&self, x: u128) -> u128 {
-            FieldParameters64::residue(self, x.try_into().unwrap()).into()
+            FieldParameters32::residue(self, x.try_into().unwrap()).into()
         }
 
         fn add(&self, x: u128, y: u128) -> u128 {
-            FieldParameters64::add(self, x.try_into().unwrap(), y.try_into().unwrap()).into()
+            FieldParameters32::add(self, x.try_into().unwrap(), y.try_into().unwrap()).into()
         }
 
         fn sub(&self, x: u128, y: u128) -> u128 {
-            FieldParameters64::sub(self, x.try_into().unwrap(), y.try_into().unwrap()).into()
+            FieldParameters32::sub(self, x.try_into().unwrap(), y.try_into().unwrap()).into()
         }
 
         fn neg(&self, x: u128) -> u128 {
-            FieldParameters64::neg(self, x.try_into().unwrap()).into()
+            FieldParameters32::neg(self, x.try_into().unwrap()).into()
         }
 
         fn mul(&self, x: u128, y: u128) -> u128 {
-            FieldParameters64::mul(self, x.try_into().unwrap(), y.try_into().unwrap()).into()
+            FieldParameters32::mul(self, x.try_into().unwrap(), y.try_into().unwrap()).into()
         }
 
         fn pow(&self, x: u128, exp: u128) -> u128 {
-            FieldParameters64::pow(self, x.try_into().unwrap(), exp.try_into().unwrap()).into()
+            FieldParameters32::pow(self, x.try_into().unwrap(), exp.try_into().unwrap()).into()
         }
 
         fn inv(&self, x: u128) -> u128 {
-            FieldParameters64::inv(self, x.try_into().unwrap()).into()
+            FieldParameters32::inv(self, x.try_into().unwrap()).into()
         }
 
         fn radix(&self) -> BigInt {
@@ -300,12 +282,12 @@ mod tests {
     }
 
     #[test]
-    fn test_fp64_u64() {
+    fn test_fp32_u32() {
         all_field_parameters_tests(TestFieldParametersData {
-            fp: Box::new(FP64),
-            expected_p: 18446744069414584321,
-            expected_g: 1753635133440165772,
-            expected_order: 1 << 32,
-        })
+            fp: Box::new(FP32),
+            expected_p: 4293918721,
+            expected_g: 3925978153,
+            expected_order: 1 << 20,
+        });
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -25,6 +25,7 @@ mod fft;
 pub mod field;
 pub mod flp;
 mod fp;
+mod fp32;
 mod fp64;
 #[cfg(all(feature = "crypto-dependencies", feature = "experimental"))]
 #[cfg_attr(


### PR DESCRIPTION
This is a 32-bit oriented implementation for GF(p) where p is a 32-bit prime.

Compared to #1097 , the timings are quite similar since I'm measuring both in a 64-bit machine. It would be interesting how they perform on a native 32-bit architecture.


| poly_mul | n | Time| Change|
|--|--|--|--|
|fft    |   1   | 205.57 ns | -18.674% |
|fft    |   30  | 5.1169 µs | -38.846% |
|fft    |   60  | 10.664 µs | -49.509% |
|fft    |   90  | 23.202 µs | -43.997% |
|fft    |   120 | 23.830 µs | -43.156% |
|fft    |   150 | 50.701 µs | -45.515% |
|fft    |   255 | 51.774 µs | -44.655% |
|direct |   1   | 68.716 ns | -26.442% |
|direct |   30  | 4.3859 µs | -46.988% |
|direct |   60  | 18.329 µs | -45.414% |
|direct |   90  | 69.479 µs | -46.361% |
|direct |   120 | 69.879 µs | -48.257% |
|direct |   150 | 279.00 µs | -45.679% |
|direct |   255 | 279.15 µs | -44.797% |