### PR TITLE
cargo vet: zlib-rs audit

### DIFF
--- a/supply-chain/audits.toml
+++ b/supply-chain/audits.toml
@@ -398,6 +398,16 @@ who = "Brandon Pitman <bran@bran.land>"
 criteria = "safe-to-deploy"
 delta = "0.2.149 -> 0.2.150"
 
+[[audits.libz-rs-sys]]
+who = "Ameer Ghani <inahga@divviup.org>"
+criteria = "safe-to-deploy"
+version = "0.4.0"
+notes = """
+This crate uses unsafe since it's for C to Rust FFI. I have reviewed and fuzzed it, and I believe it is free of any serious security problems.
+
+The only dependency is zlib-rs, which is maintained by the same maintainers as this crate.
+"""
+
 [[audits.linux-raw-sys]]
 who = "Brandon Pitman <bran@bran.land>"
 criteria = "safe-to-run"
@@ -838,6 +848,16 @@ version = "7.0.1"
 who = "Tim Geoghegan <timg@divviup.org>"
 criteria = "safe-to-run"
 delta = "7.0.0 -> 7.0.1"
+
+[[audits.zlib-rs]]
+who = "Ameer Ghani <inahga@divviup.org>"
+criteria = "safe-to-deploy"
+version = "0.4.0"
+notes = """
+zlib-rs uses unsafe Rust for invoking compiler intrinsics (i.e. SIMD), eschewing bounds checks, along the FFI boundary, and for interacting with pointers sourced from C. I have extensively reviewed and fuzzed the unsafe code. All findings from that work have been resolved as of version 0.4.0. To the best of my ability, I believe it's free of any serious security problems.
+
+zlib-rs does not require any external dependencies.
+"""
 
 [[trusted.byteorder]]
 criteria = "safe-to-deploy"


### PR DESCRIPTION
I audited this crate on behalf of ISRG. Unfortunately, in the broader cargo vet ecosystem, [this repository is used for ISRG's cargo-vet audits](https://github.com/mozilla/cargo-vet/blob/main/registry.toml#L17).

We decided for now just to submit this audit to libprio-rs, even though zlib-rs is not a dependency of libprio-rs.

The proper thing to do would be to set up a new repository containing aggregated audits, [but since "migrating" repositories in cargo-vet is ill-defined at the moment](https://github.com/mozilla/cargo-vet/issues/159), we decided to hold off on that.