### PR TITLE
Move to rand_distr::Zipf since zipf crate is deprecated

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -702,6 +702,7 @@ dependencies = [
  "prio",
  "rand",
  "rand_core",
+ "rand_distr",
  "rayon",
  "serde",
  "serde_json",
@@ -710,7 +711,6 @@ dependencies = [
  "statrs",
  "subtle",
  "thiserror",
- "zipf",
 ]
 
 [[package]]
@@ -1221,13 +1221,4 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "05f360fc0b24296329c78fda852a1e9ae82de9cf7b27dae4b7f62f118f77b9ed"
 dependencies = [
  "tap",
-]
-
-[[package]]
-name = "zipf"
-version = "7.0.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "390e51da0ed8cc3ade001d15fa5ba6f966b99c858fb466ec6b06d1682f1f94dd"
-dependencies = [
- "rand",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,6 +26,7 @@ num-rational = { version = "0.4.2", optional = true, features = ["serde"] }
 num-traits = "0.2.19"
 rand = "0.8"
 rand_core = "0.6.4"
+rand_distr = { version = "0.4.3", optional = true }
 rayon = { version = "1.10.0", optional = true }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = { version = "1.0", optional = true }
@@ -33,7 +34,6 @@ sha2 = { version = "0.10.8", optional = true }
 sha3 = "0.10.8"
 subtle = "2.6.1"
 thiserror = "2.0"
-zipf = { version = "7.0.1", optional = true }
 
 [dev-dependencies]
 assert_matches = "1.5.0"
@@ -53,7 +53,7 @@ default = ["crypto-dependencies"]
 experimental = ["bitvec", "fiat-crypto", "fixed", "num-bigint", "num-rational", "num-integer", "num-iter"]
 multithreaded = ["rayon"]
 crypto-dependencies = ["aes", "ctr", "hmac", "sha2"]
-test-util = ["hex", "serde_json", "zipf"]
+test-util = ["hex", "serde_json", "rand_distr"]
 
 [workspace]
 members = [".", "binaries"]

--- a/src/idpf.rs
+++ b/src/idpf.rs
@@ -1036,7 +1036,7 @@ enum XofMode<'a> {
 pub mod test_utils {
     use super::*;
 
-    use zipf::ZipfDistribution;
+    use rand_distr::Zipf;
 
     /// Generate a set of IDPF inputs with the given bit length `bits`. They are sampled according
     /// to the Zipf distribution with parameters `zipf_support` and `zipf_exponent`. Return the
@@ -1064,9 +1064,9 @@ pub mod test_utils {
 
         // Sample a number of inputs according to the Zipf distribution.
         let mut samples = Vec::with_capacity(measurement_count);
-        let zipf = ZipfDistribution::new(zipf_support, zipf_exponent).unwrap();
+        let zipf = Zipf::new(zipf_support as u64, zipf_exponent).unwrap();
         for _ in 0..measurement_count {
-            samples.push(inputs[zipf.sample(rng) - 1].clone());
+            samples.push(inputs[zipf.sample(rng) as usize - 1].clone());
         }
 
         // Compute the prefix tree for the desired threshold.

--- a/src/idpf.rs
+++ b/src/idpf.rs
@@ -1066,7 +1066,7 @@ pub mod test_utils {
         let mut samples = Vec::with_capacity(measurement_count);
         let zipf = Zipf::new(zipf_support as u64, zipf_exponent).unwrap();
         for _ in 0..measurement_count {
-            samples.push(inputs[zipf.sample(rng) as usize - 1].clone());
+            samples.push(inputs[zipf.sample(rng).round() as usize - 1].clone());
         }
 
         // Compute the prefix tree for the desired threshold.


### PR DESCRIPTION
Fixes issue #1222.
Also supersedes PR https://github.com/divviup/libprio-rs/pull/1217.