### PR TITLE
Add aggegation initialization method

### DIFF
--- a/src/vdaf.rs
+++ b/src/vdaf.rs
@@ -306,7 +306,13 @@ pub trait Aggregator<const VERIFY_KEY_SIZE: usize, const NONCE_SIZE: usize>: Vda
         &self,
         agg_param: &Self::AggregationParam,
         output_shares: M,
-    ) -> Result<Self::AggregateShare, VdafError>;
+    ) -> Result<Self::AggregateShare, VdafError> {
+        let mut share = self.aggregate_init(agg_param);
+        for output_share in output_shares {
+            share.accumulate(&output_share)?;
+        }
+        Ok(share)
+    }
 
     /// Create an empty aggregate share.
     fn aggregate_init(&self, agg_param: &Self::AggregationParam) -> Self::AggregateShare;

--- a/src/vdaf.rs
+++ b/src/vdaf.rs
@@ -308,6 +308,9 @@ pub trait Aggregator<const VERIFY_KEY_SIZE: usize, const NONCE_SIZE: usize>: Vda
         output_shares: M,
     ) -> Result<Self::AggregateShare, VdafError>;
 
+    /// Create an empty aggregate share.
+    fn aggregate_init(&self, agg_param: &Self::AggregationParam) -> Self::AggregateShare;
+
     /// Validates an aggregation parameter with respect to all previous aggregaiton parameters used
     /// for the same input share. `prev` MUST be sorted from least to most recently used.
     #[must_use]

--- a/src/vdaf/dummy.rs
+++ b/src/vdaf/dummy.rs
@@ -160,14 +160,18 @@ impl vdaf::Aggregator<0, 16> for Vdaf {
 
     fn aggregate<M: IntoIterator<Item = Self::OutputShare>>(
         &self,
-        _aggregation_param: &Self::AggregationParam,
+        aggregation_param: &Self::AggregationParam,
         output_shares: M,
     ) -> Result<Self::AggregateShare, VdafError> {
-        let mut aggregate_share = AggregateShare(0);
+        let mut aggregate_share = self.aggregate_init(aggregation_param);
         for output_share in output_shares {
             aggregate_share.accumulate(&output_share)?;
         }
         Ok(aggregate_share)
+    }
+
+    fn aggregate_init(&self, _agg_param: &Self::AggregationParam) -> Self::AggregateShare {
+        AggregateShare(0)
     }
 
     fn is_agg_param_valid(_cur: &Self::AggregationParam, _prev: &[Self::AggregationParam]) -> bool {

--- a/src/vdaf/dummy.rs
+++ b/src/vdaf/dummy.rs
@@ -158,18 +158,6 @@ impl vdaf::Aggregator<0, 16> for Vdaf {
         (self.prep_step_fn)(&state)
     }
 
-    fn aggregate<M: IntoIterator<Item = Self::OutputShare>>(
-        &self,
-        aggregation_param: &Self::AggregationParam,
-        output_shares: M,
-    ) -> Result<Self::AggregateShare, VdafError> {
-        let mut aggregate_share = self.aggregate_init(aggregation_param);
-        for output_share in output_shares {
-            aggregate_share.accumulate(&output_share)?;
-        }
-        Ok(aggregate_share)
-    }
-
     fn aggregate_init(&self, _agg_param: &Self::AggregationParam) -> Self::AggregateShare {
         AggregateShare(0)
     }

--- a/src/vdaf/mastic.rs
+++ b/src/vdaf/mastic.rs
@@ -641,18 +641,6 @@ where
         Ok(PrepareTransition::Finish(output_shares))
     }
 
-    fn aggregate<M: IntoIterator<Item = MasticOutputShare<T::Field>>>(
-        &self,
-        agg_param: &MasticAggregationParam,
-        output_shares: M,
-    ) -> Result<MasticAggregateShare<T::Field>, VdafError> {
-        let mut agg_share = self.aggregate_init(agg_param);
-        for output_share in output_shares.into_iter() {
-            agg_share.accumulate(&output_share)?;
-        }
-        Ok(agg_share)
-    }
-
     fn aggregate_init(&self, agg_param: &Self::AggregationParam) -> Self::AggregateShare {
         MasticAggregateShare::<T::Field>::from(vec![
             T::Field::zero();

--- a/src/vdaf/mastic.rs
+++ b/src/vdaf/mastic.rs
@@ -646,18 +646,22 @@ where
         agg_param: &MasticAggregationParam,
         output_shares: M,
     ) -> Result<MasticAggregateShare<T::Field>, VdafError> {
-        let mut agg_share = MasticAggregateShare::<T::Field>::from(vec![
+        let mut agg_share = self.aggregate_init(agg_param);
+        for output_share in output_shares.into_iter() {
+            agg_share.accumulate(&output_share)?;
+        }
+        Ok(agg_share)
+    }
+
+    fn aggregate_init(&self, agg_param: &Self::AggregationParam) -> Self::AggregateShare {
+        MasticAggregateShare::<T::Field>::from(vec![
             T::Field::zero();
             self.vidpf.weight_parameter
                 * agg_param
                     .level_and_prefixes
                     .prefixes()
                     .len()
-        ]);
-        for output_share in output_shares.into_iter() {
-            agg_share.accumulate(&output_share)?;
-        }
-        Ok(agg_share)
+        ])
     }
 }
 

--- a/src/vdaf/poplar1.rs
+++ b/src/vdaf/poplar1.rs
@@ -1251,18 +1251,6 @@ impl<P: Xof<SEED_SIZE>, const SEED_SIZE: usize> Aggregator<SEED_SIZE, 16>
         }
     }
 
