### PR TITLE
Add safeguard to bump-version job

### DIFF
--- a/.github/workflows/make-release.yml
+++ b/.github/workflows/make-release.yml
@@ -32,7 +32,7 @@ jobs:
         run: |
           cargo metadata --no-deps --format-version 1 | \
           jq -r '.packages | .[] | select(.name == "prio") | .version' | \
-          grep '^[0-9.]\+$'
+          grep '^\(0\|[1-9][0-9]*\)\.\(0\|[1-9][0-9]*\)\.\(0\|[1-9][0-9]*\)$'
 
       - name: Install Rust toolchain
         uses: dtolnay/rust-toolchain@stable


### PR DESCRIPTION
This adds a check that the current version is not a pre-release version before bumping the version.