### PR TITLE
Backport: Construct fixed job names from matrix

### DIFF
--- a/.github/workflows/ci-build.yml
+++ b/.github/workflows/ci-build.yml
@@ -23,12 +23,19 @@ jobs:
         RUSTDOCFLAGS: -Dwarnings
 
   build-binaries:
+    name: build-binaries (${{ matrix.rust-toolchain.label }})
     strategy:
       matrix:
         rust-toolchain: [
-          # MSRV from Cargo.toml
-          "1.71",
-          "stable",
+          {
+            # MSRV from Cargo.toml
+            version: "1.71",
+            label: "MSRV",
+          },
+          {
+            version: "stable",
+            label: "stable"
+          },
         ]
     runs-on: ubuntu-latest
     steps:
@@ -36,7 +43,7 @@ jobs:
     - name: Install Rust toolchain
       uses: dtolnay/rust-toolchain@master
       with:
-        toolchain: ${{ matrix.rust-toolchain }}
+        toolchain: ${{ matrix.rust-toolchain.version }}
         components: clippy
     - name: Build
       run: cargo build --verbose --package prio-binaries
@@ -44,12 +51,19 @@ jobs:
       run: cargo clippy --package prio-binaries
 
   build-crate:
+    name: build-crate (${{ matrix.rust-toolchain.label }})
     strategy:
       matrix:
         rust-toolchain: [
-          # MSRV from Cargo.toml
-          "1.71",
-          "stable",
+          {
+            # MSRV from Cargo.toml
+            version: "1.71",
+            label: "MSRV",
+          },
+          {
+            version: "stable",
+            label: "stable"
+          },
         ]
     runs-on: ubuntu-latest
     env:
@@ -59,12 +73,12 @@ jobs:
     - name: Install Rust toolchain
       uses: dtolnay/rust-toolchain@master
       with:
-        toolchain: ${{ matrix.rust-toolchain }}
+        toolchain: ${{ matrix.rust-toolchain.version }}
         components: clippy, rustfmt
     - name: Cache cargo-all-features
       uses: actions/cache@v4
       with:
-        key: cargo-all-features-bins-${{ env.CARGO_ALL_FEATURES_VERSION }}-rust-${{ matrix.rust-toolchain }}
+        key: cargo-all-features-bins-${{ env.CARGO_ALL_FEATURES_VERSION }}-rust-${{ matrix.rust-toolchain.version }}
         path: |
           ${{ runner.tool_cache }}/cargo-build-all-features
           ${{ runner.tool_cache }}/cargo-check-all-features


### PR DESCRIPTION
Interpolating the Rust version into job names makes it hard to write branch protection rules that are applicable to different release branches with different MSRVs. With this change, we instead interpolate fixed labels like "stable" or "MSRV", yielding job names like [build-binaries (MSRV)][1] that are easier to manage.

[1]: https://github.com/divviup/libprio-rs/actions/runs/15150193103/job/42594757141?pr=1263#logs