### PR TITLE
Added `Aggregator::is_agg_param_valid` method

### DIFF
--- a/src/vdaf.rs
+++ b/src/vdaf.rs
@@ -298,6 +298,11 @@ pub trait Aggregator<const VERIFY_KEY_SIZE: usize, const NONCE_SIZE: usize>: Vda
         agg_param: &Self::AggregationParam,
         output_shares: M,
     ) -> Result<Self::AggregateShare, VdafError>;
+
+    /// Validates an aggregation parameter with respect to all previous aggregaiton parameters used
+    /// for the same input share
+    #[must_use]
+    fn is_agg_param_valid(cur: &Self::AggregationParam, prev: &[Self::AggregationParam]) -> bool;
 }
 
 /// Aggregator that implements differential privacy with Aggregator-side noise addition.

--- a/src/vdaf.rs
+++ b/src/vdaf.rs
@@ -300,7 +300,7 @@ pub trait Aggregator<const VERIFY_KEY_SIZE: usize, const NONCE_SIZE: usize>: Vda
     ) -> Result<Self::AggregateShare, VdafError>;
 
     /// Validates an aggregation parameter with respect to all previous aggregaiton parameters used
-    /// for the same input share
+    /// for the same input share. `prev` MUST be sorted from least to most recently used.
     #[must_use]
     fn is_agg_param_valid(cur: &Self::AggregationParam, prev: &[Self::AggregationParam]) -> bool;
 }

--- a/src/vdaf/dummy.rs
+++ b/src/vdaf/dummy.rs
@@ -166,6 +166,10 @@ impl vdaf::Aggregator<0, 16> for Vdaf {
         }
         Ok(aggregate_share)
     }
