### PR TITLE
bump MSRV to 1.83

### DIFF
--- a/.github/workflows/ci-build.yml
+++ b/.github/workflows/ci-build.yml
@@ -29,7 +29,7 @@ jobs:
         rust-toolchain: [
           {
             # MSRV from Cargo.toml
-            version: "1.80",
+            version: "1.83",
             label: "MSRV",
           },
           {
@@ -57,7 +57,7 @@ jobs:
         rust-toolchain: [
           {
             # MSRV from Cargo.toml
-            version: "1.80",
+            version: "1.83",
             label: "MSRV",
           },
           {

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,7 +7,7 @@ exclude = ["/supply-chain"]
 description = "Implementation of the Prio aggregation system core: https://crypto.stanford.edu/prio/"
 license = "MPL-2.0 AND Apache-2.0"
 repository = "https://github.com/divviup/libprio-rs"
-rust-version = "1.80"
+rust-version = "1.83"
 resolver = "2"
 
 [dependencies]


### PR DESCRIPTION
Some of our dependencies have moved to Rust 1.83 so we are bumping our MSRV to match.