### PR TITLE
Remove `getrandom()`, clean up error handling

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -358,10 +358,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c4567c8db10ae91089c99af84c68c38da3ec2f087c3f82960bcdbf3656b6f4d7"
 dependencies = [
  "cfg-if",
- "js-sys",
  "libc",
  "wasi",
- "wasm-bindgen",
 ]
 
 [[package]]
@@ -690,7 +688,6 @@ dependencies = [
  "ctr",
  "fiat-crypto",
  "fixed",
- "getrandom",
  "hex",
  "hex-literal",
  "hmac",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,7 +17,6 @@ byteorder = "1.5.0"
 ctr = { version = "0.9.2", optional = true }
 fiat-crypto = { version = "0.2.9", optional = true }
 fixed = { version = "1.27", optional = true }
-getrandom = { version = "0.2.14", features = ["std"] }
 hex = { version = "0.4.3", features = ["serde"], optional = true }
 hmac = { version = "0.12.1", optional = true }
 num-bigint = { version = "0.4.6", optional = true, features = ["rand", "serde"] }
@@ -55,7 +54,6 @@ experimental = ["bitvec", "fiat-crypto", "fixed", "num-bigint", "num-rational", 
 multithreaded = ["rayon"]
 crypto-dependencies = ["aes", "ctr", "hmac", "sha2"]
 test-util = ["hex", "serde_json", "zipf"]
-wasm-compat = ["getrandom/js"]
 
 [workspace]
 members = [".", "binaries"]

--- a/benches/cycle_counts.rs
+++ b/benches/cycle_counts.rs
@@ -23,7 +23,7 @@ use prio::{
 };
 
 fn prng(size: usize) -> Vec<Field128> {
-    random_vector(size).unwrap()
+    random_vector(size)
 }
 
 fn prng_16() -> Vec<Field128> {

--- a/benches/speed_tests.rs
+++ b/benches/speed_tests.rs
@@ -94,7 +94,9 @@ fn poly_mul(c: &mut Criterion) {
             let m = (size + 1).next_power_of_two();
             let mut g: Mul<F> = Mul::new(*size);
             let mut outp = vec![F::zero(); 2 * m];
-            let inp = vec![random_vector(m).unwrap(); 2];
+            let mut inp = vec![];
+            inp.push(random_vector(m));
+            inp.push(random_vector(m));
 
             b.iter(|| {
                 benchmarked_gadget_mul_call_poly_fft(&mut g, &mut outp, &inp).unwrap();
@@ -105,7 +107,9 @@ fn poly_mul(c: &mut Criterion) {
             let m = (size + 1).next_power_of_two();
             let mut g: Mul<F> = Mul::new(*size);
             let mut outp = vec![F::zero(); 2 * m];
-            let inp = vec![random_vector(m).unwrap(); 2];
+            let mut inp = vec![];
+            inp.push(random_vector(m));
+            inp.push(random_vector(m));
 
             b.iter(|| {
                 benchmarked_gadget_mul_call_poly_direct(&mut g, &mut outp, &inp).unwrap();
@@ -709,11 +713,10 @@ fn idpf(c: &mut Criterion) {
             let input = IdpfInput::from_bools(&bits);
 
             let inner_values = random_vector::<Field64>(size - 1)
-                .unwrap()
                 .into_iter()
                 .map(|random_element| Poplar1IdpfValue::new([Field64::one(), random_element]))
                 .collect::<Vec<_>>();
-            let leaf_value = Poplar1IdpfValue::new([Field255::one(), random_vector(1).unwrap()[0]]);
+            let leaf_value = Poplar1IdpfValue::new([Field255::one(), random_vector(1)[0]]);
 
             let idpf = Idpf::new((), ());
             b.iter(|| {
@@ -732,11 +735,10 @@ fn idpf(c: &mut Criterion) {
             let input = IdpfInput::from_bools(&bits);
 
             let inner_values = random_vector::<Field64>(size - 1)
-                .unwrap()
                 .into_iter()
                 .map(|random_element| Poplar1IdpfValue::new([Field64::one(), random_element]))
                 .collect::<Vec<_>>();
-            let leaf_value = Poplar1IdpfValue::new([Field255::one(), random_vector(1).unwrap()[0]]);
+            let leaf_value = Poplar1IdpfValue::new([Field255::one(), random_vector(1)[0]]);
 
             let idpf = Idpf::new((), ());
             let (public_share, keys) = idpf

--- a/src/fft.rs
+++ b/src/fft.rs
@@ -136,7 +136,7 @@ mod tests {
         for size in test_sizes.iter() {
             let mut tmp = vec![F::zero(); *size];
             let mut got = vec![F::zero(); *size];
-            let want = random_vector(*size).unwrap();
+            let want = random_vector(*size);
 
             discrete_fourier_transform(&mut tmp, &want, want.len())?;
             discrete_fourier_transform_inv(&mut got, &tmp, tmp.len())?;
@@ -166,7 +166,7 @@ mod tests {
         let size = 128;
         let mut mem = TestPolyAuxMemory::new(size / 2);
 
-        let inp = random_vector(size).unwrap();
+        let inp = random_vector(size);
         let mut want = vec![FieldPrio2::zero(); size];
         let mut got = vec![FieldPrio2::zero(); size];
 
@@ -191,8 +191,8 @@ mod tests {
     fn test_fft_linearity() {
         let len = 16;
         let num_shares = 3;
-        let x: Vec<Field64> = random_vector(len).unwrap();
-        let mut x_shares = split_vector(&x, num_shares).unwrap();
+        let x: Vec<Field64> = random_vector(len);
+        let mut x_shares = split_vector(&x, num_shares);
 
         // Just for fun, let's do something different with a subset of the inputs. For the first
         // share, every odd element is set to the plaintext value. For all shares but the first,

--- a/src/field.rs
+++ b/src/field.rs
@@ -10,7 +10,7 @@
 use crate::{
     codec::{CodecError, Decode, Encode},
     fp::{FieldOps, FieldParameters, FP128, FP32, FP64},
-    prng::{Prng, PrngError},
+    prng::Prng,
 };
 use rand::{
     distributions::{Distribution, Standard},
@@ -876,31 +876,28 @@ pub(crate) fn merge_vector<F: FieldElement>(
 
 /// Outputs an additive secret sharing of the input.
 #[cfg(test)]
-pub(crate) fn split_vector<F: FieldElement>(
-    inp: &[F],
-    num_shares: usize,
-) -> Result<Vec<Vec<F>>, PrngError> {
+pub(crate) fn split_vector<F: FieldElement>(inp: &[F], num_shares: usize) -> Vec<Vec<F>> {
     if num_shares == 0 {
-        return Ok(vec![]);
+        return vec![];
     }
 
     let mut outp = Vec::with_capacity(num_shares);
     outp.push(inp.to_vec());
 
     for _ in 1..num_shares {
-        let share: Vec<F> = random_vector(inp.len())?;
+        let share: Vec<F> = random_vector(inp.len());
         for (x, y) in outp[0].iter_mut().zip(&share) {
             *x -= *y;
         }
         outp.push(share);
     }
 
-    Ok(outp)
+    outp
 }
 
 /// Generate a vector of uniformly distributed random field elements.
-pub fn random_vector<F: FieldElement>(len: usize) -> Result<Vec<F>, PrngError> {
-    Ok(Prng::new()?.take(len).collect())
+pub fn random_vector<F: FieldElement>(len: usize) -> Vec<F> {
+    Prng::new().take(len).collect()
 }
 
 /// `encode_fieldvec` serializes a type that is equivalent to a vector of field elements.
@@ -979,7 +976,7 @@ pub(crate) mod test_utils {
     }
 
     pub(crate) fn field_element_test_common<F: TestFieldElementWithInteger>() {
-        let mut prng: Prng<F, _> = Prng::new().unwrap();
+        let mut prng: Prng<F, _> = Prng::new();
         let int_modulus = F::modulus();
         let int_one = F::TestInteger::try_from(1).unwrap();
         let zero = F::zero();
@@ -1174,7 +1171,7 @@ mod tests {
     fn field_element_test<F: FftFriendlyFieldElement + Hash>() {
         field_element_test_common::<F>();
 
-        let mut prng: Prng<F, _> = Prng::new().unwrap();
+        let mut prng: Prng<F, _> = Prng::new();
         let int_modulus = F::modulus();
         let int_one = F::Integer::try_from(1).unwrap();
         let zero = F::zero();

--- a/src/flp.rs
+++ b/src/flp.rs
@@ -30,16 +30,16 @@
 //! // check the proof. The application needs to ensure that the prover
 //! // "commits" to the input before this point. In Prio3, the joint
 //! // randomness is derived from additive shares of the input.
-//! let joint_rand = random_vector(count.joint_rand_len()).unwrap();
+//! let joint_rand = random_vector(count.joint_rand_len());
 //!
 //! // The prover generates the proof.
-//! let prove_rand = random_vector(count.prove_rand_len()).unwrap();
+//! let prove_rand = random_vector(count.prove_rand_len());
 //! let proof = count.prove(&input, &prove_rand, &joint_rand).unwrap();
 //!
 //! // The verifier checks the proof. In the first step, the verifier "queries"
 //! // the input and proof, getting the "verifier message" in response. It then
 //! // inspects the verifier to decide if the input is valid.
-//! let query_rand = random_vector(count.query_rand_len()).unwrap();
+//! let query_rand = random_vector(count.query_rand_len());
 //! let verifier = count.query(&input, &proof, &query_rand, &joint_rand, 1).unwrap();
 //! assert!(count.decide(&verifier).unwrap());
 //! ```
@@ -178,7 +178,7 @@ pub trait Type: Sized + Eq + Clone + Debug {
     ///
     /// let count = Count::new();
     /// let input: Vec<Field64> = count.encode_measurement(&true).unwrap();
-    /// let joint_rand = random_vector(count.joint_rand_len()).unwrap();
+    /// let joint_rand = random_vector(count.joint_rand_len());
     /// let v = count.valid(&mut count.gadget(), &input, &joint_rand, 1).unwrap();
     /// assert!(v.into_iter().all(|f| f == Field64::zero()));
     /// ```
@@ -874,9 +874,9 @@ pub mod test_utils {
             );
 
             let mut gadgets = self.flp.gadget();
-            let joint_rand = random_vector(self.flp.joint_rand_len()).unwrap();
-            let prove_rand = random_vector(self.flp.prove_rand_len()).unwrap();
-            let query_rand = random_vector(self.flp.query_rand_len()).unwrap();
+            let joint_rand = random_vector(self.flp.joint_rand_len());
+            let prove_rand = random_vector(self.flp.prove_rand_len());
+            let query_rand = random_vector(self.flp.query_rand_len());
             assert_eq!(
                 self.flp.joint_rand_len(),
                 joint_rand.len(),
@@ -999,8 +999,7 @@ pub mod test_utils {
         outp.push(inp.to_vec());
 
         for _ in 1..SHARES {
-            let share: Vec<F> =
-                random_vector(inp.len()).expect("failed to generate a random vector");
+            let share: Vec<F> = random_vector(inp.len());
             for (x, y) in outp[0].iter_mut().zip(&share) {
                 *x -= *y;
             }
@@ -1031,21 +1030,18 @@ mod tests {
         assert_eq!(input.len(), typ.input_len());
 
         let input_shares: Vec<Vec<Field128>> = split_vector(input.as_slice(), NUM_SHARES)
-            .unwrap()
             .into_iter()
             .collect();
 
-        let joint_rand = random_vector(typ.joint_rand_len()).unwrap();
-        let prove_rand = random_vector(typ.prove_rand_len()).unwrap();
-        let query_rand = random_vector(typ.query_rand_len()).unwrap();
+        let joint_rand = random_vector(typ.joint_rand_len());
+        let prove_rand = random_vector(typ.prove_rand_len());
+        let query_rand = random_vector(typ.query_rand_len());
 
         let proof = typ.prove(&input, &prove_rand, &joint_rand).unwrap();
         assert_eq!(proof.len(), typ.proof_len());
 
-        let proof_shares: Vec<Vec<Field128>> = split_vector(&proof, NUM_SHARES)
-            .unwrap()
-            .into_iter()
-            .collect();
+        let proof_shares: Vec<Vec<Field128>> =
+            split_vector(&proof, NUM_SHARES).into_iter().collect();
 
         let verifier: Vec<Field128> = (0..NUM_SHARES)
             .map(|i| {
@@ -1191,9 +1187,9 @@ mod tests {
         let typ: Issue254Type<Field128> = Issue254Type::new();
         let input = typ.encode_measurement(&0).unwrap();
         assert_eq!(input.len(), typ.input_len());
-        let joint_rand = random_vector(typ.joint_rand_len()).unwrap();
-        let prove_rand = random_vector(typ.prove_rand_len()).unwrap();
-        let query_rand = random_vector(typ.query_rand_len()).unwrap();
+        let joint_rand = random_vector(typ.joint_rand_len());
+        let prove_rand = random_vector(typ.prove_rand_len());
+        let query_rand = random_vector(typ.query_rand_len());
         let proof = typ.prove(&input, &prove_rand, &joint_rand).unwrap();
         let verifier = typ
             .query(&input, &proof, &query_rand, &joint_rand, 1)

--- a/src/flp/gadgets.rs
+++ b/src/flp/gadgets.rs
@@ -490,7 +490,7 @@ mod tests {
 
     #[test]
     fn test_poly_eval() {
-        let poly: Vec<TestField> = random_vector(10).unwrap();
+        let poly: Vec<TestField> = random_vector(10);
 
         let num_calls = FFT_THRESHOLD / 2;
         let mut g: PolyEval<TestField> = PolyEval::new(poly.clone(), num_calls);
@@ -531,7 +531,7 @@ mod tests {
             let degree = g.degree();
 
             // Test that both gadgets evaluate to the same value when run on scalar inputs.
-            let inp: Vec<TestField> = random_vector(arity).unwrap();
+            let inp: Vec<TestField> = random_vector(arity);
             let result = g.call(&inp).unwrap();
             let result_serial = g_serial.call(&inp).unwrap();
             assert_eq!(result, result_serial);
@@ -541,7 +541,7 @@ mod tests {
                 vec![TestField::zero(); (degree * num_calls + 1).next_power_of_two()];
             let mut poly_outp_serial =
                 vec![TestField::zero(); (degree * num_calls + 1).next_power_of_two()];
-            let mut prng: Prng<TestField, _> = Prng::new().unwrap();
+            let mut prng: Prng<TestField, _> = Prng::new();
             let poly_inp: Vec<_> = iter::repeat_with(|| {
                 iter::repeat_with(|| prng.get())
                     .take(1 + num_calls)
@@ -562,7 +562,7 @@ mod tests {
     /// to evaluating each of the inputs at the same point and applying g.call() on the results.
     fn gadget_test<F: FftFriendlyFieldElement, G: Gadget<F>>(g: &mut G, num_calls: usize) {
         let wire_poly_len = (1 + num_calls).next_power_of_two();
-        let mut prng = Prng::new().unwrap();
+        let mut prng = Prng::new();
         let mut inp = vec![F::zero(); g.arity()];
         let mut gadget_poly = vec![F::zero(); gadget_poly_fft_mem_len(g.degree(), num_calls)];
         let mut wire_polys = vec![vec![F::zero(); wire_poly_len]; g.arity()];

--- a/src/flp/types.rs
+++ b/src/flp/types.rs
@@ -1420,9 +1420,9 @@ mod tests {
         let typ: SumVec<TestField, ParallelSum<TestField, _>> = SumVec::new(1, 1000, 31).unwrap();
         let input = typ.encode_measurement(&vec![0; 1000]).unwrap();
         assert_eq!(input.len(), typ.input_len());
-        let joint_rand = random_vector(typ.joint_rand_len()).unwrap();
-        let prove_rand = random_vector(typ.prove_rand_len()).unwrap();
-        let query_rand = random_vector(typ.query_rand_len()).unwrap();
+        let joint_rand = random_vector(typ.joint_rand_len());
+        let prove_rand = random_vector(typ.prove_rand_len());
+        let query_rand = random_vector(typ.query_rand_len());
         let proof = typ.prove(&input, &prove_rand, &joint_rand).unwrap();
         let verifier = typ
             .query(&input, &proof, &query_rand, &joint_rand, 1)
@@ -1438,9 +1438,9 @@ mod tests {
             SumVec::new(1, 1000, 31).unwrap();
         let input = typ.encode_measurement(&vec![0; 1000]).unwrap();
         assert_eq!(input.len(), typ.input_len());
-        let joint_rand = random_vector(typ.joint_rand_len()).unwrap();
-        let prove_rand = random_vector(typ.prove_rand_len()).unwrap();
-        let query_rand = random_vector(typ.query_rand_len()).unwrap();
+        let joint_rand = random_vector(typ.joint_rand_len());
+        let prove_rand = random_vector(typ.prove_rand_len());
+        let query_rand = random_vector(typ.query_rand_len());
         let proof = typ.prove(&input, &prove_rand, &joint_rand).unwrap();
         let verifier = typ
             .query(&input, &proof, &query_rand, &joint_rand, 1)

--- a/src/flp/types/dp.rs
+++ b/src/flp/types/dp.rs
@@ -222,7 +222,6 @@ mod tests {
             let mut rng = XofTurboShake128::init(&[0; 32], &[]).into_seed_stream();
             let [mut share1, mut share2]: [Vec<Field128>; 2] =
                 split_vector(&[Field128::zero(); SIZE], 2)
-                    .unwrap()
                     .try_into()
                     .unwrap();
 
@@ -258,7 +257,6 @@ mod tests {
             let mut rng = XofTurboShake128::init(&[1; 32], &[]).into_seed_stream();
             let [mut share1, mut share2]: [Vec<Field128>; 2] =
                 split_vector(&[Field128::zero(); SIZE], 2)
-                    .unwrap()
                     .try_into()
                     .unwrap();
 
@@ -301,7 +299,6 @@ mod tests {
         let mut rng = XofTurboShake128::init(&[2; 32], &[]).into_seed_stream();
         let [mut share1, mut share2]: [Vec<Field128>; 2] =
             split_vector(&[Field128::zero(); SIZE], 2)
-                .unwrap()
                 .try_into()
                 .unwrap();
 

--- a/src/flp/types/fixedpoint_l2.rs
+++ b/src/flp/types/fixedpoint_l2.rs
@@ -822,7 +822,7 @@ mod tests {
 
         // invalid submission length, should be 3n + (2*n - 2) for a
         // 3-element n-bit vector. 3*n bits for 3 entries, (2*n-2) for norm.
-        let joint_rand = random_vector(vsum.joint_rand_len()).unwrap();
+        let joint_rand = random_vector(vsum.joint_rand_len());
         vsum.valid(
             &mut vsum.gadget(),
             &vec![one; 3 * n + 2 * n - 1],

--- a/src/idpf.rs
+++ b/src/idpf.rs
@@ -19,7 +19,7 @@ use bitvec::{
     vec::BitVec,
     view::BitView,
 };
-use rand_core::RngCore;
+use rand::prelude::*;
 use std::{
     collections::{HashMap, VecDeque},
     fmt::Debug,
@@ -493,6 +493,7 @@ where
     where
         M: IntoIterator<Item = VI>,
     {
+        let mut rng = thread_rng();
         if input.is_empty() {
             return Err(
                 IdpfError::InvalidParameter("invalid number of bits: 0".to_string()).into(),
@@ -500,7 +501,7 @@ where
         }
         let mut random = [[0u8; 16]; 2];
         for random_seed in random.iter_mut() {
-            getrandom::getrandom(random_seed)?;
+            rng.fill(random_seed);
         }
         self.gen_with_random(input, inner_values, leaf_value, ctx, nonce, &random)
     }
@@ -1035,7 +1036,6 @@ enum XofMode<'a> {
 pub mod test_utils {
     use super::*;
 
-    use rand::prelude::*;
     use zipf::ZipfDistribution;
 
     /// Generate a set of IDPF inputs with the given bit length `bits`. They are sampled according
@@ -1373,15 +1373,14 @@ mod tests {
         let input = bits.clone().into();
 
         let mut inner_values = Vec::with_capacity(INPUT_LEN - 1);
-        let mut prng = Prng::new().unwrap();
+        let mut prng = Prng::new();
         for _ in 0..INPUT_LEN - 1 {
             inner_values.push(Poplar1IdpfValue::new([
                 Field64::one(),
                 prng.next().unwrap(),
             ]));
         }
-        let leaf_values =
-            Poplar1IdpfValue::new([Field255::one(), Prng::new().unwrap().next().unwrap()]);
+        let leaf_values = Poplar1IdpfValue::new([Field255::one(), Prng::new().next().unwrap()]);
 
         let nonce: [u8; 16] = random();
         let idpf = Idpf::new((), ());
@@ -1442,15 +1441,14 @@ mod tests {
         let input = bits.into();
 
         let mut inner_values = Vec::with_capacity(7);
-        let mut prng = Prng::new().unwrap();
+        let mut prng = Prng::new();
         for _ in 0..7 {
             inner_values.push(Poplar1IdpfValue::new([
                 Field64::one(),
                 prng.next().unwrap(),
             ]));
         }
-        let leaf_values =
-            Poplar1IdpfValue::new([Field255::one(), Prng::new().unwrap().next().unwrap()]);
+        let leaf_values = Poplar1IdpfValue::new([Field255::one(), Prng::new().next().unwrap()]);
 
         let nonce: [u8; 16] = random();
         let idpf = Idpf::new((), ());
@@ -1621,15 +1619,14 @@ mod tests {
         let input = bits.into();
 
         let mut inner_values = Vec::with_capacity(7);
-        let mut prng = Prng::new().unwrap();
+        let mut prng = Prng::new();
         for _ in 0..7 {
             inner_values.push(Poplar1IdpfValue::new([
                 Field64::one(),
                 prng.next().unwrap(),
             ]));
         }
-        let leaf_values =
-            Poplar1IdpfValue::new([Field255::one(), Prng::new().unwrap().next().unwrap()]);
+        let leaf_values = Poplar1IdpfValue::new([Field255::one(), Prng::new().next().unwrap()]);
 
         let nonce: [u8; 16] = random();
         let idpf = Idpf::new((), ());

--- a/src/vdaf.rs
+++ b/src/vdaf.rs
@@ -17,7 +17,6 @@ use crate::{
     codec::{CodecError, Decode, Encode, ParameterizedDecode},
     field::{encode_fieldvec, merge_vector, FieldElement, FieldError},
     flp::FlpError,
-    prng::PrngError,
     vdaf::xof::Seed,
 };
 use serde::{Deserialize, Serialize};
@@ -52,14 +51,6 @@ pub enum VdafError {
     #[cfg(all(feature = "crypto-dependencies", feature = "experimental"))]
     #[error("Szk error: {0}")]
     Szk(#[from] SzkError),
-
-    /// PRNG error.
-    #[error("prng error: {0}")]
-    Prng(#[from] PrngError),
-
-    /// Failure when calling getrandom().
-    #[error("getrandom: {0}")]
-    GetRandom(#[from] getrandom::Error),
 
     /// IDPF error.
     #[cfg(all(feature = "crypto-dependencies", feature = "experimental"))]
@@ -685,7 +676,7 @@ where
     for<'a> T: ParameterizedDecode<(&'a V, &'a V::AggregationParam)>,
 {
     // Generate an arbitrary vector of field elements.
-    let vec: Vec<F> = crate::field::random_vector(length).unwrap();
+    let vec: Vec<F> = crate::field::random_vector(length);
 
     // Serialize the field element vector into a vector of bytes.
     let mut bytes = Vec::with_capacity(vec.len() * F::ENCODED_SIZE);

--- a/src/vdaf/mastic.rs
+++ b/src/vdaf/mastic.rs
@@ -323,13 +323,14 @@ impl<T: Type> Client<16> for Mastic<T> {
         measurement: &(VidpfInput, T::Measurement),
         nonce: &[u8; 16],
     ) -> Result<(Self::PublicShare, Vec<Self::InputShare>), VdafError> {
-        let vidpf_keys = [VidpfKey::generate()?, VidpfKey::generate()?];
+        let mut rng = thread_rng();
+        let vidpf_keys = rng.gen();
         let joint_random_opt = if self.szk.requires_joint_rand() {
-            Some(Seed::generate()?)
+            Some(rng.gen())
         } else {
             None
         };
-        let szk_random = [Seed::generate()?, Seed::generate()?];
+        let szk_random = rng.gen();
 
         self.shard_with_random(
             ctx,

--- a/src/vdaf/prio2/server.rs
+++ b/src/vdaf/prio2/server.rs
@@ -5,7 +5,6 @@
 use crate::{
     field::{FftFriendlyFieldElement, FieldError},
     polynomial::poly_interpret_eval,
-    prng::PrngError,
     vdaf::prio2::client::{unpack_proof, SerializeError},
 };
 use serde::{Deserialize, Serialize};
@@ -23,12 +22,6 @@ pub enum ServerError {
     /// Serialization/deserialization error
     #[error("serialization/deserialization error")]
     Serialize(#[from] SerializeError),
-    /// Failure when calling getrandom().
-    #[error("getrandom: {0}")]
-    GetRandom(#[from] getrandom::Error),
-    /// PRNG error.
-    #[error("prng error: {0}")]
-    Prng(#[from] PrngError),
 }
 
 /// Verification message for proof validation
@@ -224,8 +217,7 @@ mod tests {
         ];
 
         let proof: Vec<FieldPrio2> = proof_u32.iter().map(|x| FieldPrio2::from(*x)).collect();
-        let [share1, share2]: [Vec<FieldPrio2>; 2] =
-            split_vector(&proof, 2).unwrap().try_into().unwrap();
+        let [share1, share2]: [Vec<FieldPrio2>; 2] = split_vector(&proof, 2).try_into().unwrap();
         let eval_at = FieldPrio2::from(12313);
 
         let v1 = generate_verification_message(dim, eval_at, &share1, true).unwrap();
@@ -243,8 +235,7 @@ mod tests {
         ];
 
         let proof: Vec<FieldPrio2> = proof_u32.iter().map(|x| FieldPrio2::from(*x)).collect();
-        let [share1, share2]: [Vec<FieldPrio2>; 2] =
-            split_vector(&proof, 2).unwrap().try_into().unwrap();
+        let [share1, share2]: [Vec<FieldPrio2>; 2] = split_vector(&proof, 2).try_into().unwrap();
         let eval_at = FieldPrio2::from(12313);
 
         let v1 = generate_verification_message(dim, eval_at, &share1, true).unwrap();

--- a/src/vdaf/prio2/test_vector.rs
+++ b/src/vdaf/prio2/test_vector.rs
@@ -2,17 +2,9 @@
 
 //! Test vectors of serialized Prio inputs, enabling backward compatibility testing.
 
-use crate::{field::FieldPrio2, vdaf::prio2::client::ClientError};
+use crate::field::FieldPrio2;
 use serde::{Deserialize, Serialize};
 use std::fmt::Debug;
-
-/// Errors propagated by functions in this module.
-#[derive(Debug, thiserror::Error)]
-pub(crate) enum TestVectorError {
-    /// Error from Prio client
-    #[error("Prio client error {0}")]
-    Client(#[from] ClientError),
-}
 
 /// A test vector of serialized Priov2 inputs, along with a reference sum. The field is always
 /// [`FieldPrio2`].

--- a/src/vdaf/prio3.rs
+++ b/src/vdaf/prio3.rs
@@ -58,6 +58,7 @@ use crate::vdaf::{
 };
 #[cfg(feature = "experimental")]
 use fixed::traits::Fixed;
+use rand::prelude::*;
 use std::borrow::Cow;
 use std::convert::TryFrom;
 use std::fmt::Debug;
@@ -1221,7 +1222,7 @@ where
         nonce: &[u8; 16],
     ) -> Result<(Self::PublicShare, Vec<Prio3InputShare<T::Field, SEED_SIZE>>), VdafError> {
         let mut random = vec![0u8; self.random_size()];
-        getrandom::getrandom(&mut random)?;
+        thread_rng().fill(&mut random[..]);
         self.shard_with_random(ctx, measurement, nonce, &random)
     }
 }
@@ -1743,7 +1744,6 @@ mod tests {
         },
         FixedI16, FixedI32, FixedI64,
     };
-    use rand::prelude::*;
 
     const CTX_STR: &[u8] = b"prio3 ctx";
 

--- a/src/vidpf.rs
+++ b/src/vidpf.rs
@@ -15,7 +15,7 @@ use core::{
 };
 
 use bitvec::prelude::{BitVec, Lsb0};
-use rand_core::RngCore;
+use rand::prelude::*;
 use std::fmt::Debug;
 use std::io::{Cursor, Read};
 use subtle::{Choice, ConditionallyNegatable, ConditionallySelectable, ConstantTimeEq};
@@ -46,10 +46,6 @@ pub enum VidpfError {
     /// Error when a weight has an unexpected length.
     #[error("invalid weight length")]
     InvalidWeightLength,
-
-    /// Failure when calling getrandom().
-    #[error("getrandom: {0}")]
-    GetRandom(#[from] getrandom::Error),
 }
 
 /// Represents the domain of an incremental point function.
@@ -102,7 +98,8 @@ impl<W: VidpfValue> Vidpf<W> {
         weight: &W,
         nonce: &[u8],
     ) -> Result<(VidpfPublicShare<W>, [VidpfKey; 2]), VidpfError> {
-        let keys = [VidpfKey::generate()?, VidpfKey::generate()?];
+        let mut rng = thread_rng();
+        let keys = rng.gen();
         let public = self.gen_with_keys(ctx, &keys, input, weight, nonce)?;
         Ok((public, keys))
     }


### PR DESCRIPTION
Closes #955.

Use `thread_rng().gen::<[u8; SEED_SIZE]>()` to generate seeds rather than `getrandom()`. Since this method is infallible, we no longer need to propagate errors from `getrandom()`.