### PR TITLE
Add methods for adding/subtracting vectors

### DIFF
--- a/src/flp.rs
+++ b/src/flp.rs
@@ -803,7 +803,9 @@ pub(crate) fn gadget_poly_len(gadget_degree: usize, wire_poly_len: usize) -> usi
 #[cfg_attr(docsrs, doc(cfg(feature = "test-util")))]
 pub mod test_utils {
     use super::*;
-    use crate::field::{random_vector, FieldElement, FieldElementWithInteger};
+    use crate::field::{
+        add_vector, random_vector, sub_assign_vector, FieldElement, FieldElementWithInteger,
+    };
 
     /// Various tests for an FLP.
     #[cfg_attr(docsrs, doc(cfg(feature = "test-util")))]
@@ -948,12 +950,7 @@ pub mod test_utils {
                         )
                         .unwrap()
                 })
-                .reduce(|mut left, right| {
-                    for (x, y) in left.iter_mut().zip(right.iter()) {
-                        *x += *y;
-                    }
-                    left
-                })
+                .reduce(add_vector)
                 .unwrap();
 
             let res = self.flp.decide(&verifier).unwrap();
@@ -1003,9 +1000,7 @@ pub mod test_utils {
 
         for _ in 1..SHARES {
             let share: Vec<F> = random_vector(inp.len());
-            for (x, y) in outp[0].iter_mut().zip(&share) {
-                *x -= *y;
-            }
+            sub_assign_vector(&mut outp[0], share.iter().copied());
             outp.push(share);
         }
 
@@ -1016,7 +1011,7 @@ pub mod test_utils {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::field::{random_vector, split_vector, Field128};
+    use crate::field::{add_vector, random_vector, split_vector, Field128};
     use crate::flp::gadgets::{Mul, PolyEval};
     use crate::polynomial::poly_range_check;
 
@@ -1057,12 +1052,7 @@ mod tests {
                 )
                 .unwrap()
             })
-            .reduce(|mut left, right| {
-                for (x, y) in left.iter_mut().zip(right.iter()) {
-                    *x += *y;
-                }
-                left
-            })
+            .reduce(add_vector)
             .unwrap();
         assert_eq!(verifier.len(), typ.verifier_len());
 

--- a/src/flp/gadgets.rs
+++ b/src/flp/gadgets.rs
@@ -2,6 +2,8 @@
 
 //! A collection of gadgets.
 
+#[cfg(feature = "multithreaded")]
+use crate::field::add_vector;
 use crate::field::NttFriendlyFieldElement;
 use crate::flp::{gadget_poly_len, wire_poly_len, FlpError, Gadget};
 use crate::ntt::{ntt, ntt_inv_finish};
@@ -380,15 +382,7 @@ where
                 },
             )
             .map(|state| state.partial_sum)
-            .reduce(
-                || vec![F::zero(); outp.len()],
-                |mut x, y| {
-                    for (xi, yi) in x.iter_mut().zip(y.iter()) {
-                        *xi += *yi;
-                    }
-                    x
-                },
-            );
+            .reduce(|| vec![F::zero(); outp.len()], add_vector);
 
         outp.copy_from_slice(&res[..]);
         Ok(())


### PR DESCRIPTION
Closes #301: see https://github.com/divviup/libprio-rs/issues/301#issuecomment-2599407256.

Add a method `add_assign_vector` that replaces the following zip pattern:

```
for (x, y) in a.iter_mut().zip(y) {
    *x += *y;
}
```

The method also panics if `b` is shorter than `a`.

Replace the zip pattern with this method wherever we add up vectors. This helps us ensure that we're not accidentally adding a vector that's shorter than the other.

Likewise for subtracting vectors.