+
+    fn is_agg_param_valid(_cur: &Self::AggregationParam, _prev: &[Self::AggregationParam]) -> bool {
+        true
+    }
 }
 
 impl vdaf::Client<16> for Vdaf {

--- a/src/vdaf/poplar1.rs
+++ b/src/vdaf/poplar1.rs
@@ -1249,27 +1249,19 @@ impl<P: Xof<SEED_SIZE>, const SEED_SIZE: usize> Aggregator<SEED_SIZE, 16>
 
     /// Validates that no aggregation parameter with the same level as `cur` has been used with the
     /// same input share before. `prev` contains the aggregation parameters used for the same input.
-    ///
-    /// # Panics
-    /// Panics if `prev.len() > 1`
+    /// `prev` MUST be sorted from least to most recently used.
     fn is_agg_param_valid(cur: &Poplar1AggregationParam, prev: &[Poplar1AggregationParam]) -> bool {
-        assert!(
-            prev.len() <= 1,
-            "list of previous aggregation parameters must be of size 0 or 1"
-        );
-
-        // Helper function to determine the prefix of `input` at `last_level`.
-        fn get_ancestor(input: &IdpfInput, this_level: u16, last_level: u16) -> IdpfInput {
-            input.prefix((this_level - last_level) as usize)
-        }
-
-        // Exit early if this is the first time
+        // Exit early if there are no previous aggregation params to compare to, i.e., this is the
+        // first time the input share has been processed
         if prev.is_empty() {
             return true;
         }
 
         // Unpack this agg param and the last one in the list
-        let Poplar1AggregationParam { level, prefixes } = cur;
+        let Poplar1AggregationParam {
+            level: cur_level,
+            prefixes: cur_prefixes,
+        } = cur;
         let Poplar1AggregationParam {
             level: last_level,
             prefixes: last_prefixes,
@@ -1277,20 +1269,15 @@ impl<P: Xof<SEED_SIZE>, const SEED_SIZE: usize> Aggregator<SEED_SIZE, 16>
         let last_prefixes_set = BTreeSet::from_iter(last_prefixes);
 
         // Check that the level increased.
-        if level <= last_level {
+        if cur_level <= last_level {
             return false;
         }
 
-        // Check that prefixes are suffixes of the last level's prefixes.
-        for prefix in prefixes {
-            let last_prefix = get_ancestor(prefix, *level, *last_level);
-            if !last_prefixes_set.contains(&last_prefix) {
-                // Current prefix not a suffix of last level's prefixes.
-                return false;
-            }
-        }
-
-        true
+        // Check that current prefixes are extensions of the last level's prefixes.
+        cur_prefixes.iter().all(|cur_prefix| {
+            let last_prefix = cur_prefix.prefix(*last_level as usize);
+            last_prefixes_set.contains(&last_prefix)
+        })
     }
 }
 
@@ -2024,6 +2011,57 @@ mod tests {
         assert_matches!(err, CodecError::Other(_));
         let err = Poplar1AggregationParam::get_decoded(&[0, 0, 0, 0, 0, 2, 3]).unwrap_err();
         assert_matches!(err, CodecError::Other(_));
+    }
+
+    // Tests Poplar1::is_valid() functionality. This unit tests is translated from
+    // https://github.com/cfrg/draft-irtf-cfrg-vdaf/blob/a4874547794818573acd8734874c9784043b1140/poc/tests/test_vdaf_poplar1.py#L187
+    #[test]
+    fn agg_param_validity() {
+        // The actual Poplar instance doesn't matter for the parameter validity tests
+        type V = Poplar1<XofTurboShake128, 16>;
+
+        // Helper function for making aggregation params
+        fn make_agg_param(bitstrings: &[&[u8]]) -> Result<Poplar1AggregationParam, VdafError> {
+            Poplar1AggregationParam::try_from_prefixes(
+                bitstrings
+                    .iter()
+                    .map(|v| {
+                        let bools = v.iter().map(|&b| b != 0).collect::<Vec<_>>();
+                        IdpfInput::from_bools(&bools)
+                    })
+                    .collect(),
+            )
+        }
+
+        // Test `is_valid` returns False on repeated levels, and True otherwise.
+        let agg_params = [
+            make_agg_param(&[&[0], &[1]]).unwrap(),
+            make_agg_param(&[&[0, 0]]).unwrap(),
+            make_agg_param(&[&[0, 0], &[1, 0]]).unwrap(),
+        ];
+        assert!(V::is_agg_param_valid(&agg_params[0], &[]));
+        assert!(V::is_agg_param_valid(&agg_params[1], &agg_params[..1]));
+        assert!(!V::is_agg_param_valid(&agg_params[2], &agg_params[..2]));
+
+        // Test `is_valid` accepts level jumps.
+        let agg_params = [
+            make_agg_param(&[&[0], &[1]]).unwrap(),
+            make_agg_param(&[&[0, 1, 0], &[0, 1, 1], &[1, 0, 1], &[1, 1, 1]]).unwrap(),
+        ];
+        assert!(V::is_agg_param_valid(&agg_params[1], &agg_params[..1]));
+
+        // Test `is_valid` rejects unconnected prefixes.
+        let agg_params = [
+            make_agg_param(&[&[0]]).unwrap(),
+            make_agg_param(&[&[0, 1, 0], &[0, 1, 1], &[1, 0, 1], &[1, 1, 1]]).unwrap(),
+        ];
+        assert!(!V::is_agg_param_valid(&agg_params[1], &agg_params[..1]));
+
+        // Test that the `Poplar1AggregationParam` constructor rejects unsorted and duplicate
+        // prefixes.
+        assert!(make_agg_param(&[&[1], &[0]]).is_err());
+        assert!(make_agg_param(&[&[1, 0, 0], &[0, 1, 1]]).is_err());
+        assert!(make_agg_param(&[&[0, 0, 0], &[0, 1, 0], &[0, 1, 0]]).is_err());
     }
 
     #[derive(Debug, Deserialize)]

--- a/src/vdaf/poplar1.rs
+++ b/src/vdaf/poplar1.rs
@@ -2013,7 +2013,7 @@ mod tests {
         assert_matches!(err, CodecError::Other(_));
     }
 
-    // Tests Poplar1::is_valid() functionality. This unit tests is translated from
+    // Tests Poplar1::is_valid() functionality. This unit test is translated from
     // https://github.com/cfrg/draft-irtf-cfrg-vdaf/blob/a4874547794818573acd8734874c9784043b1140/poc/tests/test_vdaf_poplar1.py#L187
     #[test]
     fn agg_param_validity() {

--- a/src/vdaf/prio2.rs
+++ b/src/vdaf/prio2.rs
@@ -326,9 +326,9 @@ impl Aggregator<32, 16> for Prio2 {
         Ok(agg_share)
     }
 
-    fn is_agg_param_valid(_cur: &Self::AggregationParam, _prev: &[Self::AggregationParam]) -> bool {
-        // Nothing to do. There are no aggregation parameters (it's the unit type)
-        true
+    /// Returns `true` iff `prev.is_empty()`
+    fn is_agg_param_valid(_cur: &Self::AggregationParam, prev: &[Self::AggregationParam]) -> bool {
+        prev.is_empty()
     }
 }
 

--- a/src/vdaf/prio2.rs
+++ b/src/vdaf/prio2.rs
@@ -325,6 +325,11 @@ impl Aggregator<32, 16> for Prio2 {
 
         Ok(agg_share)
     }
+
+    fn is_agg_param_valid(_cur: &Self::AggregationParam, _prev: &[Self::AggregationParam]) -> bool {
+        // Nothing to do. There are no aggregation parameters (it's the unit type)
+        true
+    }
 }
 
 impl Collector for Prio2 {

--- a/src/vdaf/prio3.rs
+++ b/src/vdaf/prio3.rs
@@ -1442,9 +1442,9 @@ where
         Ok(agg_share)
     }
 
-    fn is_agg_param_valid(_cur: &Self::AggregationParam, _prev: &[Self::AggregationParam]) -> bool {
-        // Nothing to do. There are no aggregation parameters (it's the unit type)
-        true
+    /// Returns `true` iff `prev.is_empty()`
+    fn is_agg_param_valid(_cur: &Self::AggregationParam, prev: &[Self::AggregationParam]) -> bool {
+        prev.is_empty()
     }
 }
 

--- a/src/vdaf/prio3.rs
+++ b/src/vdaf/prio3.rs
@@ -1441,6 +1441,11 @@ where
 
         Ok(agg_share)
     }
+
+    fn is_agg_param_valid(_cur: &Self::AggregationParam, _prev: &[Self::AggregationParam]) -> bool {
+        // Nothing to do. There are no aggregation parameters (it's the unit type)
+        true
+    }
 }
 
 #[cfg(feature = "experimental")]


### PR DESCRIPTION
Copied the method verbatim from [here](https://www.ietf.org/archive/id/draft-irtf-cfrg-vdaf-12.html#section-8.2.3), which is effectively unchanged from draft-09.

One point: this doesn't have any unit tests. I've read and re-read the draft and I still don't quite understand what this is supposed to be testing. A unit test that tests the error case we care about would be much appreciated.