### PR TITLE
Add context string to VDAF

### DIFF
--- a/benches/cycle_counts.rs
+++ b/benches/cycle_counts.rs
@@ -47,7 +47,10 @@ fn prio2_client(size: usize) -> Vec<Share<FieldPrio2, 32>> {
     let prio2 = Prio2::new(size).unwrap();
     let input = vec![0u32; size];
     let nonce = [0; 16];
-    prio2.shard(&black_box(input), &black_box(nonce)).unwrap().1
+    prio2
+        .shard(b"", &black_box(input), &black_box(nonce))
+        .unwrap()
+        .1
 }
 
 #[cfg(feature = "experimental")]
@@ -70,9 +73,19 @@ fn prio2_shard_and_prepare(size: usize) -> Prio2PrepareShare {
     let prio2 = Prio2::new(size).unwrap();
     let input = vec![0u32; size];
     let nonce = [0; 16];
-    let (public_share, input_shares) = prio2.shard(&black_box(input), &black_box(nonce)).unwrap();
+    let (public_share, input_shares) = prio2
+        .shard(b"", &black_box(input), &black_box(nonce))
+        .unwrap();
     prio2
-        .prepare_init(&[0; 32], 0, &(), &nonce, &public_share, &input_shares[0])
+        .prepare_init(
+            &[0; 32],
+            b"",
+            0,
+            &(),
+            &nonce,
+            &public_share,
+            &input_shares[0],
+        )
         .unwrap()
         .1
 }
@@ -97,7 +110,7 @@ fn prio3_client_count() -> Vec<Prio3InputShare<Field64, 16>> {
     let measurement = true;
     let nonce = [0; 16];
     prio3
-        .shard(&black_box(measurement), &black_box(nonce))
+        .shard(b"", &black_box(measurement), &black_box(nonce))
         .unwrap()
         .1
 }
@@ -107,7 +120,7 @@ fn prio3_client_histogram_10() -> Vec<Prio3InputShare<Field128, 16>> {
     let measurement = 9;
     let nonce = [0; 16];
     prio3
-        .shard(&black_box(measurement), &black_box(nonce))
+        .shard(b"", &black_box(measurement), &black_box(nonce))
         .unwrap()
         .1
 }
@@ -117,7 +130,7 @@ fn prio3_client_sum_32() -> Vec<Prio3InputShare<Field128, 16>> {
     let measurement = 1337;
     let nonce = [0; 16];
     prio3
-        .shard(&black_box(measurement), &black_box(nonce))
+        .shard(b"", &black_box(measurement), &black_box(nonce))
         .unwrap()
         .1
 }
@@ -128,7 +141,7 @@ fn prio3_client_count_vec_1000() -> Vec<Prio3InputShare<Field128, 16>> {
     let measurement = vec![0; len];
     let nonce = [0; 16];
     prio3
-        .shard(&black_box(measurement), &black_box(nonce))
+        .shard(b"", &black_box(measurement), &black_box(nonce))
         .unwrap()
         .1
 }
@@ -140,7 +153,7 @@ fn prio3_client_count_vec_multithreaded_1000() -> Vec<Prio3InputShare<Field128, 
     let measurement = vec![0; len];
     let nonce = [0; 16];
     prio3
-        .shard(&black_box(measurement), &black_box(nonce))
+        .shard(b"", &black_box(measurement), &black_box(nonce))
         .unwrap()
         .1
 }

--- a/benches/speed_tests.rs
+++ b/benches/speed_tests.rs
@@ -127,7 +127,7 @@ fn prio2(c: &mut Criterion) {
                     .map(|i| i & 1)
                     .collect::<Vec<_>>();
                 let nonce = black_box([0u8; 16]);
-                b.iter(|| vdaf.shard(&measurement, &nonce).unwrap());
+                b.iter(|| vdaf.shard(b"", &measurement, &nonce).unwrap());
             },
         );
     }
@@ -145,10 +145,18 @@ fn prio2(c: &mut Criterion) {
                     .collect::<Vec<_>>();
                 let nonce = black_box([0u8; 16]);
                 let verify_key = black_box([0u8; 32]);
-                let (public_share, input_shares) = vdaf.shard(&measurement, &nonce).unwrap();
+                let (public_share, input_shares) = vdaf.shard(b"", &measurement, &nonce).unwrap();
                 b.iter(|| {
-                    vdaf.prepare_init(&verify_key, 0, &(), &nonce, &public_share, &input_shares[0])
-                        .unwrap();
+                    vdaf.prepare_init(
+                        &verify_key,
+                        b"",
+                        0,
+                        &(),
+                        &nonce,
+                        &public_share,
+                        &input_shares[0],
+                    )
+                    .unwrap();
                 });
             },
         );
@@ -164,7 +172,7 @@ fn prio3(c: &mut Criterion) {
         let vdaf = Prio3::new_count(num_shares).unwrap();
         let measurement = black_box(true);
         let nonce = black_box([0u8; 16]);
-        b.iter(|| vdaf.shard(&measurement, &nonce).unwrap());
+        b.iter(|| vdaf.shard(b"", &measurement, &nonce).unwrap());
     });
 
     c.bench_function("prio3count_prepare_init", |b| {
@@ -172,10 +180,18 @@ fn prio3(c: &mut Criterion) {
         let measurement = black_box(true);
         let nonce = black_box([0u8; 16]);
         let verify_key = black_box([0u8; 16]);
-        let (public_share, input_shares) = vdaf.shard(&measurement, &nonce).unwrap();
+        let (public_share, input_shares) = vdaf.shard(b"", &measurement, &nonce).unwrap();
         b.iter(|| {
-            vdaf.prepare_init(&verify_key, 0, &(), &nonce, &public_share, &input_shares[0])
-                .unwrap()
+            vdaf.prepare_init(
+                &verify_key,
+                b"",
+                0,
+                &(),
+                &nonce,
+                &public_share,
+                &input_shares[0],
+            )
+            .unwrap()
         });
     });
 
@@ -185,7 +201,7 @@ fn prio3(c: &mut Criterion) {
             let vdaf = Prio3::new_sum(num_shares, *bits).unwrap();
             let measurement = (1 << bits) - 1;
             let nonce = black_box([0u8; 16]);
-            b.iter(|| vdaf.shard(&measurement, &nonce).unwrap());
+            b.iter(|| vdaf.shard(b"", &measurement, &nonce).unwrap());
         });
     }
     group.finish();
@@ -197,10 +213,18 @@ fn prio3(c: &mut Criterion) {
             let measurement = (1 << bits) - 1;
             let nonce = black_box([0u8; 16]);
             let verify_key = black_box([0u8; 16]);
-            let (public_share, input_shares) = vdaf.shard(&measurement, &nonce).unwrap();
+            let (public_share, input_shares) = vdaf.shard(b"", &measurement, &nonce).unwrap();
             b.iter(|| {
-                vdaf.prepare_init(&verify_key, 0, &(), &nonce, &public_share, &input_shares[0])
-                    .unwrap()
+                vdaf.prepare_init(
+                    &verify_key,
+                    b"",
+                    0,
+                    &(),
+                    &nonce,
+                    &public_share,
+                    &input_shares[0],
+                )
+                .unwrap()
             });
         });
     }
