### PR TITLE
Upgrade to rand 0.9

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -504,7 +504,6 @@ checksum = "a5e44f723f1133c9deac646763579fdb3ac745e418f2a7af9cd0c431da1f20b9"
 dependencies = [
  "num-integer",
  "num-traits",
- "rand",
  "serde",
 ]
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -59,6 +59,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "72b3254f16251a8381aa12e40e3c4d2f0199f8c6508fbecb9d91f575e0fbb8c6"
 
 [[package]]
+name = "bitflags"
+version = "2.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5c8214115b7bf84099f1309324e63141d4c5d7cc26862f97a0a857dbefe165bd"
+
+[[package]]
 name = "bitvec"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -322,7 +328,19 @@ checksum = "c4567c8db10ae91089c99af84c68c38da3ec2f087c3f82960bcdbf3656b6f4d7"
 dependencies = [
  "cfg-if",
  "libc",
- "wasi",
+ "wasi 0.11.0+wasi-snapshot-preview1",
+]
+
+[[package]]
+name = "getrandom"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "73fea8450eea4bac3940448fb7ae50d91f034f941199fcd9d909a5a07aa455f0"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "r-efi",
+ "wasi 0.14.2+wasi-0.2.4",
 ]
 
 [[package]]
@@ -479,8 +497,8 @@ dependencies = [
  "num-complex",
  "num-rational",
  "num-traits",
- "rand",
- "rand_distr",
+ "rand 0.8.5",
+ "rand_distr 0.4.3",
  "simba",
  "typenum",
 ]
