### PR TITLE
codec: expose `decode_fixlen_items`

### DIFF
--- a/src/codec.rs
+++ b/src/codec.rs
@@ -432,7 +432,7 @@ pub fn decode_u32_items<P, D: ParameterizedDecode<P>>(
     decode_fixlen_items(len, decoding_parameter, bytes)
 }
 
-/// Encode `bytes` as a [fixed-length vector][1] into as many instances of `D` as possible.
+/// Decode `bytes` as a [fixed-length vector][1] into as many instances of `D` as possible.
 ///
 /// [1]: https://datatracker.ietf.org/doc/html/rfc8446#section-3.4
 pub fn decode_fixlen_items<P, D: ParameterizedDecode<P>>(


### PR DESCRIPTION
For https://github.com/ietf-wg-ppm/draft-ietf-ppm-dap/pull/686, DAP will need protocol messages with fixed-length vectors in them ([1]). Module `codec` already had `encode_fixlen_items` in the public API for this, but the corresponding decode function was private.

This commit renames it to align with the encode function and makes it public.

[1]: https://datatracker.ietf.org/doc/html/rfc8446#section-3.4