### PR TITLE
Prio3 cleanups

### DIFF
--- a/src/flp/types.rs
+++ b/src/flp/types.rs
@@ -6,7 +6,6 @@ use crate::field::{FftFriendlyFieldElement, FieldElementWithIntegerExt};
 use crate::flp::gadgets::{Mul, ParallelSumGadget, PolyEval};
 use crate::flp::{FlpError, Gadget, Type};
 use crate::polynomial::poly_range_check;
-use crate::vdaf::prio3::ilog2;
 use std::convert::TryInto;
 use std::fmt::{self, Debug};
 use std::marker::PhantomData;
@@ -532,7 +531,7 @@ impl<F: FftFriendlyFieldElement, S: ParallelSumGadget<F, Mul<F>>> MultihotCountV
 
         // The bitlength of a measurement is the number of buckets plus the bitlength of the max
         // weight
-        let bits_for_weight = ilog2(max_weight) as usize + 1;
+        let bits_for_weight = max_weight.ilog2() as usize + 1;
         let meas_length = num_buckets + bits_for_weight;
 
         // Gadget calls is ⌈meas_length / chunk_length⌉
@@ -1211,7 +1210,7 @@ mod tests {
         let nine = TestField::from(9);
 
         let encoded_weight_plus_offset = |weight| {
-            let bits_for_weight = ilog2(max_weight) as usize + 1;
+            let bits_for_weight = max_weight.ilog2() as usize + 1;
             let offset = (1 << bits_for_weight) - 1 - max_weight;
             TestField::encode_as_bitvector(
                 <TestField as FieldElementWithInteger>::Integer::try_from(weight + offset).unwrap(),

--- a/src/vdaf/prio3.rs
+++ b/src/vdaf/prio3.rs
@@ -1565,20 +1565,6 @@ where
     }
 }
 
-/// This is a polyfill for `usize::ilog2()`, which is only available in Rust 1.67 and later. It is
-/// based on the implementation in the standard library. It can be removed when the MSRV has been
-/// advanced past 1.67.
-///
-/// # Panics
-///
-/// This function will panic if `input` is zero.
-pub(crate) fn ilog2(input: usize) -> u32 {
-    if input == 0 {
-        panic!("Tried to take the logarithm of zero");
-    }
-    (usize::BITS - 1) - input.leading_zeros()
-}
-
 /// Finds the optimal choice of chunk length for [`Prio3Histogram`] or [`Prio3SumVec`], given its
 /// encoded measurement length. For [`Prio3Histogram`], the measurement length is equal to the
 /// length parameter. For [`Prio3SumVec`], the measurement length is equal to the product of the
@@ -1594,7 +1580,7 @@ pub fn optimal_chunk_length(measurement_length: usize) -> usize {
         chunk_length: usize,
     }
 
-    let max_log2 = ilog2(measurement_length + 1);
+    let max_log2 = (measurement_length + 1).ilog2();
     let best_opt = (1..=max_log2)
         .rev()
         .map(|log2| {

--- a/src/vdaf/prio3.rs
+++ b/src/vdaf/prio3.rs
@@ -106,7 +106,7 @@ impl Prio3SumVec {
     }
 }
 
-/// Like [`Prio3SumVec`] except this type uses multithreading to improve sharding and preparation
+/// Like [`Prio3SumVec`] except this type uses multithreading to improve sharding
 /// time. Note that the improvement is only noticeable for very large input lengths.
 #[cfg(feature = "multithreaded")]
 #[cfg_attr(docsrs, doc(cfg(feature = "multithreaded")))]
@@ -254,7 +254,7 @@ impl Prio3Histogram {
     }
 }
 
-/// Like [`Prio3Histogram`] except this type uses multithreading to improve sharding and preparation
+/// Like [`Prio3Histogram`] except this type uses multithreading to improve sharding
 /// time. Note that this improvement is only noticeable for very large input lengths.
 #[cfg(feature = "multithreaded")]
 #[cfg_attr(docsrs, doc(cfg(feature = "multithreaded")))]
@@ -306,7 +306,7 @@ impl Prio3MultihotCountVec {
     }
 }
 
-/// Like [`Prio3MultihotCountVec`] except this type uses multithreading to improve sharding and preparation
+/// Like [`Prio3MultihotCountVec`] except this type uses multithreading to improve sharding
 /// time. Note that this improvement is only noticeable for very large input lengths.
 #[cfg(feature = "multithreaded")]
 #[cfg_attr(docsrs, doc(cfg(feature = "multithreaded")))]


### PR DESCRIPTION
This cleans up a couple things I noticed while reviewing #1123. We no longer need a polyfill for `usize::ilog2()`, because our MSRV is currently 1.71, and I corrected the documentation of the rayon-accelerated VDAF types. We only parallelize `eval_poly()` calls to the parallel sum gadget, thus only sharding is sped up. (preparation just needs `eval()` from this gadget, which doesn't require any NTTs)