@@ -636,9 +654,9 @@ dependencies = [
  "num-traits",
  "once_cell",
  "prio",
- "rand",
- "rand_core",
- "rand_distr",
+ "rand 0.9.1",
+ "rand_core 0.9.3",
+ "rand_distr 0.5.1",
  "rayon",
  "serde",
  "serde_json",
@@ -656,7 +674,7 @@ dependencies = [
  "base64",
  "fixed",
  "prio",
- "rand",
+ "rand 0.9.1",
 ]
 
 [[package]]
@@ -678,6 +696,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "r-efi"
+version = "5.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "74765f6d916ee2faa39bc8e68e4f3ed8949b48cccdac59983d287a7cb71ce9c5"
+
+[[package]]
 name = "radium"
 version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -690,8 +714,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "34af8d1a0e25924bc5b7c43c079c942339d8f0a8b57c39049bef581b46327404"
 dependencies = [
  "libc",
- "rand_chacha",
- "rand_core",
+ "rand_chacha 0.3.1",
+ "rand_core 0.6.4",
+]
+
+[[package]]
+name = "rand"
+version = "0.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9fbfd9d094a40bf3ae768db9361049ace4c0e04a4fd6b359518bd7b73a73dd97"
+dependencies = [
+ "rand_chacha 0.9.0",
+ "rand_core 0.9.3",
 ]
 
 [[package]]
@@ -701,7 +735,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e6c10a63a0fa32252be49d21e7709d4d4baf8d231c2dbce1eaa8141b9b127d88"
 dependencies = [
  "ppv-lite86",
- "rand_core",
+ "rand_core 0.6.4",
+]
+
+[[package]]
+name = "rand_chacha"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d3022b5f1df60f26e1ffddd6c66e8aa15de382ae63b3a0c1bfc0e4d3e3f325cb"
+dependencies = [
+ "ppv-lite86",
+ "rand_core 0.9.3",
 ]
 
 [[package]]
@@ -710,7 +754,16 @@ version = "0.6.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c"
 dependencies = [
- "getrandom",
+ "getrandom 0.2.15",
+]
+
+[[package]]
+name = "rand_core"
+version = "0.9.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "99d9a13982dcf210057a8a78572b2217b667c3beacbf3a0d8b454f6f82837d38"
+dependencies = [
+ "getrandom 0.3.2",
 ]
 
 [[package]]
@@ -720,7 +773,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32cb0b9bc82b0a0876c2dd994a7e7a2683d3e7390ca40e6886785ef0c7e3ee31"
 dependencies = [
  "num-traits",
- "rand",
+ "rand 0.8.5",
+]
+
+[[package]]
+name = "rand_distr"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6a8615d50dcf34fa31f7ab52692afec947c4dd0ab803cc87cb3b0b4570ff7463"
+dependencies = [
+ "num-traits",
+ "rand 0.9.1",
 ]
 
 [[package]]
@@ -863,7 +926,7 @@ dependencies = [
  "approx",
  "nalgebra",
  "num-traits",
- "rand",
+ "rand 0.8.5",
 ]
 
 [[package]]
@@ -964,6 +1027,15 @@ name = "wasi"
 version = "0.11.0+wasi-snapshot-preview1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9c8d87e72b64a3b4db28d11ce29237c246188f4f51057d65a7eab63b7987e423"
+
+[[package]]
+name = "wasi"
+version = "0.14.2+wasi-0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9683f9a5a998d873c0d21fcbe3c083009670149a8fab228644b8bd36b2c48cb3"
+dependencies = [
+ "wit-bindgen-rt",
+]
 
 [[package]]
 name = "wasm-bindgen"
@@ -1069,6 +1141,15 @@ name = "winapi-x86_64-pc-windows-gnu"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
+
+[[package]]
+name = "wit-bindgen-rt"
+version = "0.39.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6f42320e61fe2cfd34354ecb597f86f413484a798ba44a8ca1165c58d42da6c1"
+dependencies = [
+ "bitflags",
+]
 
 [[package]]
 name = "wyz"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,9 +24,9 @@ num-integer = { version = "0.1.46", optional = true }
 num-iter = { version = "0.1.45", optional = true }
 num-rational = { version = "0.4.2", optional = true, features = ["serde"] }
 num-traits = "0.2.19"
-rand = "0.8"
-rand_core = "0.6.4"
-rand_distr = { version = "0.4.3", optional = true }
+rand = "0.9"
+rand_core = { version = "0.9", features = ["os_rng"] }
+rand_distr = { version = "0.5", optional = true }
 rayon = { version = "1.10.0", optional = true }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = { version = "1.0", optional = true }
@@ -46,6 +46,7 @@ modinverse = "0.1.0"
 num-bigint = "0.4.6"
 once_cell = "1.21.3"
 prio = { path = ".", features = ["crypto-dependencies", "test-util"] }
+rand = { version = "0.9", features = ["std_rng"] }
 statrs = "0.17.1"
 
 [features]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,7 +5,7 @@ authors = ["Josh Aas <jaas@kflag.net>", "Tim Geoghegan <timg@letsencrypt.org>", 
 edition = "2021"
 exclude = ["/supply-chain"]
 description = "Implementation of the Prio aggregation system core: https://crypto.stanford.edu/prio/"
-license = "MPL-2.0"
+license = "MPL-2.0 AND Apache-2.0"
 repository = "https://github.com/divviup/libprio-rs"
 rust-version = "1.80"
 resolver = "2"
@@ -19,7 +19,7 @@ fiat-crypto = { version = "0.2.9", optional = true }
 fixed = { version = "1.27", optional = true }
 hex = { version = "0.4.3", features = ["serde"], optional = true }
 hmac = { version = "0.12.1", optional = true }
-num-bigint = { version = "0.4.6", optional = true, features = ["rand", "serde"] }
+num-bigint = { version = "0.4.6", optional = true, features = ["serde"] }
 num-integer = { version = "0.1.46", optional = true }
 num-iter = { version = "0.1.45", optional = true }
 num-rational = { version = "0.4.2", optional = true, features = ["serde"] }

--- a/LICENSE-THIRD-PARTY
+++ b/LICENSE-THIRD-PARTY
@@ -1,0 +1,204 @@
+* src/dp/rand_bigint.rs
+  Copyright 2013-2014 The Rust Project Developers
+
+                              Apache License
+                        Version 2.0, January 2004
+                     http://www.apache.org/licenses/
+
+TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+1. Definitions.
+
+   "License" shall mean the terms and conditions for use, reproduction,
+   and distribution as defined by Sections 1 through 9 of this document.
+
+   "Licensor" shall mean the copyright owner or entity authorized by
+   the copyright owner that is granting the License.
+
+   "Legal Entity" shall mean the union of the acting entity and all
+   other entities that control, are controlled by, or are under common
+   control with that entity. For the purposes of this definition,
+   "control" means (i) the power, direct or indirect, to cause the
+   direction or management of such entity, whether by contract or
+   otherwise, or (ii) ownership of fifty percent (50%) or more of the
+   outstanding shares, or (iii) beneficial ownership of such entity.
+
+   "You" (or "Your") shall mean an individual or Legal Entity
+   exercising permissions granted by this License.
+
+   "Source" form shall mean the preferred form for making modifications,
+   including but not limited to software source code, documentation
+   source, and configuration files.
+
+   "Object" form shall mean any form resulting from mechanical
+   transformation or translation of a Source form, including but
+   not limited to compiled object code, generated documentation,
+   and conversions to other media types.
+
+   "Work" shall mean the work of authorship, whether in Source or
+   Object form, made available under the License, as indicated by a
+   copyright notice that is included in or attached to the work
+   (an example is provided in the Appendix below).
+
+   "Derivative Works" shall mean any work, whether in Source or Object
+   form, that is based on (or derived from) the Work and for which the
+   editorial revisions, annotations, elaborations, or other modifications
+   represent, as a whole, an original work of authorship. For the purposes
+   of this License, Derivative Works shall not include works that remain
+   separable from, or merely link (or bind by name) to the interfaces of,
+   the Work and Derivative Works thereof.
+
+   "Contribution" shall mean any work of authorship, including
+   the original version of the Work and any modifications or additions
+   to that Work or Derivative Works thereof, that is intentionally
+   submitted to Licensor for inclusion in the Work by the copyright owner
+   or by an individual or Legal Entity authorized to submit on behalf of
+   the copyright owner. For the purposes of this definition, "submitted"
+   means any form of electronic, verbal, or written communication sent
+   to the Licensor or its representatives, including but not limited to
+   communication on electronic mailing lists, source code control systems,
+   and issue tracking systems that are managed by, or on behalf of, the
+   Licensor for the purpose of discussing and improving the Work, but
+   excluding communication that is conspicuously marked or otherwise
+   designated in writing by the copyright owner as "Not a Contribution."
+
+   "Contributor" shall mean Licensor and any individual or Legal Entity
+   on behalf of whom a Contribution has been received by Licensor and
+   subsequently incorporated within the Work.
+
+2. Grant of Copyright License. Subject to the terms and conditions of
+   this License, each Contributor hereby grants to You a perpetual,
+   worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+   copyright license to reproduce, prepare Derivative Works of,
+   publicly display, publicly perform, sublicense, and distribute the
+   Work and such Derivative Works in Source or Object form.
+
+3. Grant of Patent License. Subject to the terms and conditions of
+   this License, each Contributor hereby grants to You a perpetual,
+   worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+   (except as stated in this section) patent license to make, have made,
+   use, offer to sell, sell, import, and otherwise transfer the Work,
+   where such license applies only to those patent claims licensable
+   by such Contributor that are necessarily infringed by their
+   Contribution(s) alone or by combination of their Contribution(s)
+   with the Work to which such Contribution(s) was submitted. If You
+   institute patent litigation against any entity (including a
+   cross-claim or counterclaim in a lawsuit) alleging that the Work
+   or a Contribution incorporated within the Work constitutes direct
+   or contributory patent infringement, then any patent licenses
+   granted to You under this License for that Work shall terminate
+   as of the date such litigation is filed.
+
+4. Redistribution. You may reproduce and distribute copies of the
+   Work or Derivative Works thereof in any medium, with or without
+   modifications, and in Source or Object form, provided that You
+   meet the following conditions:
+
+   (a) You must give any other recipients of the Work or
+       Derivative Works a copy of this License; and
+
+   (b) You must cause any modified files to carry prominent notices
+       stating that You changed the files; and
+
+   (c) You must retain, in the Source form of any Derivative Works
+       that You distribute, all copyright, patent, trademark, and
+       attribution notices from the Source form of the Work,
+       excluding those notices that do not pertain to any part of
+       the Derivative Works; and
+
+   (d) If the Work includes a "NOTICE" text file as part of its
+       distribution, then any Derivative Works that You distribute must
+       include a readable copy of the attribution notices contained
+       within such NOTICE file, excluding those notices that do not
+       pertain to any part of the Derivative Works, in at least one
+       of the following places: within a NOTICE text file distributed
+       as part of the Derivative Works; within the Source form or
+       documentation, if provided along with the Derivative Works; or,
+       within a display generated by the Derivative Works, if and
+       wherever such third-party notices normally appear. The contents
+       of the NOTICE file are for informational purposes only and
+       do not modify the License. You may add Your own attribution
+       notices within Derivative Works that You distribute, alongside
+       or as an addendum to the NOTICE text from the Work, provided
+       that such additional attribution notices cannot be construed
+       as modifying the License.
+
+   You may add Your own copyright statement to Your modifications and
+   may provide additional or different license terms and conditions
+   for use, reproduction, or distribution of Your modifications, or
+   for any such Derivative Works as a whole, provided Your use,
+   reproduction, and distribution of the Work otherwise complies with
+   the conditions stated in this License.
+
+5. Submission of Contributions. Unless You explicitly state otherwise,
+   any Contribution intentionally submitted for inclusion in the Work
+   by You to the Licensor shall be under the terms and conditions of
+   this License, without any additional terms or conditions.
+   Notwithstanding the above, nothing herein shall supersede or modify
+   the terms of any separate license agreement you may have executed
+   with Licensor regarding such Contributions.
+
+6. Trademarks. This License does not grant permission to use the trade
+   names, trademarks, service marks, or product names of the Licensor,
+   except as required for reasonable and customary use in describing the
+   origin of the Work and reproducing the content of the NOTICE file.
+
+7. Disclaimer of Warranty. Unless required by applicable law or
+   agreed to in writing, Licensor provides the Work (and each
+   Contributor provides its Contributions) on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+   implied, including, without limitation, any warranties or conditions
+   of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+   PARTICULAR PURPOSE. You are solely responsible for determining the
+   appropriateness of using or redistributing the Work and assume any
+   risks associated with Your exercise of permissions under this License.
+
+8. Limitation of Liability. In no event and under no legal theory,
+   whether in tort (including negligence), contract, or otherwise,
+   unless required by applicable law (such as deliberate and grossly
+   negligent acts) or agreed to in writing, shall any Contributor be
+   liable to You for damages, including any direct, indirect, special,
+   incidental, or consequential damages of any character arising as a
+   result of this License or out of the use or inability to use the
+   Work (including but not limited to damages for loss of goodwill,
+   work stoppage, computer failure or malfunction, or any and all
+   other commercial damages or losses), even if such Contributor
+   has been advised of the possibility of such damages.
+
+9. Accepting Warranty or Additional Liability. While redistributing
+   the Work or Derivative Works thereof, You may choose to offer,
+   and charge a fee for, acceptance of support, warranty, indemnity,
+   or other liability obligations and/or rights consistent with this
+   License. However, in accepting such obligations, You may act only
+   on Your own behalf and on Your sole responsibility, not on behalf
+   of any other Contributor, and only if You agree to indemnify,
+   defend, and hold each Contributor harmless for any liability
+   incurred by, or claims asserted against, such Contributor by reason
+   of your accepting any such warranty or additional liability.
+
+END OF TERMS AND CONDITIONS
+
+APPENDIX: How to apply the Apache License to your work.
+
+   To apply the Apache License to your work, attach the following
+   boilerplate notice, with the fields enclosed by brackets "[]"
+   replaced with your own identifying information. (Don't include
+   the brackets!)  The text should be enclosed in the appropriate
+   comment syntax for the file format. We also recommend that a
+   file or class name and description of purpose be included on the
+   same "printed page" as the copyright notice for easier
+   identification within third-party archives.
+
+Copyright [yyyy] [name of copyright owner]
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+	http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.

--- a/NOTICE
+++ b/NOTICE
@@ -1,0 +1,7 @@
+libprio-rs
+Copyright (c) 2025 ISRG
+
+The file src/dp/rand_bigint.rs includes third-party code from the num-bigint
+crate, version 0.6.4, used under the terms of the Apache 2.0 license.
+(https://github.com/rust-num/num-bigint)
+Copyright 2013-2014 The Rust Project Developers.

--- a/benches/speed_tests.rs
+++ b/benches/speed_tests.rs
@@ -33,7 +33,7 @@ use prio::{
     vdaf::poplar1::{Poplar1, Poplar1AggregationParam, Poplar1IdpfValue},
 };
 #[cfg(feature = "experimental")]
-use rand::prelude::*;
+use rand::{distr::Distribution, random, rngs::StdRng, Rng, SeedableRng};
 #[cfg(feature = "experimental")]
 use std::iter;
 use std::{hint::black_box, time::Duration};
@@ -784,8 +784,8 @@ fn poplar1(c: &mut Criterion) {
         group.bench_with_input(BenchmarkId::from_parameter(size), size, |b, &size| {
             let vdaf = Poplar1::new_turboshake128(size);
             let mut rng = StdRng::seed_from_u64(RNG_SEED);
-            let nonce = rng.gen::<[u8; 16]>();
-            let bits = iter::repeat_with(|| rng.gen())
+            let nonce = rng.random::<[u8; 16]>();
+            let bits = iter::repeat_with(|| rng.random())
                 .take(size)
                 .collect::<Vec<bool>>();
             let measurement = IdpfInput::from_bools(&bits);
@@ -803,8 +803,8 @@ fn poplar1(c: &mut Criterion) {
         group.bench_with_input(BenchmarkId::from_parameter(size), size, |b, &size| {
             let vdaf = Poplar1::new_turboshake128(size);
             let mut rng = StdRng::seed_from_u64(RNG_SEED);
-            let verify_key: [u8; 32] = rng.gen();
-            let nonce: [u8; 16] = rng.gen();
+            let verify_key: [u8; 32] = rng.random();
+            let nonce: [u8; 16] = rng.random();
 
             // Parameters are chosen to match Chris Wood's experimental setup:
             // https://github.com/chris-wood/heavy-hitter-comparison

--- a/binaries/Cargo.toml
+++ b/binaries/Cargo.toml
@@ -9,5 +9,5 @@ repository = "https://github.com/divviup/libprio-rs"
 [dependencies]
 base64 = "0.22.1"
 fixed = "1.27"
-rand = "0.8"
+rand = "0.9"
 prio = { path = "..", features = ["experimental", "test-util"] }

--- a/binaries/src/bin/idpf_agg_param_size.rs
+++ b/binaries/src/bin/idpf_agg_param_size.rs
@@ -4,7 +4,7 @@ use prio::{
     codec::Encode, idpf::test_utils::generate_zipf_distributed_batch,
     vdaf::poplar1::Poplar1AggregationParam,
 };
-use rand::prelude::*;
+use rand::rng;
 
 fn main() {
     let bits = 256;
@@ -16,7 +16,7 @@ fn main() {
     println!("Generating inputs and computing the prefix tree. This may take some time...");
     let start = Instant::now();
     let (_measurements, prefix_tree) = generate_zipf_distributed_batch(
-        &mut thread_rng(),
+        &mut rng(),
         bits,
         threshold,
         measurement_count,

--- a/src/dp.rs
+++ b/src/dp.rs
@@ -174,6 +174,7 @@ pub trait DifferentialPrivacyStrategy {
 }
 
 pub mod distributions;
+mod rand_bigint;
 
 #[cfg(test)]
 mod tests {

--- a/src/dp/distributions.rs
+++ b/src/dp/distributions.rs
@@ -55,7 +55,7 @@ use num_integer::Integer;
 use num_iter::range_inclusive;
 use num_rational::Ratio;
 use num_traits::{One, Zero};
-use rand::{distributions::Distribution, Rng};
+use rand::{distr::Distribution, Rng};
 use serde::{Deserialize, Serialize};
 
 use super::{
@@ -76,9 +76,12 @@ fn sample_bernoulli<R: Rng + ?Sized>(gamma: &Ratio<BigUint>, rng: &mut R) -> boo
     assert!(!d.is_zero());
     assert!(gamma <= &Ratio::<BigUint>::one());
 
-    // sample uniform biguint in {1,...,d}
-    // uses the implementation of rand::Uniform for num_bigint::BigUint
-    let s = UniformBigUint::new_inclusive(&BigUint::one(), d).sample(rng);
+    // Sample uniform biguint in {1,...,d}.
+    // Unwrap safety: this cannot fail because the denominator cannot be zero, and therefore the
+    // range [1, d] is well-formed.
+    let s = UniformBigUint::new_inclusive(&BigUint::one(), d)
+        .unwrap()
+        .sample(rng);
 
     s <= *gamma.numer()
 }
@@ -135,9 +138,9 @@ fn sample_geometric_exp<R: Rng + ?Sized>(gamma: &Ratio<BigUint>, rng: &mut R) ->
         return BigUint::zero();
     }
 
-    // sampler for uniform biguint in {0...t-1}
-    // uses the implementation of rand::Uniform for num_bigint::BigUint
-    let usampler = UniformBigUint::new(&BigUint::zero(), t);
+    // Sampler for uniform biguint in {0...t-1}.
+    // Unwrap safety: this range is always valid because the denominator of `gamma` must be nonzero.
+    let usampler = UniformBigUint::new(&BigUint::zero(), t).unwrap();
     let mut u = usampler.sample(rng);
 
     while !sample_bernoulli_exp1(&Ratio::<BigUint>::new(u.clone(), t.clone()), rng) {
@@ -382,7 +385,7 @@ mod tests {
 
     use num_bigint::{BigUint, Sign, ToBigInt, ToBigUint};
     use num_traits::{One, Signed, ToPrimitive};
-    use rand::{distributions::Distribution, SeedableRng};
+    use rand::{distr::Distribution, SeedableRng};
     use statrs::distribution::{ChiSquared, ContinuousCDF, Normal};
     use std::collections::HashMap;
 

--- a/src/dp/distributions.rs
+++ b/src/dp/distributions.rs
@@ -50,18 +50,19 @@
 //!     Clément Canonne, Gautam Kamath, Thomas Steinke. The Discrete Gaussian for Differential Privacy. 2020.
 //!     <https://arxiv.org/pdf/2004.00010.pdf>
 
-use num_bigint::{BigInt, BigUint, UniformBigUint};
+use num_bigint::{BigInt, BigUint};
 use num_integer::Integer;
 use num_iter::range_inclusive;
 use num_rational::Ratio;
 use num_traits::{One, Zero};
-use rand::{distributions::uniform::UniformSampler, distributions::Distribution, Rng};
+use rand::{distributions::Distribution, Rng};
 use serde::{Deserialize, Serialize};
 
 use super::{
     DifferentialPrivacyBudget, DifferentialPrivacyDistribution, DifferentialPrivacyStrategy,
     DpError, PureDpBudget, ZCdpBudget,
 };
+use crate::dp::rand_bigint::UniformBigUint;
 
 /// Sample from the Bernoulli(gamma) distribution, where $gamma /leq 1$.
 ///
@@ -77,7 +78,7 @@ fn sample_bernoulli<R: Rng + ?Sized>(gamma: &Ratio<BigUint>, rng: &mut R) -> boo
 
     // sample uniform biguint in {1,...,d}
     // uses the implementation of rand::Uniform for num_bigint::BigUint
-    let s = UniformBigUint::sample_single_inclusive(BigUint::one(), d, rng);
+    let s = UniformBigUint::new_inclusive(&BigUint::one(), d).sample(rng);
 
     s <= *gamma.numer()
 }
@@ -136,7 +137,7 @@ fn sample_geometric_exp<R: Rng + ?Sized>(gamma: &Ratio<BigUint>, rng: &mut R) ->
 
     // sampler for uniform biguint in {0...t-1}
     // uses the implementation of rand::Uniform for num_bigint::BigUint
-    let usampler = UniformBigUint::new(BigUint::zero(), t);
+    let usampler = UniformBigUint::new(&BigUint::zero(), t);
     let mut u = usampler.sample(rng);
 
     while !sample_bernoulli_exp1(&Ratio::<BigUint>::new(u.clone(), t.clone()), rng) {

--- a/src/dp/rand_bigint.rs
+++ b/src/dp/rand_bigint.rs
@@ -1,0 +1,105 @@
+// Copyright (c) 2025 ISRG
+// SPDX-License-Identifier: MPL-2.0 AND Apache-2.0
+//
+// Portions of this file are derived from the num-bigint crate
+// (https://docs.rs/num-bigint/0.4.6/)
+// Copyright 2013-2014 The Rust Project Developers
+// Licensed under the Apache 2.0 license
+//
+// This file contains code covered by the following copyright and permission notice
+// and has been modified by ISRG and collaborators.
+//
+// Copyright 2013-2014 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+//! Helper functions to randomly generate big integers, sampled from uniform distributions.
+//!
+//! These were vendored from num-bigint. Unused functionality has been deleted, trait
+//! implementations have been transformed into free functions, use of the private
+//! `biguint_from_vec()` function has been replaced, use of the `SampleBorrow`
+//! trait has been removed, and documentation has been updated.
+
+use num_bigint::BigUint;
+use num_integer::Integer;
+use num_traits::{ToPrimitive, Zero};
+use rand::Rng;
+
+/// Use [`Rng::fill`] to generate random bits.
+///
+/// If `rem` is greater than zero, than only the lowest `rem` bits of the last u32 are filled with
+/// random data.
+fn gen_bits<R>(rng: &mut R, data: &mut [u32], rem: u64)
+where
+    R: Rng + ?Sized,
+{
+    // `fill` is faster than many `gen::<u32>` calls
+    rng.fill(data);
+    if rem > 0 {
+        let last = data.len() - 1;
+        data[last] >>= 32 - rem;
+    }
+}
+
+/// Uniformly generate a random [`BigUint`] in the range \[0, 2^`bits`).
+fn gen_biguint<R>(rng: &mut R, bit_size: u64) -> BigUint
+where
+    R: Rng + ?Sized,
+{
+    let (digits, rem) = bit_size.div_rem(&32);
+    let len = (digits + (rem > 0) as u64)
+        .to_usize()
+        .expect("capacity overflow");
+    let mut data = vec![0u32; len];
+    gen_bits(rng, &mut data, rem);
+    BigUint::new(data)
+}
+
+/// Uniformly generate a random [`BigUint`] in the range \[0, `bound`).
+fn gen_biguint_below<R>(rng: &mut R, bound: &BigUint) -> BigUint
+where
+    R: Rng + ?Sized,
+{
+    assert!(!bound.is_zero());
+    let bits = bound.bits();
+    loop {
+        let n = gen_biguint(rng, bits);
+        if n < *bound {
+            return n;
+        }
+    }
+}
+
+/// Uniform distribution producing [`BigUint`].
+pub(super) struct UniformBigUint {
+    base: BigUint,
+    len: BigUint,
+}
+
+impl UniformBigUint {
+    pub(super) fn new(low: &BigUint, high: &BigUint) -> Self {
+        assert!(low < high);
+        UniformBigUint {
+            len: high - low,
+            base: low.clone(),
+        }
+    }
+
+    pub(super) fn new_inclusive(low: &BigUint, high: &BigUint) -> Self {
+        assert!(low <= high);
+        Self::new(low, &(high + 1u32))
+    }
+
+    pub(super) fn sample<R>(&self, rng: &mut R) -> BigUint
+    where
+        R: Rng + ?Sized,
+    {
+        &self.base + gen_biguint_below(rng, &self.len)
+    }
+}

--- a/src/dp/rand_bigint.rs
+++ b/src/dp/rand_bigint.rs
@@ -37,6 +37,10 @@ use rand::Rng;
 ///
 /// If `rem` is greater than zero, than only the lowest `rem` bits of the last u32 are filled with
 /// random data.
+///
+/// # Panics
+///
+/// Panics if `rem` is greater than 32.
 fn random_bits<R>(rng: &mut R, data: &mut [u32], rem: u64)
 where
     R: Rng + ?Sized,

--- a/src/field.rs
+++ b/src/field.rs
@@ -13,7 +13,7 @@ use crate::{
     prng::Prng,
 };
 use rand::{
-    distributions::{Distribution, Standard},
+    distr::{Distribution, StandardUniform},
     Rng,
 };
 use rand_core::RngCore;
@@ -774,7 +774,7 @@ macro_rules! make_field {
             }
         }
 
-        impl Distribution<$elem> for Standard {
+        impl Distribution<$elem> for StandardUniform {
             fn sample<R: Rng + ?Sized>(&self, rng: &mut R) -> $elem {
                 $elem::generate_random(rng)
             }

--- a/src/flp/types/dp.rs
+++ b/src/flp/types/dp.rs
@@ -9,7 +9,7 @@ use crate::flp::{FlpError, TypeWithNoise};
 use crate::vdaf::xof::SeedStreamTurboShake128;
 use num_bigint::{BigInt, BigUint, TryFromBigIntError};
 use num_integer::Integer;
-use rand::{distributions::Distribution, Rng, SeedableRng};
+use rand::{distr::Distribution, Rng, SeedableRng};
 
 // TODO(#1071): This is implemented for the concrete fields `Field64` and `Field128` in order to
 // avoid imposing the `BigInt: From<F::Integer>` bound on all callers. In the future, we may want to
@@ -28,7 +28,7 @@ where
         self.add_noise(
             dp_strategy,
             agg_result,
-            &mut SeedStreamTurboShake128::from_entropy(),
+            &mut SeedStreamTurboShake128::from_os_rng(),
         )
     }
 }
@@ -46,7 +46,7 @@ where
         self.add_noise(
             dp_strategy,
             agg_result,
-            &mut SeedStreamTurboShake128::from_entropy(),
+            &mut SeedStreamTurboShake128::from_os_rng(),
         )
     }
 }
@@ -102,7 +102,7 @@ where
         self.add_noise(
             dp_strategy,
             agg_result,
-            &mut SeedStreamTurboShake128::from_entropy(),
+            &mut SeedStreamTurboShake128::from_os_rng(),
         )
     }
 }
@@ -120,7 +120,7 @@ where
         self.add_noise(
             dp_strategy,
             agg_result,
-            &mut SeedStreamTurboShake128::from_entropy(),
+            &mut SeedStreamTurboShake128::from_os_rng(),
         )
     }
 }

--- a/src/flp/types/fixedpoint_l2.rs
+++ b/src/flp/types/fixedpoint_l2.rs
@@ -635,7 +635,7 @@ where
         self.add_noise(
             dp_strategy,
             agg_result,
-            &mut SeedStreamTurboShake128::from_entropy(),
+            &mut SeedStreamTurboShake128::from_os_rng(),
         )
     }
 }

--- a/src/fp.rs
+++ b/src/fp.rs
@@ -132,7 +132,7 @@ pub(crate) mod tests {
     use modinverse::modinverse;
     use num_bigint::{BigInt, ToBigInt};
     use num_traits::AsPrimitive;
-    use rand::{distributions::Distribution, thread_rng, Rng};
+    use rand::{distr::Distribution, rng, Rng};
 
     use super::ops::Word;
     use crate::fp::{log2, FieldOps, FP128, FP32, FP64, MAX_ROOTS};
@@ -241,8 +241,8 @@ pub(crate) mod tests {
             let u128_p = T::PRIME.as_();
             let big_p = &u128_p.to_bigint().unwrap();
             let big_zero = &BigInt::from(0);
-            let uniform = rand::distributions::Uniform::from(0..u128_p);
-            let mut rng = thread_rng();
+            let uniform = rand::distr::Uniform::try_from(0..u128_p).unwrap();
+            let mut rng = rng();
 
             let mut weird_ints = Vec::from([
                 0,
@@ -263,8 +263,8 @@ pub(crate) mod tests {
 
             let mut generate_random = || -> (W, BigInt) {
                 // Add bias to random element generation, to explore "interesting" inputs.
-                let intu128 = if rng.gen_ratio(1, 4) {
-                    weird_ints[rng.gen_range(0..weird_ints.len())]
+                let intu128 = if rng.random_ratio(1, 4) {
+                    weird_ints[rng.random_range(0..weird_ints.len())]
                 } else {
                     uniform.sample(&mut rng)
                 };

--- a/src/idpf.rs
+++ b/src/idpf.rs
@@ -19,7 +19,7 @@ use bitvec::{
     vec::BitVec,
     view::BitView,
 };
-use rand::prelude::*;
+use rand::{rng, Rng, RngCore};
 use std::{
     collections::{HashMap, VecDeque},
     fmt::Debug,
@@ -493,7 +493,7 @@ where
     where
         M: IntoIterator<Item = VI>,
     {
-        let mut rng = thread_rng();
+        let mut rng = rng();
         if input.is_empty() {
             return Err(
                 IdpfError::InvalidParameter("invalid number of bits: 0".to_string()).into(),
@@ -1036,6 +1036,7 @@ enum XofMode<'a> {
 pub mod test_utils {
     use super::*;
 
+    use rand::distr::Distribution;
     use rand_distr::Zipf;
 
     /// Generate a set of IDPF inputs with the given bit length `bits`. They are sampled according
@@ -1058,13 +1059,13 @@ pub mod test_utils {
         // Generate random inputs.
         let mut inputs = Vec::with_capacity(zipf_support);
         for _ in 0..zipf_support {
-            let bools: Vec<bool> = (0..bits).map(|_| rng.gen()).collect();
+            let bools: Vec<bool> = (0..bits).map(|_| rng.random()).collect();
             inputs.push(IdpfInput::from_bools(&bools));
         }
 
         // Sample a number of inputs according to the Zipf distribution.
         let mut samples = Vec::with_capacity(measurement_count);
-        let zipf = Zipf::new(zipf_support as u64, zipf_exponent).unwrap();
+        let zipf = Zipf::new(zipf_support as f64, zipf_exponent).unwrap();
         for _ in 0..measurement_count {
             samples.push(inputs[zipf.sample(rng).round() as usize - 1].clone());
         }

--- a/src/polynomial.rs
+++ b/src/polynomial.rs
@@ -235,7 +235,7 @@ mod tests {
             TestPolyAuxMemory,
         },
     };
-    use rand::prelude::*;
+    use rand::random;
     use std::convert::TryFrom;
 
     #[test]

--- a/src/prng.rs
+++ b/src/prng.rs
@@ -9,7 +9,7 @@ use crate::field::{FieldElement, FieldElementExt};
 #[cfg(all(feature = "crypto-dependencies", feature = "experimental"))]
 use crate::vdaf::xof::SeedStreamAes128;
 use crate::vdaf::xof::{Seed, SeedStreamTurboShake128, Xof, XofTurboShake128};
-use rand::prelude::*;
+use rand::{rng, Rng, RngCore};
 
 use std::marker::PhantomData;
 use std::ops::ControlFlow;
@@ -40,7 +40,7 @@ impl<F: FieldElement> Prng<F, SeedStreamAes128> {
 impl<F: FieldElement> Prng<F, SeedStreamTurboShake128> {
     /// Create a [`Prng`] from a randomly generated seed.
     pub(crate) fn new() -> Self {
-        let seed = thread_rng().gen::<Seed<32>>();
+        let seed = rng().random::<Seed<32>>();
         Prng::from_seed_stream(XofTurboShake128::seed_stream(seed.as_ref(), &[], &[]))
     }
 }
@@ -241,7 +241,7 @@ mod tests {
     // once it reaches the end.
     #[test]
     fn left_over_buffer_back_fill() {
-        let seed = thread_rng().gen::<Seed<32>>();
+        let seed = rng().random::<Seed<32>>();
 
         let mut prng: Prng<Field64, SeedStreamTurboShake128> =
             Prng::from_seed_stream(XofTurboShake128::seed_stream(seed.as_ref(), &[], &[]));
@@ -263,7 +263,7 @@ mod tests {
     #[cfg(feature = "experimental")]
     #[test]
     fn into_different_field() {
-        let seed = thread_rng().gen::<Seed<32>>();
+        let seed = rng().random::<Seed<32>>();
         let want: Prng<Field64, SeedStreamTurboShake128> =
             Prng::from_seed_stream(XofTurboShake128::seed_stream(seed.as_ref(), &[], &[]));
         let want_buffer = want.buffer.clone();

--- a/src/vdaf.rs
+++ b/src/vdaf.rs
@@ -479,7 +479,7 @@ impl<F: FieldElement> Encode for AggregateShare<F> {
 pub mod test_utils {
     use super::{Aggregatable, Aggregator, Client, Collector, PrepareTransition, VdafError};
     use crate::codec::{Encode, ParameterizedDecode};
-    use rand::prelude::*;
+    use rand::{random, rng, Rng};
 
     /// Execute the VDAF end-to-end and return the aggregate result.
     pub fn run_vdaf<V, M, const SEED_SIZE: usize>(
@@ -515,7 +515,7 @@ pub mod test_utils {
         M: IntoIterator<Item = (V::PublicShare, [u8; 16], I)>,
         I: IntoIterator<Item = V::InputShare>,
     {
-        let mut rng = thread_rng();
+        let mut rng = rng();
         let mut verify_key = [0; SEED_SIZE];
         rng.fill(&mut verify_key[..]);
 

--- a/src/vdaf/dummy.rs
+++ b/src/vdaf/dummy.rs
@@ -346,17 +346,17 @@ where
 mod tests {
     use super::*;
     use crate::vdaf::{test_utils::run_vdaf_sharded, Client};
-    use rand::prelude::*;
+    use rand::{rng, Rng};
 
     fn run_test(rounds: u32, aggregation_parameter: u8) {
         let vdaf = Vdaf::new(rounds);
         let mut verify_key = [0; 0];
-        thread_rng().fill(&mut verify_key[..]);
+        rng().fill(&mut verify_key[..]);
         let measurements = [10, 20, 30, 40, 50, 60, 70, 80, 90, 100];
 
         let mut sharded_measurements = Vec::new();
         for measurement in measurements {
-            let nonce = thread_rng().gen();
+            let nonce = rng().random();
             let (public_share, input_shares) =
                 vdaf.shard(b"dummy ctx", &measurement, &nonce).unwrap();
 

--- a/src/vdaf/mastic.rs
+++ b/src/vdaf/mastic.rs
@@ -23,7 +23,7 @@ use crate::{
 
 use szk::{Szk, SzkJointShare, SzkProofShare, SzkQueryShare, SzkQueryState};
 
-use rand::prelude::*;
+use rand::{rng, Rng};
 use std::io::{Cursor, Read};
 use std::ops::BitAnd;
 use std::slice::from_ref;
@@ -345,14 +345,14 @@ impl<T: Type> Client<16> for Mastic<T> {
         measurement: &(VidpfInput, T::Measurement),
         nonce: &[u8; 16],
     ) -> Result<(Self::PublicShare, Vec<Self::InputShare>), VdafError> {
-        let mut rng = thread_rng();
-        let vidpf_keys = rng.gen();
+        let mut rng = rng();
+        let vidpf_keys = rng.random();
         let joint_random_opt = if self.szk.requires_joint_rand() {
-            Some(rng.gen())
+            Some(rng.random())
         } else {
             None
         };
-        let szk_random = rng.gen();
+        let szk_random = rng.random();
 
         self.shard_with_random(
             ctx,
@@ -797,7 +797,7 @@ mod tests {
     use crate::flp::gadgets::{Mul, ParallelSum};
     use crate::flp::types::{Count, Histogram, Sum, SumVec};
     use crate::vdaf::test_utils::run_vdaf;
-    use rand::{thread_rng, Rng};
+    use rand::{rng, Rng};
 
     const CTX_STR: &[u8] = b"mastic ctx";
 
@@ -809,7 +809,7 @@ mod tests {
         let mastic = Mastic::new(algorithm_id, sum_typ, 32).unwrap();
 
         let mut nonce = [0u8; 16];
-        thread_rng().fill(&mut nonce[..]);
+        rng().fill(&mut nonce[..]);
 
         let inputs = [
             VidpfInput::from_bytes(&[240u8, 0u8, 1u8, 4u8][..]),
@@ -888,7 +888,7 @@ mod tests {
         let mastic = Mastic::new(algorithm_id, sum_typ, 32).unwrap();
 
         let mut nonce = [0u8; 16];
-        thread_rng().fill(&mut nonce[..]);
+        rng().fill(&mut nonce[..]);
 
         let first_input = VidpfInput::from_bytes(&[15u8, 0u8, 1u8, 4u8][..]);
 
@@ -939,7 +939,7 @@ mod tests {
         let mastic = Mastic::new(algorithm_id, sum_typ, 32).unwrap();
 
         let mut nonce = [0u8; 16];
-        thread_rng().fill(&mut nonce[..]);
+        rng().fill(&mut nonce[..]);
 
         let first_input = VidpfInput::from_bytes(&[15u8, 0u8, 1u8, 4u8][..]);
 
@@ -960,7 +960,7 @@ mod tests {
         let mastic = Mastic::new(algorithm_id, count, 32).unwrap();
 
         let mut nonce = [0u8; 16];
-        thread_rng().fill(&mut nonce[..]);
+        rng().fill(&mut nonce[..]);
 
         let inputs = [
             VidpfInput::from_bytes(&[240u8, 0u8, 1u8, 4u8][..]),
@@ -1037,7 +1037,7 @@ mod tests {
         let mastic = Mastic::new(algorithm_id, count, 32).unwrap();
 
         let mut nonce = [0u8; 16];
-        thread_rng().fill(&mut nonce[..]);
+        rng().fill(&mut nonce[..]);
         let first_input = VidpfInput::from_bytes(&[15u8, 0u8, 1u8, 4u8][..]);
 
         let (public, _) = mastic.shard(CTX_STR, &(first_input, true), &nonce).unwrap();
@@ -1055,7 +1055,7 @@ mod tests {
         let mastic = Mastic::new(algorithm_id, count, 32).unwrap();
 
         let mut nonce = [0u8; 16];
-        thread_rng().fill(&mut nonce[..]);
+        rng().fill(&mut nonce[..]);
 
         let first_input = VidpfInput::from_bytes(&[15u8, 0u8, 1u8, 4u8][..]);
 
@@ -1075,7 +1075,7 @@ mod tests {
         let mastic = Mastic::new(algorithm_id, sumvec, 32).unwrap();
 
         let mut nonce = [0u8; 16];
-        thread_rng().fill(&mut nonce[..]);
+        rng().fill(&mut nonce[..]);
 
         let inputs = [
             VidpfInput::from_bytes(&[240u8, 0u8, 1u8, 4u8][..]),
@@ -1163,7 +1163,7 @@ mod tests {
         let mastic = Mastic::new(algorithm_id, sumvec, 32).unwrap();
 
         let mut nonce = [0u8; 16];
-        thread_rng().fill(&mut nonce[..]);
+        rng().fill(&mut nonce[..]);
 
         let first_input = VidpfInput::from_bytes(&[15u8, 0u8, 1u8, 4u8][..]);
 
@@ -1192,7 +1192,7 @@ mod tests {
         let mastic = Mastic::new(algorithm_id, sumvec, 32).unwrap();
 
         let mut nonce = [0u8; 16];
-        thread_rng().fill(&mut nonce[..]);
+        rng().fill(&mut nonce[..]);
 
         let first_input = VidpfInput::from_bytes(&[15u8, 0u8, 1u8, 4u8][..]);
 
@@ -1223,7 +1223,7 @@ mod tests {
         let mastic = Mastic::new(algorithm_id, sumvec, 32).unwrap();
 
         let mut nonce = [0u8; 16];
-        thread_rng().fill(&mut nonce[..]);
+        rng().fill(&mut nonce[..]);
 
         let first_input = VidpfInput::from_bytes(&[15u8, 0u8, 1u8, 4u8][..]);
 
@@ -1246,7 +1246,7 @@ mod tests {
         let mastic = Mastic::new(algorithm_id, sumvec, 32).unwrap();
 
         let mut nonce = [0u8; 16];
-        thread_rng().fill(&mut nonce[..]);
+        rng().fill(&mut nonce[..]);
 
         let first_input = VidpfInput::from_bytes(&[15u8, 0u8, 1u8, 4u8][..]);
 

--- a/src/vdaf/mastic/szk.rs
+++ b/src/vdaf/mastic/szk.rs
@@ -664,19 +664,19 @@ mod tests {
             Flp, Type,
         },
     };
-    use rand::{thread_rng, Rng};
+    use rand::{rng, Rng};
 
     fn generic_szk_test<T: Type>(typ: T, encoded_measurement: &[T::Field], valid: bool) {
-        let mut rng = thread_rng();
+        let mut rng = rng();
         let ctx = b"some application context";
         let mut nonce = [0u8; 16];
         let mut verify_key = [0u8; 32];
         let szk_typ = Szk::new(typ.clone(), 0);
-        thread_rng().fill(&mut verify_key[..]);
-        thread_rng().fill(&mut nonce[..]);
-        let prove_rand_seed = rng.gen();
-        let helper_seed = rng.gen();
-        let leader_seed_opt = szk_typ.requires_joint_rand().then(|| rng.gen());
+        rng.fill(&mut verify_key[..]);
+        rng.fill(&mut nonce[..]);
+        let prove_rand_seed = rng.random();
+        let helper_seed = rng.random();
+        let leader_seed_opt = szk_typ.requires_joint_rand().then(|| rng.random());
         let helper_input_share = T::Field::random_vector(szk_typ.typ.input_len());
         let mut leader_input_share = encoded_measurement.to_owned();
         sub_assign_vector(&mut leader_input_share, helper_input_share.iter().copied());
@@ -741,7 +741,7 @@ mod tests {
 
         //test mutated jr seed
         if szk_typ.requires_joint_rand() {
-            let joint_rand_seed_opt = Some(rng.gen());
+            let joint_rand_seed_opt = Some(rng.random());
             if let Ok(()) = szk_typ.decide(joint_rand_seed_opt.clone(), joint_share) {
                 panic!("Leader accepted wrong jr seed");
             };
@@ -831,16 +831,16 @@ mod tests {
 
     #[test]
     fn test_sum_proof_share_encode() {
-        let mut rng = thread_rng();
+        let mut rng = rng();
         let mut nonce = [0u8; 16];
         let max_measurement = 13;
-        thread_rng().fill(&mut nonce[..]);
+        rng.fill(&mut nonce[..]);
         let sum = Sum::<Field128>::new(max_measurement).unwrap();
         let encoded_measurement = sum.encode_measurement(&9).unwrap();
         let szk_typ = Szk::new(sum, 0);
-        let prove_rand_seed = rng.gen();
-        let helper_seed = rng.gen();
-        let leader_seed_opt = Some(rng.gen());
+        let prove_rand_seed = rng.random();
+        let helper_seed = rng.random();
+        let leader_seed_opt = Some(rng.random());
         let helper_input_share = Field128::random_vector(szk_typ.typ.input_len());
         let mut leader_input_share = encoded_measurement.clone().to_owned();
         sub_assign_vector(&mut leader_input_share, helper_input_share.iter().copied());
@@ -865,16 +865,16 @@ mod tests {
 
     #[test]
     fn test_sumvec_proof_share_encode() {
-        let mut rng = thread_rng();
+        let mut rng = rng();
         let mut nonce = [0u8; 16];
-        thread_rng().fill(&mut nonce[..]);
+        rng.fill(&mut nonce[..]);
         let sumvec =
             SumVec::<Field128, ParallelSum<Field128, Mul<Field128>>>::new(5, 3, 3).unwrap();
         let encoded_measurement = sumvec.encode_measurement(&vec![1, 16, 0]).unwrap();
         let szk_typ = Szk::new(sumvec, 0);
-        let prove_rand_seed = rng.gen();
-        let helper_seed = rng.gen();
-        let leader_seed_opt = Some(rng.gen());
+        let prove_rand_seed = rng.random();
+        let helper_seed = rng.random();
+        let leader_seed_opt = Some(rng.random());
         let helper_input_share = Field128::random_vector(szk_typ.typ.input_len());
         let mut leader_input_share = encoded_measurement.clone().to_owned();
         sub_assign_vector(&mut leader_input_share, helper_input_share.iter().copied());
@@ -899,15 +899,15 @@ mod tests {
 
     #[test]
     fn test_count_proof_share_encode() {
-        let mut rng = thread_rng();
+        let mut rng = rng();
         let mut nonce = [0u8; 16];
-        thread_rng().fill(&mut nonce[..]);
+        rng.fill(&mut nonce[..]);
         let count = Count::<Field128>::new();
         let encoded_measurement = count.encode_measurement(&true).unwrap();
         let szk_typ = Szk::new(count, 0);
-        let prove_rand_seed = rng.gen();
-        let helper_seed = rng.gen();
-        let leader_seed_opt = Some(rng.gen());
+        let prove_rand_seed = rng.random();
+        let helper_seed = rng.random();
+        let leader_seed_opt = Some(rng.random());
         let helper_input_share = Field128::random_vector(szk_typ.typ.input_len());
         let mut leader_input_share = encoded_measurement.clone().to_owned();
         sub_assign_vector(&mut leader_input_share, helper_input_share.iter().copied());
@@ -932,15 +932,15 @@ mod tests {
 
     #[test]
     fn test_sum_leader_proof_share_roundtrip() {
-        let mut rng = thread_rng();
+        let mut rng = rng();
         let max_measurement = 13;
         let mut nonce = [0u8; 16];
-        thread_rng().fill(&mut nonce[..]);
+        rng.fill(&mut nonce[..]);
         let sum = Sum::<Field128>::new(max_measurement).unwrap();
         let encoded_measurement = sum.encode_measurement(&9).unwrap();
         let szk_typ = Szk::new(sum, 0);
-        let prove_rand_seed = rng.gen();
-        let helper_seed = rng.gen();
+        let prove_rand_seed = rng.random();
+        let helper_seed = rng.random();
         let leader_seed_opt = None;
         let helper_input_share = Field128::random_vector(szk_typ.typ.input_len());
         let mut leader_input_share = encoded_measurement.clone().to_owned();
@@ -972,15 +972,15 @@ mod tests {
 
     #[test]
     fn test_sum_helper_proof_share_roundtrip() {
-        let mut rng = thread_rng();
+        let mut rng = rng();
         let max_measurement = 13;
         let mut nonce = [0u8; 16];
-        thread_rng().fill(&mut nonce[..]);
+        rng.fill(&mut nonce[..]);
         let sum = Sum::<Field128>::new(max_measurement).unwrap();
         let encoded_measurement = sum.encode_measurement(&9).unwrap();
         let szk_typ = Szk::new(sum, 0);
-        let prove_rand_seed = rng.gen();
-        let helper_seed = rng.gen();
+        let prove_rand_seed = rng.random();
+        let helper_seed = rng.random();
         let leader_seed_opt = None;
         let helper_input_share = Field128::random_vector(szk_typ.typ.input_len());
         let mut leader_input_share = encoded_measurement.clone().to_owned();
@@ -1012,14 +1012,14 @@ mod tests {
 
     #[test]
     fn test_count_leader_proof_share_roundtrip() {
-        let mut rng = thread_rng();
+        let mut rng = rng();
         let mut nonce = [0u8; 16];
-        thread_rng().fill(&mut nonce[..]);
+        rng.fill(&mut nonce[..]);
         let count = Count::<Field128>::new();
         let encoded_measurement = count.encode_measurement(&true).unwrap();
         let szk_typ = Szk::new(count, 0);
-        let prove_rand_seed = rng.gen();
-        let helper_seed = rng.gen();
+        let prove_rand_seed = rng.random();
+        let helper_seed = rng.random();
         let leader_seed_opt = None;
         let helper_input_share = Field128::random_vector(szk_typ.typ.input_len());
         let mut leader_input_share = encoded_measurement.clone().to_owned();
@@ -1051,14 +1051,14 @@ mod tests {
 
     #[test]
     fn test_count_helper_proof_share_roundtrip() {
-        let mut rng = thread_rng();
+        let mut rng = rng();
         let mut nonce = [0u8; 16];
-        thread_rng().fill(&mut nonce[..]);
+        rng.fill(&mut nonce[..]);
         let count = Count::<Field128>::new();
         let encoded_measurement = count.encode_measurement(&true).unwrap();
         let szk_typ = Szk::new(count, 0);
-        let prove_rand_seed = rng.gen();
-        let helper_seed = rng.gen();
+        let prove_rand_seed = rng.random();
+        let helper_seed = rng.random();
         let leader_seed_opt = None;
         let helper_input_share = Field128::random_vector(szk_typ.typ.input_len());
         let mut leader_input_share = encoded_measurement.clone().to_owned();
@@ -1090,16 +1090,16 @@ mod tests {
 
     #[test]
     fn test_sumvec_leader_proof_share_roundtrip() {
-        let mut rng = thread_rng();
+        let mut rng = rng();
         let mut nonce = [0u8; 16];
-        thread_rng().fill(&mut nonce[..]);
+        rng.fill(&mut nonce[..]);
         let sumvec =
             SumVec::<Field128, ParallelSum<Field128, Mul<Field128>>>::new(5, 3, 3).unwrap();
         let encoded_measurement = sumvec.encode_measurement(&vec![1, 16, 0]).unwrap();
         let szk_typ = Szk::new(sumvec, 0);
-        let prove_rand_seed = rng.gen();
-        let helper_seed = rng.gen();
-        let leader_seed_opt = Some(rng.gen());
+        let prove_rand_seed = rng.random();
+        let helper_seed = rng.random();
+        let leader_seed_opt = Some(rng.random());
         let helper_input_share = Field128::random_vector(szk_typ.typ.input_len());
         let mut leader_input_share = encoded_measurement.clone().to_owned();
         sub_assign_vector(&mut leader_input_share, helper_input_share.iter().copied());
@@ -1130,16 +1130,16 @@ mod tests {
 
     #[test]
     fn test_sumvec_helper_proof_share_roundtrip() {
-        let mut rng = thread_rng();
+        let mut rng = rng();
         let mut nonce = [0u8; 16];
-        thread_rng().fill(&mut nonce[..]);
+        rng.fill(&mut nonce[..]);
         let sumvec =
             SumVec::<Field128, ParallelSum<Field128, Mul<Field128>>>::new(5, 3, 3).unwrap();
         let encoded_measurement = sumvec.encode_measurement(&vec![1, 16, 0]).unwrap();
         let szk_typ = Szk::new(sumvec, 0);
-        let prove_rand_seed = rng.gen();
-        let helper_seed = rng.gen();
-        let leader_seed_opt = Some(rng.gen());
+        let prove_rand_seed = rng.random();
+        let helper_seed = rng.random();
+        let leader_seed_opt = Some(rng.random());
         let helper_input_share = Field128::random_vector(szk_typ.typ.input_len());
         let mut leader_input_share = encoded_measurement.clone().to_owned();
         sub_assign_vector(&mut leader_input_share, helper_input_share.iter().copied());

--- a/src/vdaf/prio2/client.rs
+++ b/src/vdaf/prio2/client.rs
@@ -11,7 +11,7 @@ use crate::{
     vdaf::{xof::SeedStreamAes128, VdafError},
 };
 
-use rand::prelude::*;
+use rand::{rng, Rng};
 use std::convert::TryFrom;
 
 /// Serialization errors
@@ -40,7 +40,7 @@ pub(crate) struct ClientMemory<F> {
 
 impl<F: NttFriendlyFieldElement> ClientMemory<F> {
     pub(crate) fn new(dimension: usize) -> Result<Self, VdafError> {
-        let mut rng = thread_rng();
+        let mut rng = rng();
         let n = (dimension + 1).next_power_of_two();
         if let Ok(size) = F::Integer::try_from(2 * n) {
             if size > F::generator_order() {
@@ -55,7 +55,7 @@ impl<F: NttFriendlyFieldElement> ClientMemory<F> {
         }
 
         Ok(Self {
-            prng: Prng::from_prio2_seed(&rng.gen()),
+            prng: Prng::from_prio2_seed(&rng.random()),
             points_f: vec![F::zero(); n],
             points_g: vec![F::zero(); n],
             evals_f: vec![F::zero(); 2 * n],

--- a/src/vdaf/prio3.rs
+++ b/src/vdaf/prio3.rs
@@ -61,7 +61,7 @@ use crate::vdaf::{
 };
 #[cfg(feature = "experimental")]
 use fixed::traits::Fixed;
-use rand::prelude::*;
+use rand::{rng, Rng};
 use std::borrow::Cow;
 use std::convert::TryFrom;
 use std::fmt::Debug;
@@ -376,19 +376,19 @@ impl Prio3Average {
 ///     Aggregator, Client, Collector, PrepareTransition,
 ///     prio3::Prio3,
 /// };
-/// use rand::prelude::*;
+/// use rand::{rng, Rng, RngCore};
 ///
 /// let num_shares = 2;
 /// let ctx = b"my context str";
 /// let vdaf = Prio3::new_count(num_shares).unwrap();
 ///
 /// let mut out_shares = vec![vec![]; num_shares.into()];
-/// let mut rng = thread_rng();
-/// let verify_key = rng.gen();
+/// let mut rng = rng();
+/// let verify_key = rng.random();
 /// let measurements = [false, true, true, true, false];
 /// for measurement in measurements {
 ///     // Shard
-///     let nonce = rng.gen::<[u8; 16]>();
+///     let nonce = rng.random::<[u8; 16]>();
 ///     let (public_share, input_shares) = vdaf.shard(ctx, &measurement, &nonce).unwrap();
 ///
 ///     // Prepare
@@ -1217,7 +1217,7 @@ where
         nonce: &[u8; 16],
     ) -> Result<(Self::PublicShare, Vec<Prio3InputShare<T::Field, SEED_SIZE>>), VdafError> {
         let mut random = vec![0u8; self.random_size()];
-        thread_rng().fill(&mut random[..]);
+        rng().fill(&mut random[..]);
         self.shard_with_random(ctx, measurement, nonce, &random)
     }
 }
@@ -1783,8 +1783,8 @@ mod tests {
 
         let mut nonce = [0; 16];
         let mut verify_key = [0; 32];
-        thread_rng().fill(&mut verify_key[..]);
-        thread_rng().fill(&mut nonce[..]);
+        rng().fill(&mut verify_key[..]);
+        rng().fill(&mut nonce[..]);
 
         let (public_share, input_shares) = prio3.shard(CTX_STR, &false, &nonce).unwrap();
         run_vdaf_prepare(
@@ -1837,7 +1837,7 @@ mod tests {
         );
 
         let mut verify_key = [0; 32];
-        thread_rng().fill(&mut verify_key[..]);
+        rng().fill(&mut verify_key[..]);
         let nonce = [0; 16];
 
         let (public_share, mut input_shares) = prio3.shard(CTX_STR, &1, &nonce).unwrap();
@@ -2104,8 +2104,8 @@ mod tests {
 
             let mut verify_key = [0; 32];
             let mut nonce = [0; 16];
-            thread_rng().fill(&mut verify_key);
-            thread_rng().fill(&mut nonce);
+            rng().fill(&mut verify_key);
+            rng().fill(&mut nonce);
 
             let (public_share, mut input_shares) = prio3
                 .shard(CTX_STR, &vec![fp_4_inv, fp_8_inv, fp_16_inv], &nonce)
@@ -2274,7 +2274,7 @@ mod tests {
         P: Xof<SEED_SIZE>,
     {
         let mut verify_key = [0; SEED_SIZE];
-        thread_rng().fill(&mut verify_key[..]);
+        rng().fill(&mut verify_key[..]);
         let (public_share, input_shares) = prio3.shard(CTX_STR, measurement, nonce)?;
 
         let encoded_public_share = public_share.get_encoded().unwrap();

--- a/src/vidpf.rs
+++ b/src/vidpf.rs
@@ -15,7 +15,7 @@ use core::{
 };
 
 use bitvec::prelude::{BitVec, Lsb0};
-use rand::prelude::*;
+use rand::{rng, Rng, RngCore};
 use std::fmt::Debug;
 use std::io::{Cursor, Read};
 use subtle::{Choice, ConditionallyNegatable, ConditionallySelectable, ConstantTimeEq};
@@ -98,8 +98,8 @@ impl<W: VidpfValue> Vidpf<W> {
         weight: &W,
         nonce: &[u8],
     ) -> Result<(VidpfPublicShare<W>, [VidpfKey; 2]), VidpfError> {
-        let mut rng = thread_rng();
-        let keys = rng.gen();
+        let mut rng = rng();
+        let keys = rng.random();
         let public = self.gen_with_keys(ctx, &keys, input, weight, nonce)?;
         Ok((public, keys))
     }

--- a/supply-chain/audits.toml
+++ b/supply-chain/audits.toml
@@ -595,6 +595,11 @@ who = "Brandon Pitman <bran@bran.land>"
 criteria = "safe-to-deploy"
 delta = "1.0.52 -> 1.0.54"
 
+[[audits.rand]]
+who = "David Cook <dcook@divviup.org>"
+criteria = "safe-to-deploy"
+delta = "0.8.5 -> 0.9.1"
+
 [[audits.rand_chacha]]
 who = "David Cook <dcook@divviup.org>"
 criteria = "safe-to-deploy"

--- a/supply-chain/audits.toml
+++ b/supply-chain/audits.toml
@@ -620,6 +620,11 @@ who = "David Cook <dcook@divviup.org>"
 criteria = "safe-to-run"
 delta = "0.6.1 -> 0.5.1"
 
+[[audits.rand_core]]
+who = "David Cook <dcook@divviup.org>"
+criteria = "safe-to-deploy"
+delta = "0.6.4 -> 0.9.3"
+
 [[audits.rand_hc]]
 who = "David Cook <dcook@divviup.org>"
 criteria = "safe-to-run"

--- a/supply-chain/audits.toml
+++ b/supply-chain/audits.toml
@@ -600,6 +600,11 @@ who = "David Cook <dcook@divviup.org>"
 criteria = "safe-to-run"
 delta = "0.3.0 -> 0.2.2"
 
+[[audits.rand_chacha]]
+who = "David Cook <dcook@divviup.org>"
+criteria = "safe-to-deploy"
+delta = "0.3.1 -> 0.9.0"
+
 [[audits.rand_core]]
 who = "David Cook <dcook@divviup.org>"
 criteria = "safe-to-deploy"

--- a/supply-chain/audits.toml
+++ b/supply-chain/audits.toml
@@ -339,6 +339,11 @@ who = "David Cook <dcook@divviup.org>"
 criteria = "safe-to-deploy"
 delta = "0.2.14 -> 0.2.15"
 
+[[audits.getrandom]]
+who = "David Cook <dcook@divviup.org>"
+criteria = "safe-to-deploy"
+delta = "0.3.1 -> 0.3.2"
+
 [[audits.ghash]]
 who = "David Cook <dcook@divviup.org>"
 criteria = "safe-to-deploy"

--- a/supply-chain/audits.toml
+++ b/supply-chain/audits.toml
@@ -625,6 +625,11 @@ who = "David Cook <dcook@divviup.org>"
 criteria = "safe-to-deploy"
 delta = "0.6.4 -> 0.9.3"
 
+[[audits.rand_distr]]
+who = "David Cook <dcook@divviup.org>"
+criteria = "safe-to-deploy"
+delta = "0.4.3 -> 0.5.1"
+
 [[audits.rand_hc]]
 who = "David Cook <dcook@divviup.org>"
 criteria = "safe-to-run"

--- a/supply-chain/config.toml
+++ b/supply-chain/config.toml
@@ -145,6 +145,11 @@ criteria = "safe-to-run"
 version = "0.2.16"
 criteria = "safe-to-deploy"
 
+[[exemptions.r-efi]]
+version = "5.2.0"
+criteria = "safe-to-deploy"
+notes = "This is only used on UEFI targets"
+
 [[exemptions.radium]]
 version = "0.7.0"
 criteria = "safe-to-deploy"
@@ -164,6 +169,11 @@ criteria = "safe-to-run"
 [[exemptions.typenum]]
 version = "1.15.0"
 criteria = "safe-to-deploy"
+
+[[exemptions.wasi]]
+version = "0.14.2+wasi-0.2.4"
+criteria = "safe-to-deploy"
+notes = "This is only used on WASI targets"
 
 [[exemptions.wide]]
 version = "0.7.11"

--- a/supply-chain/imports.lock
+++ b/supply-chain/imports.lock
@@ -211,6 +211,24 @@ user-id = 189
 user-login = "BurntSushi"
 user-name = "Andrew Gallant"
 
+[[publisher.wit-bindgen-rt]]
+version = "0.39.0"
+when = "2025-02-05"
+user-id = 73222
+user-login = "wasmtime-publish"
+
+[[audits.bytecode-alliance.wildcard-audits.wit-bindgen-rt]]
+who = "Alex Crichton <alex@alexcrichton.com>"
+criteria = "safe-to-deploy"
+user-id = 73222 # wasmtime-publish
+start = "2023-01-01"
+end = "2025-05-08"
+notes = """
+The Bytecode Alliance uses the `wasmtime-publish` crates.io account to automate
+publication of this crate from CI. This repository requires all PRs are reviewed
+by a Bytecode Alliance maintainer and it owned by the Bytecode Alliance itself.
+"""
+
 [[audits.bytecode-alliance.audits.anes]]
 who = "Pat Hickey <phickey@fastly.com>"
 criteria = "safe-to-deploy"
@@ -222,6 +240,34 @@ who = "Pat Hickey <phickey@fastly.com>"
 criteria = "safe-to-deploy"
 version = "0.21.0"
 notes = "This crate has no dependencies, no build.rs, and contains no unsafe code."
+
+[[audits.bytecode-alliance.audits.bitflags]]
+who = "Jamey Sharp <jsharp@fastly.com>"
+criteria = "safe-to-deploy"
+delta = "2.1.0 -> 2.2.1"
+notes = """
+This version adds unsafe impls of traits from the bytemuck crate when built
+with that library enabled, but I believe the impls satisfy the documented
+safety requirements for bytemuck. The other changes are minor.
+"""
+
+[[audits.bytecode-alliance.audits.bitflags]]
+who = "Alex Crichton <alex@alexcrichton.com>"
+criteria = "safe-to-deploy"
+delta = "2.3.2 -> 2.3.3"
+notes = """
+Nothing outside the realm of what one would expect from a bitflags generator,
+all as expected.
+"""
+
+[[audits.bytecode-alliance.audits.bitflags]]
+who = "Alex Crichton <alex@alexcrichton.com>"
+criteria = "safe-to-deploy"
+delta = "2.4.1 -> 2.6.0"
+notes = """
+Changes in how macros are invoked and various bits and pieces of macro-fu.
+Otherwise no major changes and nothing dealing with `unsafe`.
+"""
 
 [[audits.bytecode-alliance.audits.block-buffer]]
 who = "Benjamin Bouvier <public@benj.me>"
@@ -334,6 +380,36 @@ delta = "1.0.9 -> 1.0.10"
 notes = "Minor changes related to `write_str`."
 aggregated-from = "https://chromium.googlesource.com/chromium/src/+/main/third_party/rust/chromium_crates_io/supply-chain/audits.toml?format=TEXT"
 
+[[audits.google.audits.bitflags]]
+who = "Lukasz Anforowicz <lukasza@chromium.org>"
+criteria = "safe-to-deploy"
+version = "1.3.2"
+notes = """
+Security review of earlier versions of the crate can be found at
+(Google-internal, sorry): go/image-crate-chromium-security-review
+
+The crate exposes a function marked as `unsafe`, but doesn't use any
+`unsafe` blocks (except for tests of the single `unsafe` function).  I
+think this justifies marking this crate as `ub-risk-1`.
+
+Additional review comments can be found at https://crrev.com/c/4723145/31
+"""
+aggregated-from = "https://chromium.googlesource.com/chromium/src/+/main/third_party/rust/chromium_crates_io/supply-chain/audits.toml?format=TEXT"
+
+[[audits.google.audits.bitflags]]
+who = "Lukasz Anforowicz <lukasza@chromium.org>"
+criteria = "safe-to-deploy"
+delta = "2.6.0 -> 2.8.0"
+notes = "No changes related to `unsafe impl ... bytemuck` pieces from `src/external.rs`."
+aggregated-from = "https://chromium.googlesource.com/chromium/src/+/main/third_party/rust/chromium_crates_io/supply-chain/audits.toml?format=TEXT"
+
+[[audits.google.audits.bitflags]]
+who = "Daniel Cheng <dcheng@chromium.org>"
+criteria = "safe-to-deploy"
+delta = "2.8.0 -> 2.9.0"
+notes = "Adds a straightforward clear() function, but no new unsafe code."
+aggregated-from = "https://chromium.googlesource.com/chromium/src/+/main/third_party/rust/chromium_crates_io/supply-chain/audits.toml?format=TEXT"
+
 [[audits.google.audits.cast]]
 who = "George Burgess IV <gbiv@google.com>"
 criteria = "safe-to-run"
@@ -357,6 +433,17 @@ who = "Lukasz Anforowicz <lukasza@chromium.org>"
 criteria = "safe-to-run"
 delta = "0.7.1 -> 0.7.2"
 notes = "No `.rs` changes in the delta."
+aggregated-from = "https://chromium.googlesource.com/chromium/src/+/main/third_party/rust/chromium_crates_io/supply-chain/audits.toml?format=TEXT"
+
+[[audits.google.audits.getrandom]]
+who = "danakj@chromium.org"
+criteria = "safe-to-run"
+version = "0.2.11"
+notes = """
+Reviewed in https://crrev.com/c/5171063
+
+Previously reviewed during security review and the audit is grandparented in.
+"""
 aggregated-from = "https://chromium.googlesource.com/chromium/src/+/main/third_party/rust/chromium_crates_io/supply-chain/audits.toml?format=TEXT"
 
 [[audits.google.audits.itertools]]
@@ -440,6 +527,38 @@ criteria = "safe-to-deploy"
 version = "1.1.0"
 notes = "All code written or reviewed by Josh Stone."
 aggregated-from = "https://hg.mozilla.org/mozilla-central/raw-file/tip/supply-chain/audits.toml"
+
+[[audits.mozilla.audits.bitflags]]
+who = "Alex Franchuk <afranchuk@mozilla.com>"
+criteria = "safe-to-deploy"
+delta = "1.3.2 -> 2.0.2"
+notes = "Removal of some unsafe code/methods. No changes to externals, just some refactoring (mostly internal)."
+aggregated-from = "https://hg.mozilla.org/mozilla-central/raw-file/tip/supply-chain/audits.toml"
+
+[[audits.mozilla.audits.bitflags]]
+who = "Nicolas Silva <nical@fastmail.com>"
+criteria = "safe-to-deploy"
+delta = "2.0.2 -> 2.1.0"
+aggregated-from = "https://hg.mozilla.org/mozilla-central/raw-file/tip/supply-chain/audits.toml"
+
+[[audits.mozilla.audits.bitflags]]
+who = "Teodor Tanasoaia <ttanasoaia@mozilla.com>"
+criteria = "safe-to-deploy"
+delta = "2.2.1 -> 2.3.2"
+aggregated-from = "https://hg.mozilla.org/mozilla-central/raw-file/tip/supply-chain/audits.toml"
+
+[[audits.mozilla.audits.bitflags]]
+who = "Mike Hommey <mh+mozilla@glandium.org>"
+criteria = "safe-to-deploy"
+delta = "2.3.3 -> 2.4.0"
+aggregated-from = "https://hg.mozilla.org/mozilla-central/raw-file/tip/supply-chain/audits.toml"
+
+[[audits.mozilla.audits.bitflags]]
+who = "Jan-Erik Rediger <jrediger@mozilla.com>"
+criteria = "safe-to-deploy"
+delta = "2.4.0 -> 2.4.1"
+notes = "Only allowing new clippy lints"
+aggregated-from = "https://raw.githubusercontent.com/mozilla/glean/main/supply-chain/audits.toml"
 
 [[audits.mozilla.audits.block-buffer]]
 who = "Mike Hommey <mh+mozilla@glandium.org>"
@@ -667,50 +786,6 @@ who = "Jack Grigg <jack@electriccoin.co>"
 criteria = "safe-to-deploy"
 delta = "0.9.14 -> 0.9.15"
 notes = "Bumps memoffset to 0.9, and unmarks some ARMv7r and Sony Vita targets as not having 64-bit atomics."
-aggregated-from = "https://raw.githubusercontent.com/zcash/zcash/master/qa/supply-chain/audits.toml"
-
-[[audits.zcash.audits.getrandom]]
-who = "Jack Grigg <jack@electriccoin.co>"
-criteria = "safe-to-deploy"
-delta = "0.2.8 -> 0.2.9"
-notes = """
-The new `getrandom_uninit` method is introduced by retrofitting every system
-implementation to take `&mut [MaybeUninit<u8>]` instead of `&mut [u8]`.
-
-Most implementations are only altered to update their signature, and to
-internally cast the slice back to `*mut u8` when writing to it. All of these
-backends appear to write bytes to the full length of the slice, so it should be
-fully initialized afterwards, upholding the invariants of the new `unsafe` code
-in the public APIs.
-
-- I did not check the behaviour of each implementation's system method to ensure
-  they never write uninitialized bytes; the code prior to this change already
-  needed to uphold that invariant as it was writing into `&mut [u8]`.
-
-The following system implementations have additional `unsafe` code modifications:
-
-- `custom`: The slice is zero-filled to ensure the `MaybeUninit<u8>` doesn't
-  escape into a system implementation that might not write initialized bytes
-  into the entire slice. The internal API between registration and usage is also
-  switched from C ABI to Rust ABI, to guard against potential panics.
-
-- `emscripten`: New backend, implementation looks reasonable.
-
-- `hermit`: New backend, writes incrementally to the slice, but ensures that the
-  entire slice has been written to before returning `Ok(())`. I note that it is
-  possible for the implementation to loop indefinitely if `sys_read_entropy`
-  were to always return 0 for some reason.
-
-- `js`: Adds chunking to limit each write to less than 2^31 (but that seems like
-  a bugfix). The safety requirements for `Uint8Array::view_mut_raw` appear to be
-  satisfied.
-
-- `rdrand`: Code changes to better handle CPU families with broken RDRAND.
-
-- `solaris_illumos`: Now uses `GRND_RANDOM`.
-
-- `windows`: Added `RtlGenRandom` fallback for non-UWP Windows.
-"""
 aggregated-from = "https://raw.githubusercontent.com/zcash/zcash/master/qa/supply-chain/audits.toml"
 
 [[audits.zcash.audits.inout]]

--- a/supply-chain/imports.lock
+++ b/supply-chain/imports.lock
@@ -502,6 +502,23 @@ criteria = "safe-to-deploy"
 delta = "1.7.0 -> 1.8.0"
 aggregated-from = "https://hg.mozilla.org/mozilla-central/raw-file/tip/supply-chain/audits.toml"
 
+[[audits.mozilla.audits.getrandom]]
+who = "Yannis Juglaret <yjuglaret@mozilla.com>"
+criteria = "safe-to-deploy"
+delta = "0.2.8 -> 0.2.9"
+aggregated-from = "https://hg.mozilla.org/mozilla-central/raw-file/tip/supply-chain/audits.toml"
+
+[[audits.mozilla.audits.getrandom]]
+who = "Chris Martin <cmartin@mozilla.com>"
+criteria = "safe-to-deploy"
+delta = "0.2.15 -> 0.3.1"
+notes = """
+I've looked over all unsafe code, and it appears to be safe, fully initializing the rng buffers.
+In addition, I've checked Linux, Windows, Mac, and Android more thoroughly against API
+documentation.
+"""
+aggregated-from = "https://hg.mozilla.org/mozilla-central/raw-file/tip/supply-chain/audits.toml"
+
 [[audits.mozilla.audits.half]]
 who = "John M. Schanck <jschanck@mozilla.com>"
 criteria = "safe-to-deploy"

--- a/tests/discrete_gauss.rs
+++ b/tests/discrete_gauss.rs
@@ -5,7 +5,7 @@ use num_rational::Ratio;
 use num_traits::FromPrimitive;
 use prio::dp::distributions::DiscreteGaussian;
 use prio::vdaf::xof::SeedStreamTurboShake128;
-use rand::distributions::Distribution;
+use rand::distr::Distribution;
 use rand::SeedableRng;
 use serde::Deserialize;
 


### PR DESCRIPTION
This closes #1216. Arbitrary precision integer sampling routines from num-bigint were vendored to allow us to proceed without a new version of that crate. All new versions of dependencies have been audited. Note that version 0.9.1 of the `rand` crate and 0.9.3 of the `rand_core` crate do not depend on `zerocopy`, unlike earlier 0.9 versions.

There is still a transitive dependency on rand 0.8 via `statrs` and `nalgebra`, but we can take care of that separately, as it only affects some tests.