### PR TITLE
Prio3Sum: Use Field64

### DIFF
--- a/benches/cycle_counts.rs
+++ b/benches/cycle_counts.rs
@@ -125,7 +125,7 @@ fn prio3_client_histogram_10() -> Vec<Prio3InputShare<Field128, 16>> {
         .1
 }
 
-fn prio3_client_sum_32() -> Vec<Prio3InputShare<Field128, 16>> {
+fn prio3_client_sum_32() -> Vec<Prio3InputShare<Field64, 16>> {
     let bits = 16;
     let prio3 = Prio3::new_sum(2, (1 << bits) - 1).unwrap();
     let measurement = 1337;

--- a/src/vdaf/prio3.rs
+++ b/src/vdaf/prio3.rs
@@ -140,14 +140,14 @@ impl Prio3SumVecMultithreaded {
 
 /// The sum type. Each measurement is an integer in `[0,2^bits)` for some `0 < bits < 64` and the
 /// aggregate is the sum.
-pub type Prio3Sum = Prio3<Sum<Field128>, XofTurboShake128, 16>;
+pub type Prio3Sum = Prio3<Sum<Field64>, XofTurboShake128, 16>;
 
 impl Prio3Sum {
     /// Construct an instance of `Prio3Sum` with the given number of aggregators, where each summand
     /// must be in the range `[0, max_measurement]`. Errors if `max_measurement == 0`.
     pub fn new_sum(
         num_aggregators: u8,
-        max_measurement: <Field128 as FieldElementWithInteger>::Integer,
+        max_measurement: <Field64 as FieldElementWithInteger>::Integer,
     ) -> Result<Self, VdafError> {
         Prio3::new(num_aggregators, 1, 0x00000001, Sum::new(max_measurement)?)
     }
@@ -1711,7 +1711,7 @@ mod tests {
 
         let (public_share, mut input_shares) = prio3.shard(CTX_STR, &1, &nonce).unwrap();
         assert_matches!(input_shares[0].measurement_share, Share::Leader(ref mut data) => {
-            data[0] += Field128::one();
+            data[0] += Field64::one();
         });
         let result = run_vdaf_prepare(
             &prio3,
@@ -1726,7 +1726,7 @@ mod tests {
 
         let (public_share, mut input_shares) = prio3.shard(CTX_STR, &1, &nonce).unwrap();
         assert_matches!(input_shares[0].proofs_share, Share::Leader(ref mut data) => {
-                data[0] += Field128::one();
+                data[0] += Field64::one();
         });
         let result = run_vdaf_prepare(
             &prio3,

--- a/src/vdaf/prio3_test.rs
+++ b/src/vdaf/prio3_test.rs
@@ -285,7 +285,7 @@ mod tests {
     #[ignore]
     #[test]
     fn test_vec_prio3_sum() {
-        const FAKE_MAX_MEASUREMENT_UPDATE_ME: u128 = 0;
+        const FAKE_MAX_MEASUREMENT_UPDATE_ME: u64 = 0;
         for test_vector_str in [
             include_str!("test_vec/08/Prio3Sum_0.json"),
             include_str!("test_vec/08/Prio3Sum_1.json"),


### PR DESCRIPTION
Partially addresses #1122.

As of draft 12, Prio3Sum uses Field64 instead of Field128, since we no longer use joint randomness in the circuit.