### PR TITLE
adjust PingPong topology to match VDAF #543

### DIFF
--- a/src/vdaf.rs
+++ b/src/vdaf.rs
@@ -175,7 +175,9 @@ pub trait Vdaf: Clone + Debug {
     type OutputShare: Clone
         + Debug
         + for<'a> ParameterizedDecode<(&'a Self, &'a Self::AggregationParam)>
-        + Encode;
+        + Encode
+        + PartialEq
+        + Eq;
 
     /// An Aggregator's share of the aggregate result.
     type AggregateShare: Aggregatable<OutputShare = Self::OutputShare>


### PR DESCRIPTION
This updates `prio::topology::ping_pong`'s API to match the changes proposed in https://github.com/cfrg/draft-irtf-cfrg-vdaf/pull/543.