### PR TITLE
Fix Clippy warning

### DIFF
--- a/src/topology/ping_pong.rs
+++ b/src/topology/ping_pong.rs
@@ -421,7 +421,7 @@ pub trait PingPongTopology<const VERIFY_KEY_SIZE: usize, const NONCE_SIZE: usize
     ///   share may be accumulated.
     ///
     /// - `PingPongContinuedValue::FinishedNoMessage`: preparation is finished and the output share
-    ///    may be accumulated. No message needs to be sent to the helper.
+    ///   may be accumulated. No message needs to be sent to the helper.
     ///
     /// # Errors
     ///


### PR DESCRIPTION
This fixes indentation in a doc comment.