@@ -217,7 +241,7 @@ fn prio3(c: &mut Criterion) {
                     .map(|i| i & 1)
                     .collect::<Vec<_>>();
                 let nonce = black_box([0u8; 16]);
-                b.iter(|| vdaf.shard(&measurement, &nonce).unwrap());
+                b.iter(|| vdaf.shard(b"", &measurement, &nonce).unwrap());
             },
         );
     }
@@ -240,7 +264,7 @@ fn prio3(c: &mut Criterion) {
                         .map(|i| i & 1)
                         .collect::<Vec<_>>();
                     let nonce = black_box([0u8; 16]);
-                    b.iter(|| vdaf.shard(&measurement, &nonce).unwrap());
+                    b.iter(|| vdaf.shard(b"", &measurement, &nonce).unwrap());
                 },
             );
         }
@@ -259,10 +283,18 @@ fn prio3(c: &mut Criterion) {
                     .collect::<Vec<_>>();
                 let nonce = black_box([0u8; 16]);
                 let verify_key = black_box([0u8; 16]);
-                let (public_share, input_shares) = vdaf.shard(&measurement, &nonce).unwrap();
+                let (public_share, input_shares) = vdaf.shard(b"", &measurement, &nonce).unwrap();
                 b.iter(|| {
-                    vdaf.prepare_init(&verify_key, 0, &(), &nonce, &public_share, &input_shares[0])
-                        .unwrap()
+                    vdaf.prepare_init(
+                        &verify_key,
+                        b"",
+                        0,
+                        &(),
+                        &nonce,
+                        &public_share,
+                        &input_shares[0],
+                    )
+                    .unwrap()
                 });
             },
         );
@@ -287,7 +319,8 @@ fn prio3(c: &mut Criterion) {
                         .collect::<Vec<_>>();
                     let nonce = black_box([0u8; 16]);
                     let verify_key = black_box([0u8; 16]);
-                    let (public_share, input_shares) = vdaf.shard(&measurement, &nonce).unwrap();
+                    let (public_share, input_shares) =
+                        vdaf.shard(b"", &measurement, &nonce).unwrap();
                     b.iter(|| {
                         vdaf.prepare_init(
                             &verify_key,
@@ -323,7 +356,7 @@ fn prio3(c: &mut Criterion) {
                 let vdaf = Prio3::new_histogram(num_shares, *input_length, *chunk_length).unwrap();
                 let measurement = black_box(0);
                 let nonce = black_box([0u8; 16]);
-                b.iter(|| vdaf.shard(&measurement, &nonce).unwrap());
+                b.iter(|| vdaf.shard(b"", &measurement, &nonce).unwrap());
             },
         );
     }
@@ -352,7 +385,7 @@ fn prio3(c: &mut Criterion) {
                     .unwrap();
                     let measurement = black_box(0);
                     let nonce = black_box([0u8; 16]);
-                    b.iter(|| vdaf.shard(&measurement, &nonce).unwrap());
+                    b.iter(|| vdaf.shard(b"", &measurement, &nonce).unwrap());
                 },
             );
         }
@@ -378,10 +411,18 @@ fn prio3(c: &mut Criterion) {
                 let measurement = black_box(0);
                 let nonce = black_box([0u8; 16]);
                 let verify_key = black_box([0u8; 16]);
-                let (public_share, input_shares) = vdaf.shard(&measurement, &nonce).unwrap();
+                let (public_share, input_shares) = vdaf.shard(b"", &measurement, &nonce).unwrap();
                 b.iter(|| {
-                    vdaf.prepare_init(&verify_key, 0, &(), &nonce, &public_share, &input_shares[0])
-                        .unwrap()
+                    vdaf.prepare_init(
+                        &verify_key,
+                        b"",
+                        0,
+                        &(),
+                        &nonce,
+                        &public_share,
+                        &input_shares[0],
+                    )
+                    .unwrap()
                 });
             },
         );
@@ -412,7 +453,8 @@ fn prio3(c: &mut Criterion) {
                     let measurement = black_box(0);
                     let nonce = black_box([0u8; 16]);
                     let verify_key = black_box([0u8; 16]);
-                    let (public_share, input_shares) = vdaf.shard(&measurement, &nonce).unwrap();
+                    let (public_share, input_shares) =
+                        vdaf.shard(b"", &measurement, &nonce).unwrap();
                     b.iter(|| {
                         vdaf.prepare_init(
                             &verify_key,
@@ -448,7 +490,7 @@ fn prio3(c: &mut Criterion) {
                     let mut measurement = vec![FP16_ZERO; *dimension];
                     measurement[0] = FP16_HALF;
                     let nonce = black_box([0u8; 16]);
-                    b.iter(|| vdaf.shard(&measurement, &nonce).unwrap());
+                    b.iter(|| vdaf.shard(b"", &measurement, &nonce).unwrap());
                 },
             );
         }
@@ -468,7 +510,7 @@ fn prio3(c: &mut Criterion) {
                         let mut measurement = vec![FP16_ZERO; *dimension];
                         measurement[0] = FP16_HALF;
                         let nonce = black_box([0u8; 16]);
-                        b.iter(|| vdaf.shard(&measurement, &nonce).unwrap());
+                        b.iter(|| vdaf.shard(b"", &measurement, &nonce).unwrap());
                     },
                 );
             }
