### PR TITLE
Implement `Prio3MutlihotCountVec`

### DIFF
--- a/src/flp.rs
+++ b/src/flp.rs
@@ -134,7 +134,8 @@ pub trait Type: Sized + Eq + Clone + Debug {
         measurement: &Self::Measurement,
     ) -> Result<Vec<Self::Field>, FlpError>;
 
-    /// Decode an aggregate result.
+    /// Decode an aggregate result. The input is NOT the inverse of `encode_measurement`. Rather,
+    /// its input is an aggregation of truncated measurements.
     fn decode_result(
         &self,
         data: &[Self::Field],

--- a/src/flp.rs
+++ b/src/flp.rs
@@ -134,8 +134,10 @@ pub trait Type: Sized + Eq + Clone + Debug {
         measurement: &Self::Measurement,
     ) -> Result<Vec<Self::Field>, FlpError>;
 
-    /// Decode an aggregate result. The input is NOT the inverse of `encode_measurement`. Rather,
-    /// its input is an aggregation of truncated measurements.
+    /// Decodes an aggregate result.
+    ///
+    /// This is NOT the inverse of `encode_measurement`. Rather, the input is an aggregation of
+    /// truncated measurements.
     fn decode_result(
         &self,
         data: &[Self::Field],

--- a/src/flp/types.rs
+++ b/src/flp/types.rs
@@ -616,7 +616,7 @@ where
         _num_measurements: usize,
     ) -> Result<Self::AggregateResult, FlpError> {
         // The aggregate is the same as the decoded result. Just convert to integers
-        Ok(data.iter().map(|f| F::Integer::from(*f)).collect())
+        decode_result_vec(data, self.length)
     }
 
     fn gadget(&self) -> Vec<Box<dyn Gadget<F>>> {

--- a/src/flp/types.rs
+++ b/src/flp/types.rs
@@ -516,6 +516,11 @@ impl<F: FftFriendlyFieldElement, S: ParallelSumGadget<F, Mul<F>>> MultihotCountV
                 "chunk_length cannot be zero".to_string(),
             ));
         }
+        if max_weight == 0 {
+            return Err(FlpError::InvalidParameter(
+                "max_weight cannot be zero".to_string(),
+            ));
+        }
 
         // The bitlength of a measurement is the number of buckets plus the bitlength of the max
         // weight

--- a/src/flp/types.rs
+++ b/src/flp/types.rs
@@ -664,6 +664,7 @@ where
     // Truncates the measurement, removing extra data that was necessary for validity (here, the
     // encoded weight), but not important for aggregation
     fn truncate(&self, input: Vec<Self::Field>) -> Result<Vec<Self::Field>, FlpError> {
+        self.truncate_call_check(&input)?;
         // Cut off the encoded weight
         Ok(input[..self.length].to_vec())
     }

--- a/src/flp/types.rs
+++ b/src/flp/types.rs
@@ -670,12 +670,10 @@ where
     }
 
     fn proof_len(&self) -> usize {
-        // TODO: where does this calculation come from? I copied it from Histogram
         (self.chunk_length * 2) + 2 * ((1 + self.gadget_calls).next_power_of_two() - 1) + 1
     }
 
     fn verifier_len(&self) -> usize {
-        // TODO: where does this calculation come from? I copied it from Histogram
         2 + self.chunk_length * 2
     }
 
@@ -690,12 +688,12 @@ where
     }
 
     fn prove_rand_len(&self) -> usize {
-        // TODO: where does this calculation come from? I copied it from Histogram
         self.chunk_length * 2
     }
 
     fn query_rand_len(&self) -> usize {
-        // TODO: where does this calculation come from? I copied it from Histogram
+        // TODO: this will need to be increase once draft-10 is implemented and more randomness is
+        // necessary due to random linear combination computations
         1
     }
 }

--- a/src/vdaf/prio3.rs
+++ b/src/vdaf/prio3.rs
@@ -306,7 +306,7 @@ impl Prio3MultihotCountVec {
     }
 }
 
