### PR TITLE
Change decoding parameter for PrepareShare/PrepareMessage

### DIFF
--- a/src/vdaf/prio2.rs
+++ b/src/vdaf/prio2.rs
@@ -233,9 +233,9 @@ impl Encode for Prio2PrepareShare {
     }
 }
 
-impl ParameterizedDecode<Prio2PrepareState> for Prio2PrepareShare {
+impl<'a> ParameterizedDecode<(&'a Prio2, &'a (), usize, u16)> for Prio2PrepareShare {
     fn decode_with_param(
-        _state: &Prio2PrepareState,
+        _: &(&Prio2, &(), usize, u16),
         bytes: &mut Cursor<&[u8]>,
     ) -> Result<Self, CodecError> {
         Ok(Self(v2_server::VerificationMessage {
@@ -470,9 +470,11 @@ mod tests {
             );
 
             let encoded_prepare_share = prepare_share.get_encoded().unwrap();
-            let decoded_prepare_share =
-                Prio2PrepareShare::get_decoded_with_param(&prepare_state, &encoded_prepare_share)
-                    .expect("failed to decode prepare share");
+            let decoded_prepare_share = Prio2PrepareShare::get_decoded_with_param(
+                &(&prio2, &(), agg_id, 0),
+                &encoded_prepare_share,
+            )
+            .expect("failed to decode prepare share");
             assert_eq!(decoded_prepare_share.0.f_r, prepare_share.0.f_r);
             assert_eq!(decoded_prepare_share.0.g_r, prepare_share.0.g_r);
             assert_eq!(decoded_prepare_share.0.h_r, prepare_share.0.h_r);

--- a/src/vdaf/prio3_test.rs
+++ b/src/vdaf/prio3_test.rs
@@ -120,7 +120,7 @@ where
     for (i, want) in t.prep_shares[0].iter().enumerate() {
         assert_eq!(
             prep_shares[i],
-            Prio3PrepareShare::get_decoded_with_param(&states[i], want.as_ref())
+            Prio3PrepareShare::get_decoded_with_param(&(prio3, &(), i, 0), want.as_ref())
                 .unwrap_or_else(|e| err!(test_num, e, "decode test vector (prep share)")),
             "#{test_num}"
         );


### PR DESCRIPTION
This is a prototype of a change to the decoding parameters used for `PrepareShare` and `PrepareMessage`. See #912. The handling of round numbers could use more attention, both in terms of documenting the semantics of round numbers for prepare shares and prepare messages, and testing to catch off-by-one errors. Currently anonymous tuples are used for the decoding parameters, but since we have two integer types next to each other now, I think those need to become named structs instead. I think the impact on the ping pong API is worth looking at. Since it does encoding and decoding internally, I had to add some round number arguments. Those, too, need better documentation of their semantics, especially since some transitions may involve two VDAF preparations with different round numbers.

It's not strictly necessary that the whole aggregation parameter be present for decoding. It would be sufficient to project out the level, or whether we are at the last level. That would add another associated type and more complication, though.

One other idea: what if we had two decoding implementations, one using the more convenient `ParameterizedDecode<Self::PrepareState>`, and the other using a more complicated struct assembled from public information? Would other use cases with an extra intermediary be able to use this easily? Which should be required in the type bounds in the `Aggregator` trait?