@@ -487,10 +529,12 @@ fn prio3(c: &mut Criterion) {
                     measurement[0] = FP16_HALF;
                     let nonce = black_box([0u8; 16]);
                     let verify_key = black_box([0u8; 16]);
-                    let (public_share, input_shares) = vdaf.shard(&measurement, &nonce).unwrap();
+                    let (public_share, input_shares) =
+                        vdaf.shard(b"", &measurement, &nonce).unwrap();
                     b.iter(|| {
                         vdaf.prepare_init(
                             &verify_key,
+                            b"",
                             0,
                             &(),
                             &nonce,
@@ -520,10 +564,11 @@ fn prio3(c: &mut Criterion) {
                         let nonce = black_box([0u8; 16]);
                         let verify_key = black_box([0u8; 16]);
                         let (public_share, input_shares) =
-                            vdaf.shard(&measurement, &nonce).unwrap();
+                            vdaf.shard(b"", &measurement, &nonce).unwrap();
                         b.iter(|| {
                             vdaf.prepare_init(
                                 &verify_key,
+                                b"",
                                 0,
                                 &(),
                                 &nonce,
@@ -549,7 +594,7 @@ fn prio3(c: &mut Criterion) {
                     let mut measurement = vec![FP32_ZERO; *dimension];
                     measurement[0] = FP32_HALF;
                     let nonce = black_box([0u8; 16]);
-                    b.iter(|| vdaf.shard(&measurement, &nonce).unwrap());
+                    b.iter(|| vdaf.shard(b"", &measurement, &nonce).unwrap());
                 },
             );
         }
@@ -569,7 +614,7 @@ fn prio3(c: &mut Criterion) {
                         let mut measurement = vec![FP32_ZERO; *dimension];
                         measurement[0] = FP32_HALF;
                         let nonce = black_box([0u8; 16]);
-                        b.iter(|| vdaf.shard(&measurement, &nonce).unwrap());
+                        b.iter(|| vdaf.shard(b"", &measurement, &nonce).unwrap());
                     },
                 );
             }
@@ -588,10 +633,12 @@ fn prio3(c: &mut Criterion) {
                     measurement[0] = FP32_HALF;
                     let nonce = black_box([0u8; 16]);
                     let verify_key = black_box([0u8; 16]);
-                    let (public_share, input_shares) = vdaf.shard(&measurement, &nonce).unwrap();
+                    let (public_share, input_shares) =
+                        vdaf.shard(b"", &measurement, &nonce).unwrap();
                     b.iter(|| {
                         vdaf.prepare_init(
                             &verify_key,
+                            b"",
                             0,
                             &(),
                             &nonce,
@@ -621,10 +668,11 @@ fn prio3(c: &mut Criterion) {
                         let nonce = black_box([0u8; 16]);
                         let verify_key = black_box([0u8; 16]);
                         let (public_share, input_shares) =
-                            vdaf.shard(&measurement, &nonce).unwrap();
+                            vdaf.shard(b"", &measurement, &nonce).unwrap();
                         b.iter(|| {
                             vdaf.prepare_init(
                                 &verify_key,
+                                b"",
                                 0,
                                 &(),
                                 &nonce,
@@ -724,7 +772,7 @@ fn poplar1(c: &mut Criterion) {
             let measurement = IdpfInput::from_bools(&bits);
 
             b.iter(|| {
-                vdaf.shard(&measurement, &nonce).unwrap();
+                vdaf.shard(b"", &measurement, &nonce).unwrap();
             });
         });
     }
@@ -753,7 +801,7 @@ fn poplar1(c: &mut Criterion) {
             // We are benchmarking preparation of a single report. For this test, it doesn't matter
             // which measurement we generate a report for, so pick the first measurement
             // arbitrarily.
-            let (public_share, input_shares) = vdaf.shard(&measurements[0], &nonce).unwrap();
+            let (public_share, input_shares) = vdaf.shard(b"", &measurements[0], &nonce).unwrap();
             let input_share = input_shares.into_iter().next().unwrap();
 
             // For the aggregation paramter, we use the candidate prefixes from the prefix tree for
@@ -765,6 +813,7 @@ fn poplar1(c: &mut Criterion) {
             b.iter(|| {
                 vdaf.prepare_init(
                     &verify_key,
+                    b"",
                     0,
                     &agg_param,
                     &nonce,

--- a/benches/speed_tests.rs
+++ b/benches/speed_tests.rs
@@ -324,6 +324,7 @@ fn prio3(c: &mut Criterion) {
                     b.iter(|| {
                         vdaf.prepare_init(
                             &verify_key,
+                            b"",
                             0,
                             &(),
                             &nonce,
@@ -458,6 +459,7 @@ fn prio3(c: &mut Criterion) {
                     b.iter(|| {
                         vdaf.prepare_init(
                             &verify_key,
+                            b"",
                             0,
                             &(),
                             &nonce,

--- a/binaries/src/bin/vdaf_message_sizes.rs
+++ b/binaries/src/bin/vdaf_message_sizes.rs
@@ -15,6 +15,9 @@ use prio::{
     },
 };
 
+const PRIO2_CTX_STR: &[u8] = b"prio2 ctx";
+const PRIO3_CTX_STR: &[u8] = b"prio3 ctx";
+
 fn main() {
     let num_shares = 2;
     let nonce = [0; 16];
@@ -23,7 +26,9 @@ fn main() {
     let measurement = true;
     println!(
         "prio3 count share size = {}",
-        vdaf_input_share_size::<Prio3Count, 16>(prio3.shard(&measurement, &nonce).unwrap())
+        vdaf_input_share_size::<Prio3Count, 16>(
+            prio3.shard(PRIO3_CTX_STR, &measurement, &nonce).unwrap()
+        )
     );
 
     let length = 10;
@@ -32,7 +37,9 @@ fn main() {
     println!(
         "prio3 histogram ({} buckets) share size = {}",
         length,
-        vdaf_input_share_size::<Prio3Histogram, 16>(prio3.shard(&measurement, &nonce).unwrap())
+        vdaf_input_share_size::<Prio3Histogram, 16>(
+            prio3.shard(PRIO3_CTX_STR, &measurement, &nonce).unwrap()
+        )
     );
 
     let bits = 32;
@@ -41,7 +48,9 @@ fn main() {
     println!(
         "prio3 sum ({} bits) share size = {}",
         bits,
-        vdaf_input_share_size::<Prio3Sum, 16>(prio3.shard(&measurement, &nonce).unwrap())
+        vdaf_input_share_size::<Prio3Sum, 16>(
+            prio3.shard(PRIO3_CTX_STR, &measurement, &nonce).unwrap()
+        )
     );
 
     let len = 1000;
@@ -50,7 +59,9 @@ fn main() {
     println!(
         "prio3 sumvec ({} len) share size = {}",
         len,
-        vdaf_input_share_size::<Prio3SumVec, 16>(prio3.shard(&measurement, &nonce).unwrap())
+        vdaf_input_share_size::<Prio3SumVec, 16>(
+            prio3.shard(PRIO3_CTX_STR, &measurement, &nonce).unwrap()
+        )
     );
 
     let len = 1000;
@@ -61,7 +72,7 @@ fn main() {
         "prio3 fixedpoint16 boundedl2 vec ({} entries) size = {}",
         len,
         vdaf_input_share_size::<Prio3FixedPointBoundedL2VecSum<FixedI16<U15>>, 16>(
-            prio3.shard(&measurement, &nonce).unwrap()
+            prio3.shard(PRIO3_CTX_STR, &measurement, &nonce).unwrap()
         )
     );
 
@@ -74,7 +85,9 @@ fn main() {
         println!(
             "prio2 ({} entries) size = {}",
             size,
-            vdaf_input_share_size::<Prio2, 16>(prio2.shard(&measurement, &nonce).unwrap())
+            vdaf_input_share_size::<Prio2, 16>(
+                prio2.shard(PRIO2_CTX_STR, &measurement, &nonce).unwrap()
+            )
         );
 
         // Prio3
@@ -83,7 +96,9 @@ fn main() {
         println!(
             "prio3 sumvec ({} entries) size = {}",
             size,
-            vdaf_input_share_size::<Prio3SumVec, 16>(prio3.shard(&measurement, &nonce).unwrap())
+            vdaf_input_share_size::<Prio3SumVec, 16>(
+                prio3.shard(PRIO3_CTX_STR, &measurement, &nonce).unwrap()
+            )
         );
     }
 }

--- a/src/topology/ping_pong.rs
+++ b/src/topology/ping_pong.rs
@@ -390,6 +390,7 @@ pub trait PingPongTopology<const VERIFY_KEY_SIZE: usize, const NONCE_SIZE: usize
     /// `inbound` must be `PingPongMessage::Initialize` or the function will fail.
     ///
     /// [VDAF]: https://datatracker.ietf.org/doc/html/draft-irtf-cfrg-vdaf-08#section-5.8
+    #[allow(clippy::too_many_arguments)]
     fn helper_initialized(
         &self,
         verify_key: &[u8; VERIFY_KEY_SIZE],

--- a/src/topology/ping_pong.rs
+++ b/src/topology/ping_pong.rs
@@ -362,6 +362,7 @@ pub trait PingPongTopology<const VERIFY_KEY_SIZE: usize, const NONCE_SIZE: usize
     fn leader_initialized(
         &self,
         verify_key: &[u8; VERIFY_KEY_SIZE],
+        ctx: &[u8],
         agg_param: &Self::AggregationParam,
         nonce: &[u8; NONCE_SIZE],
         public_share: &Self::PublicShare,
@@ -390,6 +391,7 @@ pub trait PingPongTopology<const VERIFY_KEY_SIZE: usize, const NONCE_SIZE: usize
     fn helper_initialized(
         &self,
         verify_key: &[u8; VERIFY_KEY_SIZE],
+        ctx: &[u8],
         agg_param: &Self::AggregationParam,
         nonce: &[u8; NONCE_SIZE],
         public_share: &Self::PublicShare,
@@ -493,6 +495,7 @@ where
     fn leader_initialized(
         &self,
         verify_key: &[u8; VERIFY_KEY_SIZE],
+        ctx: &[u8],
         agg_param: &Self::AggregationParam,
         nonce: &[u8; NONCE_SIZE],
         public_share: &Self::PublicShare,
@@ -500,6 +503,7 @@ where
     ) -> Result<(Self::State, PingPongMessage), PingPongError> {
         self.prepare_init(
             verify_key,
+            ctx,
             /* Leader */ 0,
             agg_param,
             nonce,
@@ -522,6 +526,7 @@ where
     fn helper_initialized(
         &self,
         verify_key: &[u8; VERIFY_KEY_SIZE],
+        ctx: &[u8],
         agg_param: &Self::AggregationParam,
         nonce: &[u8; NONCE_SIZE],
         public_share: &Self::PublicShare,
@@ -531,6 +536,7 @@ where
         let (prep_state, prep_share) = self
             .prepare_init(
                 verify_key,
+                ctx,
                 /* Helper */ 1,
                 agg_param,
                 nonce,
@@ -667,6 +673,8 @@ mod tests {
     use crate::vdaf::dummy;
     use assert_matches::assert_matches;
 
+    const CTX_STR: &[u8] = b"pingpong ctx";
+
     #[test]
     fn ping_pong_one_round() {
         let verify_key = [];
@@ -683,6 +691,7 @@ mod tests {
         let (leader_state, leader_message) = leader
             .leader_initialized(
                 &verify_key,
+                CTX_STR,
                 &aggregation_param,
                 &nonce,
                 &public_share,
@@ -694,6 +703,7 @@ mod tests {
         let (helper_state, helper_message) = helper
             .helper_initialized(
                 &verify_key,
+                CTX_STR,
                 &aggregation_param,
                 &nonce,
                 &public_share,
@@ -733,6 +743,7 @@ mod tests {
         let (leader_state, leader_message) = leader
             .leader_initialized(
                 &verify_key,
+                CTX_STR,
                 &aggregation_param,
                 &nonce,
                 &public_share,
@@ -744,6 +755,7 @@ mod tests {
         let (helper_state, helper_message) = helper
             .helper_initialized(
                 &verify_key,
+                CTX_STR,
                 &aggregation_param,
                 &nonce,
                 &public_share,
@@ -795,6 +807,7 @@ mod tests {
         let (leader_state, leader_message) = leader
             .leader_initialized(
                 &verify_key,
+                CTX_STR,
                 &aggregation_param,
                 &nonce,
                 &public_share,
@@ -806,6 +819,7 @@ mod tests {
         let (helper_state, helper_message) = helper
             .helper_initialized(
                 &verify_key,
+                CTX_STR,
                 &aggregation_param,
                 &nonce,
                 &public_share,

--- a/src/vdaf/dummy.rs
+++ b/src/vdaf/dummy.rs
@@ -123,6 +123,7 @@ impl vdaf::Aggregator<0, 16> for Vdaf {
     fn prepare_init(
         &self,
         _verify_key: &[u8; 0],
+        _ctx: &[u8],
         _: usize,
         aggregation_param: &Self::AggregationParam,
         _nonce: &[u8; 16],
@@ -175,6 +176,7 @@ impl vdaf::Aggregator<0, 16> for Vdaf {
 impl vdaf::Client<16> for Vdaf {
     fn shard(
         &self,
+        _ctx: &[u8],
         measurement: &Self::Measurement,
         _nonce: &[u8; 16],
     ) -> Result<(Self::PublicShare, Vec<Self::InputShare>), VdafError> {
@@ -361,12 +363,14 @@ mod tests {
         let mut sharded_measurements = Vec::new();
         for measurement in measurements {
             let nonce = thread_rng().gen();
-            let (public_share, input_shares) = vdaf.shard(&measurement, &nonce).unwrap();
+            let (public_share, input_shares) =
+                vdaf.shard(b"dummy ctx", &measurement, &nonce).unwrap();
 
             sharded_measurements.push((public_share, nonce, input_shares));
         }
 
         let result = run_vdaf_sharded(
+            b"dummy ctx",
             &vdaf,
             &AggregationParam(aggregation_parameter),
             sharded_measurements.clone(),

--- a/src/vdaf/dummy.rs
+++ b/src/vdaf/dummy.rs
@@ -142,6 +142,7 @@ impl vdaf::Aggregator<0, 16> for Vdaf {
 
     fn prepare_shares_to_prepare_message<M: IntoIterator<Item = Self::PrepareShare>>(
         &self,
+        _ctx: &[u8],
         _: &Self::AggregationParam,
         _: M,
     ) -> Result<Self::PrepareMessage, VdafError> {
@@ -150,6 +151,7 @@ impl vdaf::Aggregator<0, 16> for Vdaf {
 
     fn prepare_next(
         &self,
+        _ctx: &[u8],
         state: Self::PrepareState,
         _: Self::PrepareMessage,
     ) -> Result<PrepareTransition<Self, 0, 16>, VdafError> {

--- a/src/vdaf/mastic.rs
+++ b/src/vdaf/mastic.rs
@@ -341,6 +341,7 @@ where
 {
     fn shard(
         &self,
+        ctx: &[u8],
         (attribute, weight): &(VidpfInput, T::Measurement),
         nonce: &[u8; 16],
     ) -> Result<(Self::PublicShare, Vec<Self::InputShare>), VdafError> {
@@ -388,6 +389,7 @@ mod tests {
     use rand::{thread_rng, Rng};
 
     const TEST_NONCE_SIZE: usize = 16;
+    const CTX_STR: &[u8] = b"mastic ctx";
 
     #[test]
     fn test_mastic_shard_sum() {
@@ -404,7 +406,9 @@ mod tests {
         let first_input = VidpfInput::from_bytes(&[15u8, 0u8, 1u8, 4u8][..]);
 
         let mastic = Mastic::new(algorithm_id, sum_szk, sum_vidpf, 32);
-        let (_public, _input_shares) = mastic.shard(&(first_input, 24u128), &nonce).unwrap();
+        let (_public, _input_shares) = mastic
+            .shard(CTX_STR, &(first_input, 24u128), &nonce)
+            .unwrap();
     }
 
     #[test]
@@ -422,7 +426,9 @@ mod tests {
         let first_input = VidpfInput::from_bytes(&[15u8, 0u8, 1u8, 4u8][..]);
 
         let mastic = Mastic::new(algorithm_id, sum_szk, sum_vidpf, 32);
-        let (_, input_shares) = mastic.shard(&(first_input, 26u128), &nonce).unwrap();
+        let (_, input_shares) = mastic
+            .shard(CTX_STR, &(first_input, 26u128), &nonce)
+            .unwrap();
         let [leader_input_share, helper_input_share] = [&input_shares[0], &input_shares[1]];
 
         assert_eq!(
@@ -450,7 +456,7 @@ mod tests {
         let first_input = VidpfInput::from_bytes(&[15u8, 0u8, 1u8, 4u8][..]);
 
         let mastic = Mastic::new(algorithm_id, szk, sum_vidpf, 32);
-        let (_public, _input_shares) = mastic.shard(&(first_input, true), &nonce).unwrap();
+        let (_public, _input_shares) = mastic.shard(CTX_STR, &(first_input, true), &nonce).unwrap();
     }
 
     #[test]
@@ -470,7 +476,9 @@ mod tests {
         let first_input = VidpfInput::from_bytes(&[15u8, 0u8, 1u8, 4u8][..]);
 
         let mastic = Mastic::new(algorithm_id, szk, sum_vidpf, 32);
-        let (_public, _input_shares) = mastic.shard(&(first_input, measurement), &nonce).unwrap();
+        let (_public, _input_shares) = mastic
+            .shard(CTX_STR, &(first_input, measurement), &nonce)
+            .unwrap();
     }
 
     #[test]
@@ -490,7 +498,9 @@ mod tests {
         let first_input = VidpfInput::from_bytes(&[15u8, 0u8, 1u8, 4u8][..]);
 
         let mastic = Mastic::new(algorithm_id, szk, sum_vidpf, 32);
-        let (_public, input_shares) = mastic.shard(&(first_input, measurement), &nonce).unwrap();
+        let (_public, input_shares) = mastic
+            .shard(CTX_STR, &(first_input, measurement), &nonce)
+            .unwrap();
         let leader_input_share = &input_shares[0];
         let helper_input_share = &input_shares[1];
 
@@ -521,7 +531,9 @@ mod tests {
         let first_input = VidpfInput::from_bytes(&[15u8, 0u8, 1u8, 4u8][..]);
 
         let mastic = Mastic::new(algorithm_id, szk, sum_vidpf, 32);
-        let (_public, input_shares) = mastic.shard(&(first_input, measurement), &nonce).unwrap();
+        let (_public, input_shares) = mastic
+            .shard(CTX_STR, &(first_input, measurement), &nonce)
+            .unwrap();
         let leader_input_share = &input_shares[0];
         let helper_input_share = &input_shares[1];
 

--- a/src/vdaf/mastic.rs
+++ b/src/vdaf/mastic.rs
@@ -341,7 +341,7 @@ where
 {
     fn shard(
         &self,
-        ctx: &[u8],
+        _ctx: &[u8],
         (attribute, weight): &(VidpfInput, T::Measurement),
         nonce: &[u8; 16],
     ) -> Result<(Self::PublicShare, Vec<Self::InputShare>), VdafError> {

--- a/src/vdaf/prio2.rs
+++ b/src/vdaf/prio2.rs
@@ -143,6 +143,7 @@ impl Vdaf for Prio2 {
 impl Client<16> for Prio2 {
     fn shard(
         &self,
+        _ctx: &[u8],
         measurement: &Vec<u32>,
         _nonce: &[u8; 16],
     ) -> Result<(Self::PublicShare, Vec<Share<FieldPrio2, 32>>), VdafError> {
@@ -253,6 +254,7 @@ impl Aggregator<32, 16> for Prio2 {
     fn prepare_init(
         &self,
         agg_key: &[u8; 32],
+        _ctx: &[u8],
         agg_id: usize,
         _agg_param: &Self::AggregationParam,
         nonce: &[u8; 16],
@@ -406,12 +408,17 @@ mod tests {
     use assert_matches::assert_matches;
     use rand::prelude::*;
 
+    // The value of this string doesn't matter. Prio2 is not defined to use the context string for
+    // any computation
+    pub(crate) const CTX_STR: &[u8] = b"prio2 ctx";
+
     #[test]
     fn run_prio2() {
         let prio2 = Prio2::new(6).unwrap();
 
         assert_eq!(
             run_vdaf(
+                CTX_STR,
                 &prio2,
                 &(),
                 [
@@ -434,11 +441,12 @@ mod tests {
         let nonce = rng.gen::<[u8; 16]>();
         let data = vec![0, 0, 1, 1, 0];
         let prio2 = Prio2::new(data.len()).unwrap();
-        let (public_share, input_shares) = prio2.shard(&data, &nonce).unwrap();
+        let (public_share, input_shares) = prio2.shard(CTX_STR, &data, &nonce).unwrap();
         for (agg_id, input_share) in input_shares.iter().enumerate() {
             let (prepare_state, prepare_share) = prio2
                 .prepare_init(
                     &verify_key,
+                    CTX_STR,
                     agg_id,
                     &(),
                     &[0; 16],
@@ -500,10 +508,10 @@ mod tests {
             let input_share_1 = Share::get_decoded_with_param(&(&vdaf, 0), server_1_share).unwrap();
             let input_share_2 = Share::get_decoded_with_param(&(&vdaf, 1), server_2_share).unwrap();
             let (prepare_state_1, prepare_share_1) = vdaf
-                .prepare_init(&[0; 32], 0, &(), &[0; 16], &(), &input_share_1)
+                .prepare_init(&[0; 32], CTX_STR, 0, &(), &[0; 16], &(), &input_share_1)
                 .unwrap();
             let (prepare_state_2, prepare_share_2) = vdaf
-                .prepare_init(&[0; 32], 1, &(), &[0; 16], &(), &input_share_2)
+                .prepare_init(&[0; 32], CTX_STR, 1, &(), &[0; 16], &(), &input_share_2)
                 .unwrap();
             vdaf.prepare_shares_to_prepare_message(&(), [prepare_share_1, prepare_share_2])
                 .unwrap();

--- a/src/vdaf/prio2.rs
+++ b/src/vdaf/prio2.rs
@@ -280,6 +280,7 @@ impl Aggregator<32, 16> for Prio2 {
 
     fn prepare_shares_to_prepare_message<M: IntoIterator<Item = Prio2PrepareShare>>(
         &self,
+        _ctx: &[u8],
         _: &Self::AggregationParam,
         inputs: M,
     ) -> Result<(), VdafError> {
@@ -302,6 +303,7 @@ impl Aggregator<32, 16> for Prio2 {
 
     fn prepare_next(
         &self,
+        _ctx: &[u8],
         state: Prio2PrepareState,
         _input: (),
     ) -> Result<PrepareTransition<Self, 32, 16>, VdafError> {
@@ -513,12 +515,16 @@ mod tests {
             let (prepare_state_2, prepare_share_2) = vdaf
                 .prepare_init(&[0; 32], CTX_STR, 1, &(), &[0; 16], &(), &input_share_2)
                 .unwrap();
-            vdaf.prepare_shares_to_prepare_message(&(), [prepare_share_1, prepare_share_2])
-                .unwrap();
-            let transition_1 = vdaf.prepare_next(prepare_state_1, ()).unwrap();
+            vdaf.prepare_shares_to_prepare_message(
+                CTX_STR,
+                &(),
+                [prepare_share_1, prepare_share_2],
+            )
+            .unwrap();
+            let transition_1 = vdaf.prepare_next(CTX_STR, prepare_state_1, ()).unwrap();
             let output_share_1 =
                 assert_matches!(transition_1, PrepareTransition::Finish(out) => out);
-            let transition_2 = vdaf.prepare_next(prepare_state_2, ()).unwrap();
+            let transition_2 = vdaf.prepare_next(CTX_STR, prepare_state_2, ()).unwrap();
             let output_share_2 =
                 assert_matches!(transition_2, PrepareTransition::Finish(out) => out);
             leader_output_shares.push(output_share_1);

--- a/src/vdaf/prio2/server.rs
+++ b/src/vdaf/prio2/server.rs
@@ -205,6 +205,7 @@ mod tests {
             prio2::{
                 client::{proof_length, unpack_proof_mut},
                 server::test_util::Server,
+                tests::CTX_STR,
                 Prio2,
             },
             Client, Share, ShareDecodingParameter,
@@ -285,7 +286,7 @@ mod tests {
         }
 
         let vdaf = Prio2::new(dim).unwrap();
-        let (_, shares) = vdaf.shard(&data, &[0; 16]).unwrap();
+        let (_, shares) = vdaf.shard(CTX_STR, &data, &[0; 16]).unwrap();
         let share1_original = shares[0].get_encoded().unwrap();
         let share2 = shares[1].get_encoded().unwrap();
 

--- a/src/vdaf/prio3.rs
+++ b/src/vdaf/prio3.rs
@@ -388,7 +388,7 @@ impl Prio3Average {
 /// for measurement in measurements {
 ///     // Shard
 ///     let nonce = rng.gen::<[u8; 16]>();
-///     let (public_share, input_shares) = vdaf.shard(&measurement, &nonce).unwrap();
+///     let (public_share, input_shares) = vdaf.shard(b"my ctx", &measurement, &nonce).unwrap();
 ///
 ///     // Prepare
 ///     let mut prep_states = vec![];
@@ -396,6 +396,7 @@ impl Prio3Average {
 ///     for (agg_id, input_share) in input_shares.iter().enumerate() {
 ///         let (state, share) = vdaf.prepare_init(
 ///             &verify_key,
+///             b"my ctx",
 ///             agg_id,
 ///             &(),
 ///             &nonce,
@@ -1083,6 +1084,7 @@ where
     #[allow(clippy::type_complexity)]
     fn shard(
         &self,
+        ctx: &[u8],
         measurement: &T::Measurement,
         nonce: &[u8; 16],
     ) -> Result<(Self::PublicShare, Vec<Prio3InputShare<T::Field, SEED_SIZE>>), VdafError> {
@@ -1213,6 +1215,7 @@ where
     fn prepare_init(
         &self,
         verify_key: &[u8; SEED_SIZE],
+        ctx: &[u8],
         agg_id: usize,
         _agg_param: &Self::AggregationParam,
         nonce: &[u8; 16],
@@ -1627,12 +1630,14 @@ mod tests {
     };
     use rand::prelude::*;
 
+    const CTX_STR: &[u8] = b"prio3 ctx";
+
     #[test]
     fn test_prio3_count() {
         let prio3 = Prio3::new_count(2).unwrap();
 
         assert_eq!(
-            run_vdaf(&prio3, &(), [true, false, false, true, true]).unwrap(),
+            run_vdaf(CTX_STR, &prio3, &(), [true, false, false, true, true]).unwrap(),
             3
         );
 
@@ -1641,17 +1646,41 @@ mod tests {
         thread_rng().fill(&mut verify_key[..]);
         thread_rng().fill(&mut nonce[..]);
 
-        let (public_share, input_shares) = prio3.shard(&false, &nonce).unwrap();
-        run_vdaf_prepare(&prio3, &verify_key, &(), &nonce, public_share, input_shares).unwrap();
+        let (public_share, input_shares) = prio3.shard(CTX_STR, &false, &nonce).unwrap();
+        run_vdaf_prepare(
+            &prio3,
+            &verify_key,
+            CTX_STR,
+            &(),
+            &nonce,
+            public_share,
+            input_shares,
+        )
+        .unwrap();
 
-        let (public_share, input_shares) = prio3.shard(&true, &nonce).unwrap();
-        run_vdaf_prepare(&prio3, &verify_key, &(), &nonce, public_share, input_shares).unwrap();
+        let (public_share, input_shares) = prio3.shard(CTX_STR, &true, &nonce).unwrap();
+        run_vdaf_prepare(
+            &prio3,
+            &verify_key,
+            CTX_STR,
+            &(),
+            &nonce,
+            public_share,
+            input_shares,
+        )
+        .unwrap();
 
         test_serialization(&prio3, &true, &nonce).unwrap();
 
         let prio3_extra_helper = Prio3::new_count(3).unwrap();
         assert_eq!(
-            run_vdaf(&prio3_extra_helper, &(), [true, false, false, true, true]).unwrap(),
+            run_vdaf(
+                CTX_STR,
+                &prio3_extra_helper,
+                &(),
+                [true, false, false, true, true]
+            )
+            .unwrap(),
             3,
         );
     }
@@ -1661,7 +1690,7 @@ mod tests {
         let prio3 = Prio3::new_sum(3, 16).unwrap();
 
         assert_eq!(
-            run_vdaf(&prio3, &(), [0, (1 << 16) - 1, 0, 1, 1]).unwrap(),
+            run_vdaf(CTX_STR, &prio3, &(), [0, (1 << 16) - 1, 0, 1, 1]).unwrap(),
             (1 << 16) + 1
         );
 
@@ -1669,18 +1698,34 @@ mod tests {
         thread_rng().fill(&mut verify_key[..]);
         let nonce = [0; 16];
 
-        let (public_share, mut input_shares) = prio3.shard(&1, &nonce).unwrap();
+        let (public_share, mut input_shares) = prio3.shard(CTX_STR, &1, &nonce).unwrap();
         assert_matches!(input_shares[0].measurement_share, Share::Leader(ref mut data) => {
             data[0] += Field128::one();
         });
-        let result = run_vdaf_prepare(&prio3, &verify_key, &(), &nonce, public_share, input_shares);
+        let result = run_vdaf_prepare(
+            &prio3,
+            &verify_key,
+            CTX_STR,
+            &(),
+            &nonce,
+            public_share,
+            input_shares,
+        );
         assert_matches!(result, Err(VdafError::Uncategorized(_)));
 
-        let (public_share, mut input_shares) = prio3.shard(&1, &nonce).unwrap();
+        let (public_share, mut input_shares) = prio3.shard(CTX_STR, &1, &nonce).unwrap();
         assert_matches!(input_shares[0].proofs_share, Share::Leader(ref mut data) => {
                 data[0] += Field128::one();
         });
-        let result = run_vdaf_prepare(&prio3, &verify_key, &(), &nonce, public_share, input_shares);
+        let result = run_vdaf_prepare(
+            &prio3,
+            &verify_key,
+            CTX_STR,
+            &(),
+            &nonce,
+            public_share,
+            input_shares,
+        );
         assert_matches!(result, Err(VdafError::Uncategorized(_)));
 
         test_serialization(&prio3, &1, &nonce).unwrap();
@@ -1691,6 +1736,7 @@ mod tests {
         let prio3 = Prio3::new_sum_vec(2, 2, 20, 4).unwrap();
         assert_eq!(
             run_vdaf(
+                CTX_STR,
                 &prio3,
                 &(),
                 [
@@ -1715,6 +1761,7 @@ mod tests {
 
         assert_eq!(
             run_vdaf(
+                CTX_STR,
                 &prio3,
                 &(),
                 [
@@ -1734,6 +1781,7 @@ mod tests {
         let prio3 = Prio3::new_sum_vec_multithreaded(2, 2, 20, 4).unwrap();
         assert_eq!(
             run_vdaf(
+                CTX_STR,
                 &prio3,
                 &(),
                 [
@@ -1787,7 +1835,7 @@ mod tests {
 
             let measurements = [fp_vec.clone(), fp_vec];
             assert_eq!(
-                run_vdaf(&prio3, &(), measurements).unwrap(),
+                run_vdaf(CTX_STR, &prio3, &(), measurements).unwrap(),
                 vec![0.0; SIZE]
             );
         }
@@ -1888,21 +1936,21 @@ mod tests {
             // positive entries
             let fp_list = [fp_vec1, fp_vec2];
             assert_eq!(
-                run_vdaf(&prio3, &(), fp_list).unwrap(),
+                run_vdaf(CTX_STR, &prio3, &(), fp_list).unwrap(),
                 vec!(0.5, 0.25, 0.125),
             );
 
             // negative entries
             let fp_list2 = [fp_vec3, fp_vec4];
             assert_eq!(
-                run_vdaf(&prio3, &(), fp_list2).unwrap(),
+                run_vdaf(CTX_STR, &prio3, &(), fp_list2).unwrap(),
                 vec!(-0.5, -0.25, -0.125),
             );
 
             // both
             let fp_list3 = [fp_vec5, fp_vec6];
             assert_eq!(
-                run_vdaf(&prio3, &(), fp_list3).unwrap(),
+                run_vdaf(CTX_STR, &prio3, &(), fp_list3).unwrap(),
                 vec!(0.5, 0.0, 0.0),
             );
 
@@ -1912,31 +1960,52 @@ mod tests {
             thread_rng().fill(&mut nonce);
 
             let (public_share, mut input_shares) = prio3
-                .shard(&vec![fp_4_inv, fp_8_inv, fp_16_inv], &nonce)
+                .shard(CTX_STR, &vec![fp_4_inv, fp_8_inv, fp_16_inv], &nonce)
                 .unwrap();
             input_shares[0].joint_rand_blind.as_mut().unwrap().0[0] ^= 255;
-            let result =
-                run_vdaf_prepare(&prio3, &verify_key, &(), &nonce, public_share, input_shares);
+            let result = run_vdaf_prepare(
+                &prio3,
+                &verify_key,
+                CTX_STR,
+                &(),
+                &nonce,
+                public_share,
+                input_shares,
+            );
             assert_matches!(result, Err(VdafError::Uncategorized(_)));
 
             let (public_share, mut input_shares) = prio3
-                .shard(&vec![fp_4_inv, fp_8_inv, fp_16_inv], &nonce)
+                .shard(CTX_STR, &vec![fp_4_inv, fp_8_inv, fp_16_inv], &nonce)
                 .unwrap();
             assert_matches!(input_shares[0].measurement_share, Share::Leader(ref mut data) => {
                 data[0] += Field128::one();
             });
-            let result =
-                run_vdaf_prepare(&prio3, &verify_key, &(), &nonce, public_share, input_shares);
+            let result = run_vdaf_prepare(
+                &prio3,
+                &verify_key,
+                CTX_STR,
+                &(),
+                &nonce,
+                public_share,
+                input_shares,
+            );
             assert_matches!(result, Err(VdafError::Uncategorized(_)));
 
             let (public_share, mut input_shares) = prio3
-                .shard(&vec![fp_4_inv, fp_8_inv, fp_16_inv], &nonce)
+                .shard(CTX_STR, &vec![fp_4_inv, fp_8_inv, fp_16_inv], &nonce)
                 .unwrap();
             assert_matches!(input_shares[0].proofs_share, Share::Leader(ref mut data) => {
                     data[0] += Field128::one();
             });
-            let result =
-                run_vdaf_prepare(&prio3, &verify_key, &(), &nonce, public_share, input_shares);
+            let result = run_vdaf_prepare(
+                &prio3,
+                &verify_key,
+                CTX_STR,
+                &(),
+                &nonce,
+                public_share,
+                input_shares,
+            );
             assert_matches!(result, Err(VdafError::Uncategorized(_)));
 
             test_serialization(&prio3, &vec![fp_4_inv, fp_8_inv, fp_16_inv], &nonce).unwrap();
@@ -1948,13 +2017,25 @@ mod tests {
         let prio3 = Prio3::new_histogram(2, 4, 2).unwrap();
 
         assert_eq!(
-            run_vdaf(&prio3, &(), [0, 1, 2, 3]).unwrap(),
+            run_vdaf(CTX_STR, &prio3, &(), [0, 1, 2, 3]).unwrap(),
             vec![1, 1, 1, 1]
         );
-        assert_eq!(run_vdaf(&prio3, &(), [0]).unwrap(), vec![1, 0, 0, 0]);
-        assert_eq!(run_vdaf(&prio3, &(), [1]).unwrap(), vec![0, 1, 0, 0]);
-        assert_eq!(run_vdaf(&prio3, &(), [2]).unwrap(), vec![0, 0, 1, 0]);
-        assert_eq!(run_vdaf(&prio3, &(), [3]).unwrap(), vec![0, 0, 0, 1]);
+        assert_eq!(
+            run_vdaf(CTX_STR, &prio3, &(), [0]).unwrap(),
+            vec![1, 0, 0, 0]
+        );
+        assert_eq!(
+            run_vdaf(CTX_STR, &prio3, &(), [1]).unwrap(),
+            vec![0, 1, 0, 0]
+        );
+        assert_eq!(
+            run_vdaf(CTX_STR, &prio3, &(), [2]).unwrap(),
+            vec![0, 0, 1, 0]
+        );
+        assert_eq!(
+            run_vdaf(CTX_STR, &prio3, &(), [3]).unwrap(),
+            vec![0, 0, 0, 1]
+        );
         test_serialization(&prio3, &3, &[0; 16]).unwrap();
     }
 
@@ -1964,13 +2045,25 @@ mod tests {
         let prio3 = Prio3::new_histogram_multithreaded(2, 4, 2).unwrap();
 
         assert_eq!(
-            run_vdaf(&prio3, &(), [0, 1, 2, 3]).unwrap(),
+            run_vdaf(CTX_STR, &prio3, &(), [0, 1, 2, 3]).unwrap(),
             vec![1, 1, 1, 1]
         );
-        assert_eq!(run_vdaf(&prio3, &(), [0]).unwrap(), vec![1, 0, 0, 0]);
-        assert_eq!(run_vdaf(&prio3, &(), [1]).unwrap(), vec![0, 1, 0, 0]);
-        assert_eq!(run_vdaf(&prio3, &(), [2]).unwrap(), vec![0, 0, 1, 0]);
-        assert_eq!(run_vdaf(&prio3, &(), [3]).unwrap(), vec![0, 0, 0, 1]);
+        assert_eq!(
+            run_vdaf(CTX_STR, &prio3, &(), [0]).unwrap(),
+            vec![1, 0, 0, 0]
+        );
+        assert_eq!(
+            run_vdaf(CTX_STR, &prio3, &(), [1]).unwrap(),
+            vec![0, 1, 0, 0]
+        );
+        assert_eq!(
+            run_vdaf(CTX_STR, &prio3, &(), [2]).unwrap(),
+            vec![0, 0, 1, 0]
+        );
+        assert_eq!(
+            run_vdaf(CTX_STR, &prio3, &(), [3]).unwrap(),
+            vec![0, 0, 0, 1]
+        );
         test_serialization(&prio3, &3, &[0; 16]).unwrap();
     }
 
@@ -1978,11 +2071,14 @@ mod tests {
     fn test_prio3_average() {
         let prio3 = Prio3::new_average(2, 64).unwrap();
 
-        assert_eq!(run_vdaf(&prio3, &(), [17, 8]).unwrap(), 12.5f64);
-        assert_eq!(run_vdaf(&prio3, &(), [1, 1, 1, 1]).unwrap(), 1f64);
-        assert_eq!(run_vdaf(&prio3, &(), [0, 0, 0, 1]).unwrap(), 0.25f64);
+        assert_eq!(run_vdaf(CTX_STR, &prio3, &(), [17, 8]).unwrap(), 12.5f64);
+        assert_eq!(run_vdaf(CTX_STR, &prio3, &(), [1, 1, 1, 1]).unwrap(), 1f64);
         assert_eq!(
-            run_vdaf(&prio3, &(), [1, 11, 111, 1111, 3, 8]).unwrap(),
+            run_vdaf(CTX_STR, &prio3, &(), [0, 0, 0, 1]).unwrap(),
+            0.25f64
+        );
+        assert_eq!(
+            run_vdaf(CTX_STR, &prio3, &(), [1, 11, 111, 1111, 3, 8]).unwrap(),
             207.5f64
         );
     }
@@ -1990,7 +2086,7 @@ mod tests {
     #[test]
     fn test_prio3_input_share() {
         let prio3 = Prio3::new_sum(5, 16).unwrap();
-        let (_public_share, input_shares) = prio3.shard(&1, &[0; 16]).unwrap();
+        let (_public_share, input_shares) = prio3.shard(CTX_STR, &1, &[0; 16]).unwrap();
 
         // Check that seed shares are distinct.
         for (i, x) in input_shares.iter().enumerate() {
@@ -2023,7 +2119,7 @@ mod tests {
     {
         let mut verify_key = [0; SEED_SIZE];
         thread_rng().fill(&mut verify_key[..]);
-        let (public_share, input_shares) = prio3.shard(measurement, nonce)?;
+        let (public_share, input_shares) = prio3.shard(CTX_STR, measurement, nonce)?;
 
         let encoded_public_share = public_share.get_encoded().unwrap();
         let decoded_public_share =
@@ -2050,8 +2146,15 @@ mod tests {
         let mut prepare_shares = Vec::new();
         let mut last_prepare_state = None;
         for (agg_id, input_share) in input_shares.iter().enumerate() {
-            let (prepare_state, prepare_share) =
-                prio3.prepare_init(&verify_key, agg_id, &(), nonce, &public_share, input_share)?;
+            let (prepare_state, prepare_share) = prio3.prepare_init(
+                &verify_key,
+                CTX_STR,
+                agg_id,
+                &(),
+                nonce,
+                &public_share,
+                input_share,
+            )?;
 
             let encoded_prepare_state = prepare_state.get_encoded().unwrap();
             let decoded_prepare_state =

--- a/src/vdaf/prio3_test.rs
+++ b/src/vdaf/prio3_test.rs
@@ -176,12 +176,12 @@ where
     T: Type<Measurement = MP>,
     P: Xof<SEED_SIZE>,
 {
-    let verify_key = t.verify_key.as_ref();
-    let ctx = t.ctx.as_ref().try_into().unwrap();
+    let verify_key = t.verify_key.as_ref().try_into().unwrap();
+    let ctx = t.ctx.as_ref();
 
     let mut all_output_shares = vec![Vec::new(); prio3.num_aggregators()];
     for (test_num, p) in t.prep.iter().enumerate() {
-        let output_shares = check_prep_test_vec(prio3, ctx, verify_key, test_num, p);
+        let output_shares = check_prep_test_vec(prio3, verify_key, ctx, test_num, p);
         for (aggregator_output_shares, output_share) in
             all_output_shares.iter_mut().zip(output_shares.into_iter())
         {

--- a/src/vdaf/prio3_test.rs
+++ b/src/vdaf/prio3_test.rs
@@ -76,7 +76,7 @@ where
 {
     let nonce = <[u8; 16]>::try_from(t.nonce.clone()).unwrap();
     let (public_share, input_shares) = prio3
-        .shard_with_random(&t.measurement.clone().into(), &nonce, &t.rand)
+        .shard_with_random(ctx, &t.measurement.clone().into(), &nonce, &t.rand)
         .expect("failed to generate input shares");
 
     assert_eq!(
@@ -132,14 +132,17 @@ where
     }
 
     let inbound = prio3
-        .prepare_shares_to_prepare_message(&(), prep_shares)
+        .prepare_shares_to_prepare_message(ctx, &(), prep_shares)
         .unwrap_or_else(|e| err!(test_num, e, "prep preprocess"));
     assert_eq!(t.prep_messages.len(), 1);
     assert_eq!(inbound.get_encoded().unwrap(), t.prep_messages[0].as_ref());
 
     let mut out_shares = Vec::new();
     for state in states.iter_mut() {
-        match prio3.prepare_next(state.clone(), inbound.clone()).unwrap() {
+        match prio3
+            .prepare_next(ctx, state.clone(), inbound.clone())
+            .unwrap()
+        {
             PrepareTransition::Finish(out_share) => {
                 out_shares.push(out_share);
             }
@@ -173,7 +176,7 @@ where
     T: Type<Measurement = MP>,
     P: Xof<SEED_SIZE>,
 {
-    let verify_key = t.verify_key.as_ref().try_into().unwrap();
+    let verify_key = t.verify_key.as_ref();
     let ctx = t.ctx.as_ref().try_into().unwrap();
 
     let mut all_output_shares = vec![Vec::new(); prio3.num_aggregators()];


### PR DESCRIPTION
Adds the `ctx` string to all the methods that require it. Importantly, this requires updates to the `Aggregator` trait, among others. My methodology was basically to add `ctx` to the args of `domain_separation_tag()` and propagate the changes out. It's a lot.

I kept an empty context string for the benchmarks to minimize the affect on XOF computation.

One note: clippy isn't very happy with how many arguments `Aggregator::prepare_init` and `PingPongTopology::helper_initialized` have. Open to suggestions here.

Completes a subtask of #1122.