-/// Like [`Prio3Histogram`] except this type uses multithreading to improve sharding and preparation
+/// Like [`Prio3MultihotCountVec`] except this type uses multithreading to improve sharding and preparation
 /// time. Note that this improvement is only noticeable for very large input lengths.
 #[cfg(feature = "multithreaded")]
 #[cfg_attr(docsrs, doc(cfg(feature = "multithreaded")))]

--- a/src/vdaf/prio3.rs
+++ b/src/vdaf/prio3.rs
@@ -1519,7 +1519,7 @@ where
 /// # Panics
 ///
 /// This function will panic if `input` is zero.
-fn ilog2(input: usize) -> u32 {
+pub(crate) fn ilog2(input: usize) -> u32 {
     if input == 0 {
         panic!("Tried to take the logarithm of zero");
     }

--- a/src/vdaf/prio3.rs
+++ b/src/vdaf/prio3.rs
@@ -44,7 +44,7 @@ use crate::flp::gadgets::{Mul, ParallelSum};
 use crate::flp::types::fixedpoint_l2::{
     compatible_float::CompatibleFloat, FixedPointBoundedL2VecSum,
 };
-use crate::flp::types::{Average, Count, Histogram, Sum, SumVec};
+use crate::flp::types::{Average, Count, Histogram, MultihotCountVec, Sum, SumVec};
 use crate::flp::Type;
 #[cfg(feature = "experimental")]
 use crate::flp::TypeWithNoise;
@@ -278,6 +278,59 @@ impl Prio3HistogramMultithreaded {
             1,
             0x00000003,
             Histogram::new(length, chunk_length)?,
+        )
+    }
+}
+
+/// The multihot counter data type. Each measurement is a list of booleans of length `length`, with
+/// at most `max_weight` true values, and the aggregate is a histogram counting the number of true
+/// values at each position across all measurements.
+pub type Prio3MultihotCountVec =
+    Prio3<MultihotCountVec<Field128, ParallelSum<Field128, Mul<Field128>>>, XofTurboShake128, 16>;
+
+impl Prio3MultihotCountVec {
+    /// Constructs an instance of Prio3MultihotCountVec with the given number of aggregators, number
+    /// of buckets, max weight, and parallel sum gadget chunk length.
+    pub fn new_multihot_count_vec(
+        num_aggregators: u8,
+        num_buckets: usize,
+        max_weight: usize,
+        chunk_length: usize,
+    ) -> Result<Self, VdafError> {
+        Prio3::new(
+            num_aggregators,
+            1,
+            0xFFFF0000,
+            MultihotCountVec::new(num_buckets, max_weight, chunk_length)?,
+        )
+    }
+}
+
+/// Like [`Prio3Histogram`] except this type uses multithreading to improve sharding and preparation
+/// time. Note that this improvement is only noticeable for very large input lengths.
+#[cfg(feature = "multithreaded")]
+#[cfg_attr(docsrs, doc(cfg(feature = "multithreaded")))]
+pub type Prio3MultihotCountVecMultithreaded = Prio3<
+    MultihotCountVec<Field128, ParallelSumMultithreaded<Field128, Mul<Field128>>>,
+    XofTurboShake128,
+    16,
+>;
+
+#[cfg(feature = "multithreaded")]
+impl Prio3MultihotCountVecMultithreaded {
+    /// Constructs an instance of Prio3MultihotCountVecMultithreaded with the given number of
+    /// aggregators, number of buckets, max weight, and parallel sum gadget chunk length.
+    pub fn new_multihot_count_vec_multithreaded(
+        num_aggregators: u8,
+        num_buckets: usize,
+        max_weight: usize,
+        chunk_length: usize,
+    ) -> Result<Self, VdafError> {
+        Prio3::new(
+            num_aggregators,
+            1,
+            0xFFFF0000,
+            MultihotCountVec::new(num_buckets, max_weight, chunk_length)?,
         )
     }
 }


### PR DESCRIPTION
This implements `Prio3MultiHotCountVec` (introduced in draft 10).

Any feedback is welcome. One thing I need: I have some TODOs in here regarding some constants whose origin I don't know or understand. Any pointers would be helpful.

Partially addresses #1122.

cc @divergentdave @cjpatton 