### PR TITLE
Fix Clippy lints

### DIFF
--- a/src/dp/distributions.rs
+++ b/src/dp/distributions.rs
@@ -619,8 +619,7 @@ mod tests {
             let var = (p * p) as f64;
             assert!(
                 test_mean(sampler, mean, var, 0.00001, 1000),
-                "Empirical evaluation of discrete Gaussian({:?}) sampler mean failed.",
-                p
+                "Empirical evaluation of discrete Gaussian({p:?}) sampler mean failed."
             );
         });
         // we only do chi square for std 100 because it's expensive
@@ -645,8 +644,7 @@ mod tests {
             let var = mean * (1. - mean);
             assert!(
                 test_mean(sampler, mean, var, 0.00001, 1000),
-                "Empirical evaluation of the Bernoulli(1/{:?}) distribution mean failed",
-                p
+                "Empirical evaluation of the Bernoulli(1/{p:?}) distribution mean failed"
             );
         })
     }
@@ -668,8 +666,7 @@ mod tests {
             let var = (1. - p_prob) / p_prob.powi(2);
             assert!(
                 test_mean(sampler, mean, var, 0.0001, 1000),
-                "Empirical evaluation of the Geometric(1-exp(-1/{:?})) distribution mean failed",
-                p
+                "Empirical evaluation of the Geometric(1-exp(-1/{p:?})) distribution mean failed"
             );
         })
     }
@@ -688,8 +685,7 @@ mod tests {
             let var = (1. / *p as f64).powi(2);
             assert!(
                 test_mean(sampler, mean, var, 0.0001, 1000),
-                "Empirical evaluation of the Laplace(0,1/{:?}) distribution mean failed",
-                p
+                "Empirical evaluation of the Laplace(0,1/{p:?}) distribution mean failed"
             );
         })
     }

--- a/src/flp.rs
+++ b/src/flp.rs
@@ -969,8 +969,7 @@ pub mod test_utils {
                     .unwrap();
                 assert!(
                     !self.flp.decide(&verifier).unwrap(),
-                    "{name}: proof mutant {} deemed valid",
-                    i
+                    "{name}: proof mutant {i} deemed valid"
                 );
             }
 

--- a/src/vidpf.rs
+++ b/src/vidpf.rs
@@ -1043,9 +1043,7 @@ mod tests {
             assert_eq!(
                 (a.clone() + b.clone()) + (a.clone() - b.clone()),
                 c,
-                "a: {:?} b:{:?}",
-                a,
-                b
+                "a: {a:?} b:{b:?}"
             );
         }
 
@@ -1058,7 +1056,7 @@ mod tests {
             d.conditional_negate(Choice::from(1));
             let zero = TestWeight::zero(&TEST_WEIGHT_LEN);
 
-            assert_eq!(c + d, zero, "a: {:?}", a);
+            assert_eq!(c + d, zero, "a: {a:?}");
         }
 
         #[test]


### PR DESCRIPTION
This fixes some new Clippy lints that show up with a 1.88 toolchain.