### PR TITLE
Raise open pull request limit

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,6 +4,7 @@ updates:
     directory: "/"
     schedule:
       interval: "weekly"
+    open-pull-requests-limit: 20
 
   - package-ecosystem: "github-actions"
     directory: "/"
@@ -15,6 +16,7 @@ updates:
     schedule:
       interval: "weekly"
     target-branch: release/0.16
+    open-pull-requests-limit: 20
 
   - package-ecosystem: "github-actions"
     directory: "/"


### PR DESCRIPTION
This raises Dependabot's open pull request limit. We are currently bumping into it because of the rand ecosystem of crates, which we still can't take yet.