### PR TITLE
flp: Split out FLP methods into their own trait

### DIFF
--- a/src/vdaf/mastic/szk.rs
+++ b/src/vdaf/mastic/szk.rs
@@ -666,7 +666,7 @@ mod tests {
         field::{random_vector, FieldElementWithInteger},
         flp::gadgets::{Mul, ParallelSum},
         flp::types::{Count, Sum, SumVec},
-        flp::Type,
+        flp::{Flp, Type},
     };
     use rand::{thread_rng, Rng};
 

--- a/src/vdaf/prio3.rs
+++ b/src/vdaf/prio3.rs
@@ -46,10 +46,12 @@ use crate::flp::gadgets::{Mul, ParallelSum};
 use crate::flp::types::fixedpoint_l2::{
     compatible_float::CompatibleFloat, FixedPointBoundedL2VecSum,
 };
-use crate::flp::types::{Average, Count, Histogram, MultihotCountVec, Sum, SumVec};
-use crate::flp::Type;
 #[cfg(feature = "experimental")]
 use crate::flp::TypeWithNoise;
+use crate::flp::{
+    types::{Average, Count, Histogram, MultihotCountVec, Sum, SumVec},
+    Type,
+};
 use crate::prng::Prng;
 use crate::vdaf::xof::{IntoFieldVec, Seed, Xof};
 use crate::vdaf::{
@@ -1731,9 +1733,12 @@ mod tests {
     use super::*;
     #[cfg(feature = "experimental")]
     use crate::flp::gadgets::ParallelSumGadget;
-    use crate::vdaf::{
-        equality_comparison_test, fieldvec_roundtrip_test,
-        test_utils::{run_vdaf, run_vdaf_prepare},
+    use crate::{
+        flp::Flp,
+        vdaf::{
+            equality_comparison_test, fieldvec_roundtrip_test,
+            test_utils::{run_vdaf, run_vdaf_prepare},
+        },
     };
     use assert_matches::assert_matches;
     #[cfg(feature = "experimental")]


### PR DESCRIPTION
Closes #1108.

Define a new trait, `Flp`, that implements the core FLP proof system. The remaining methods on `Type` are related to encoding of the measurement, truncating the output shares, and decoding the aggregate result.