### PR TITLE
bump MSRV to Rust 1.80

### DIFF
--- a/.github/workflows/ci-build.yml
+++ b/.github/workflows/ci-build.yml
@@ -27,7 +27,7 @@ jobs:
       matrix:
         rust-toolchain: [
           # MSRV from Cargo.toml
-          "1.71",
+          "1.80",
           "stable",
         ]
     runs-on: ubuntu-latest
@@ -48,7 +48,7 @@ jobs:
       matrix:
         rust-toolchain: [
           # MSRV from Cargo.toml
-          "1.71",
+          "1.80",
           "stable",
         ]
     runs-on: ubuntu-latest

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,7 +7,7 @@ exclude = ["/supply-chain"]
 description = "Implementation of the Prio aggregation system core: https://crypto.stanford.edu/prio/"
 license = "MPL-2.0"
 repository = "https://github.com/divviup/libprio-rs"
-rust-version = "1.71"
+rust-version = "1.80"
 resolver = "2"
 
 [dependencies]

--- a/src/flp/types.rs
+++ b/src/flp/types.rs
@@ -594,7 +594,7 @@ impl<F: NttFriendlyFieldElement, S: ParallelSumGadget<F, Mul<F>>> MultihotCountV
         let meas_length = num_buckets + bits_for_weight;
 
         // Gadget calls is ⌈meas_length / chunk_length⌉
-        let gadget_calls = (meas_length + chunk_length - 1) / chunk_length;
+        let gadget_calls = meas_length.div_ceil(chunk_length);
         // Offset is 2^max_weight.bitlen() - 1 - max_weight
         let offset = (1 << bits_for_weight) - 1 - max_weight;
 

--- a/src/flp/types/fixedpoint_l2.rs
+++ b/src/flp/types/fixedpoint_l2.rs
@@ -331,11 +331,11 @@ where
         // Compute chunk length and number of calls for parallel sum gadgets.
         let len0 = bits_per_entry * entries + bits_for_norm;
         let gadget0_chunk_length = std::cmp::max(1, (len0 as f64).sqrt() as usize);
-        let gadget0_calls = (len0 + gadget0_chunk_length - 1) / gadget0_chunk_length;
+        let gadget0_calls = len0.div_ceil(gadget0_chunk_length);
 
         let len1 = entries;
         let gadget1_chunk_length = std::cmp::max(1, (len1 as f64).sqrt() as usize);