-    fn aggregate<M: IntoIterator<Item = Poplar1FieldVec>>(
-        &self,
-        agg_param: &Poplar1AggregationParam,
-        output_shares: M,
-    ) -> Result<Poplar1FieldVec, VdafError> {
-        aggregate(
-            usize::from(agg_param.level) == self.bits - 1,
-            agg_param.prefixes.len(),
-            output_shares,
-        )
-    }
-
     fn aggregate_init(&self, agg_param: &Self::AggregationParam) -> Self::AggregateShare {
         Poplar1FieldVec::zero(
             usize::from(agg_param.level) == self.bits - 1,

--- a/src/vdaf/poplar1.rs
+++ b/src/vdaf/poplar1.rs
@@ -1263,6 +1263,13 @@ impl<P: Xof<SEED_SIZE>, const SEED_SIZE: usize> Aggregator<SEED_SIZE, 16>
         )
     }
 
+    fn aggregate_init(&self, agg_param: &Self::AggregationParam) -> Self::AggregateShare {
+        Poplar1FieldVec::zero(
+            usize::from(agg_param.level) == self.bits - 1,
+            agg_param.prefixes.len(),
+        )
+    }
+
     /// Validates that no aggregation parameter with the same level as `cur` has been used with the
     /// same input share before. `prev` contains the aggregation parameters used for the same input.
     /// `prev` MUST be sorted from least to most recently used.

--- a/src/vdaf/prio2.rs
+++ b/src/vdaf/prio2.rs
@@ -317,19 +317,6 @@ impl Aggregator<32, 16> for Prio2 {
         Ok(PrepareTransition::Finish(OutputShare::from(data)))
     }
 
-    fn aggregate<M: IntoIterator<Item = OutputShare<FieldPrio2>>>(
-        &self,
-        _agg_param: &Self::AggregationParam,
-        out_shares: M,
-    ) -> Result<AggregateShare<FieldPrio2>, VdafError> {
-        let mut agg_share = self.aggregate_init(&());
-        for out_share in out_shares.into_iter() {
-            agg_share.accumulate(&out_share)?;
-        }
-
-        Ok(agg_share)
-    }
-
     fn aggregate_init(&self, _agg_param: &Self::AggregationParam) -> Self::AggregateShare {
         AggregateShare(vec![FieldPrio2::zero(); self.input_len])
     }

--- a/src/vdaf/prio2.rs
+++ b/src/vdaf/prio2.rs
@@ -322,12 +322,16 @@ impl Aggregator<32, 16> for Prio2 {
         _agg_param: &Self::AggregationParam,
         out_shares: M,
     ) -> Result<AggregateShare<FieldPrio2>, VdafError> {
-        let mut agg_share = AggregateShare(vec![FieldPrio2::zero(); self.input_len]);
+        let mut agg_share = self.aggregate_init(&());
         for out_share in out_shares.into_iter() {
             agg_share.accumulate(&out_share)?;
         }
 
         Ok(agg_share)
+    }
+
+    fn aggregate_init(&self, _agg_param: &Self::AggregationParam) -> Self::AggregateShare {
+        AggregateShare(vec![FieldPrio2::zero(); self.input_len])
     }
 
     /// Returns `true` iff `prev.is_empty()`

--- a/src/vdaf/prio3.rs
+++ b/src/vdaf/prio3.rs
@@ -1440,20 +1440,6 @@ where
         Ok(PrepareTransition::Finish(output_share))
     }
 
-    /// Aggregates a sequence of output shares into an aggregate share.
-    fn aggregate<It: IntoIterator<Item = OutputShare<T::Field>>>(
-        &self,
-        _agg_param: &(),
-        output_shares: It,
-    ) -> Result<AggregateShare<T::Field>, VdafError> {
-        let mut agg_share = self.aggregate_init(&());
-        for output_share in output_shares.into_iter() {
-            agg_share.accumulate(&output_share)?;
-        }
-
-        Ok(agg_share)
-    }
-
     fn aggregate_init(&self, _agg_param: &Self::AggregationParam) -> Self::AggregateShare {
         AggregateShare(vec![T::Field::zero(); self.typ.output_len()])
     }

--- a/src/vdaf/prio3.rs
+++ b/src/vdaf/prio3.rs
@@ -1446,12 +1446,16 @@ where
         _agg_param: &(),
         output_shares: It,
     ) -> Result<AggregateShare<T::Field>, VdafError> {
-        let mut agg_share = AggregateShare(vec![T::Field::zero(); self.typ.output_len()]);
+        let mut agg_share = self.aggregate_init(&());
         for output_share in output_shares.into_iter() {
             agg_share.accumulate(&output_share)?;
         }
 
         Ok(agg_share)
+    }
+
+    fn aggregate_init(&self, _agg_param: &Self::AggregationParam) -> Self::AggregateShare {
+        AggregateShare(vec![T::Field::zero(); self.typ.output_len()])
     }
 
     /// Returns `true` iff `prev.is_empty()`


### PR DESCRIPTION
This adds an `Aggregator::aggregate_init()` method to match `vdaf.agg_init()` from the spec. When combined with the existing `Aggregatable` trait, this completes the streaming aggregation API from draft-irtf-cfrg-vdaf-13. A default implementation is provided for `Aggregator::aggregate()`, making use of the streaming API.

Closes #569.