### PR TITLE
Prepare for `release/0.17` branch

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -23,3 +23,16 @@ updates:
     schedule:
       interval: "weekly"
     target-branch: release/0.16
+
+  - package-ecosystem: "cargo"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    target-branch: release/0.17
+    open-pull-requests-limit: 20
+
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    target-branch: release/0.17

--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ increases (e.g., 0.10 to 0.11).
 | 0.14 | `release/0.14` | [`draft-irtf-cfrg-vdaf-06`][vdaf-06] | [`draft-ietf-ppm-dap-05`][dap-05] | Yes | Unmaintained |
 | 0.15 | `release/0.15` | [`draft-irtf-cfrg-vdaf-07`][vdaf-07] | [`draft-ietf-ppm-dap-07`][dap-07] | Yes | Unmaintained as of June 24, 2024 |
 | 0.16 | `release/0.16` | [`draft-irtf-cfrg-vdaf-08`][vdaf-08] | [`draft-ietf-ppm-dap-09`][dap-09] | Yes | Supported |
-| 0.17 | `main` | [`draft-irtf-cfrg-vdaf-13`][vdaf-13] | [`draft-ietf-ppm-dap-13`][dap-13] | [No](https://github.com/divviup/libprio-rs/issues/1122) | Supported |
+| 0.17 | `release/0.17` | [`draft-irtf-cfrg-vdaf-13`][vdaf-13] | [`draft-ietf-ppm-dap-13`][dap-13] | Yes | Supported |
 
 [vdaf-01]: https://datatracker.ietf.org/doc/draft-irtf-cfrg-vdaf/01/
 [vdaf-03]: https://datatracker.ietf.org/doc/draft-irtf-cfrg-vdaf/03/


### PR DESCRIPTION
Our draft-irtf-cfrg-vdaf-13 implementation is complete (#1122). `main` will now track implementing draft 14 and beyond (#1266). This commit:

- Documents the `release/0.17` branch in README.md
- Adds dependabot stanzas for that branch to keep it up to date so that `prio 0.17` can be used in downstreams.

We expect to swiftly deprecate this branch as we expect our deployments to skip ahead to draft-irtf-cfrg-vdaf-15.