-        let gadget1_calls = (len1 + gadget1_chunk_length - 1) / gadget1_chunk_length;
+        let gadget1_calls = len1.div_ceil(gadget1_chunk_length);
 
         Ok(Self {
             bits_per_entry,

--- a/src/idpf.rs
+++ b/src/idpf.rs
@@ -727,7 +727,7 @@ where
 
     fn encoded_len(&self) -> Option<usize> {
         let control_bits_count = (self.inner_correction_words.len() + 1) * 2;
-        let mut len = (control_bits_count + 7) / 8 + (self.inner_correction_words.len() + 1) * 16;
+        let mut len = control_bits_count.div_ceil(8) + (self.inner_correction_words.len() + 1) * 16;
         for correction_words in self.inner_correction_words.iter() {
             len += correction_words.value.encoded_len()?;
         }
@@ -742,7 +742,7 @@ where
     VL: Decode,
 {
     fn decode_with_param(bits: &usize, bytes: &mut Cursor<&[u8]>) -> Result<Self, CodecError> {
-        let packed_control_len = (bits + 3) / 4;
+        let packed_control_len = bits.div_ceil(4);
         let mut packed_control_bits = vec![0u8; packed_control_len];
         bytes.read_exact(&mut packed_control_bits)?;
         let unpacked_control_bits: BitVec<u8, Lsb0> = BitVec::from_vec(packed_control_bits);

--- a/src/vdaf/poplar1.rs
+++ b/src/vdaf/poplar1.rs
@@ -800,7 +800,7 @@ impl Encode for Poplar1AggregationParam {
     }
 
     fn encoded_len(&self) -> Option<usize> {
-        let encoded_prefixes_len = (((self.level + 1) as usize + 7) / 8) * self.prefixes.len();
+        let encoded_prefixes_len = ((self.level + 1) as usize).div_ceil(8) * self.prefixes.len();
         // 4 bytes for the number of prefixes, 2 bytes for the level, and a variable number of bytes
         // for the encoded prefixes themselves.
         Some(6 + encoded_prefixes_len)
@@ -818,7 +818,7 @@ impl Decode for Poplar1AggregationParam {
 
         // Encoded prefixes
         let mut prefixes = Vec::with_capacity(num_prefixes);
-        let mut buf = vec![0; ((level + 1) as usize + 7) / 8];
+        let mut buf = vec![0; ((level + 1) as usize).div_ceil(8)];
         let last_byte_mask = match (level + 1) % 8 {
             0 => 0,
             num_bits => {

--- a/src/vdaf/prio3.rs
+++ b/src/vdaf/prio3.rs
@@ -1702,7 +1702,7 @@ pub fn optimal_chunk_length(measurement_length: usize) -> usize {
         .rev()
         .map(|log2| {
             let gadget_calls = (1 << log2) - 1;
-            let chunk_length = (measurement_length + gadget_calls - 1) / gadget_calls;
+            let chunk_length = measurement_length.div_ceil(gadget_calls);
             Candidate {
                 gadget_calls,
                 chunk_length,

--- a/src/vdaf/xof.rs
+++ b/src/vdaf/xof.rs
@@ -474,7 +474,7 @@ impl SeedStreamFixedKeyAes128 {
 
         // NOTE(cjpatton) We might be able to speed this up by unrolling this loop and encrypting
         // multiple blocks at the same time via `self.cipher.encrypt_blocks()`.
-        for block_counter in self.length_consumed / 16..(next_length_consumed + 15) / 16 {
+        for block_counter in self.length_consumed / 16..next_length_consumed.div_ceil(16) {
             block.clone_from(&self.base_block);
             for (b, i) in block.iter_mut().zip(block_counter.to_le_bytes().iter()) {
                 *b ^= i;

--- a/src/vidpf.rs
+++ b/src/vidpf.rs
@@ -527,7 +527,7 @@ impl<W: VidpfValue> Encode for VidpfPublicShare<W> {
             .map_or(Some(0), |cw| cw.weight.encoded_len())?;
 
         let mut len = 0;
-        len += (2 * self.cw.len() + 7) / 8; // packed control bits
+        len += (2 * self.cw.len()).div_ceil(8); // packed control bits
         len += self.cw.len() * VIDPF_SEED_SIZE; // seeds
         len += self.cw.len() * weight_len; // weights
         len += self.cw.len() * VIDPF_PROOF_SIZE; // nod proofs
@@ -538,7 +538,7 @@ impl<W: VidpfValue> Encode for VidpfPublicShare<W> {
 impl<W: VidpfValue> ParameterizedDecode<Vidpf<W>> for VidpfPublicShare<W> {
     fn decode_with_param(vidpf: &Vidpf<W>, bytes: &mut Cursor<&[u8]>) -> Result<Self, CodecError> {
         let bits = usize::from(vidpf.bits);
-        let packed_control_len = (bits + 3) / 4;
+        let packed_control_len = bits.div_ceil(4);
         let mut packed_control_bits = vec![0u8; packed_control_len];
         bytes.read_exact(&mut packed_control_bits)?;
         let unpacked_control_bits: BitVec<u8, Lsb0> = BitVec::from_vec(packed_control_bits);


### PR DESCRIPTION
Staying on 1.71 is preventing us from taking dependency updates (#1260) so it's time to increase MSRV. This is only happening on `main`, so as to avoid breaking clients that depend on release branches.