### PR TITLE
Renew wildcard audit of prio

### DIFF
--- a/supply-chain/audits.toml
+++ b/supply-chain/audits.toml
@@ -14,7 +14,7 @@ who = "David Cook <dcook@divviup.org>"
 criteria = "safe-to-deploy"
 user-id = 213776
 start = "2020-09-28"
-end = "2025-02-12"
+end = "2026-01-07"
 
 [[audits.aes]]
 who = "Brandon Pitman <bran@bran.land>"


### PR DESCRIPTION
This renews our wildcard audit of the prio crate, since its expiration is coming up.