### PR TITLE
Prio2: Use iterative NTT implementation

### DIFF
--- a/src/benchmarked.rs
+++ b/src/benchmarked.rs
@@ -8,20 +8,6 @@
 use crate::field::NttFriendlyFieldElement;
 use crate::flp::gadgets::Mul;
 use crate::flp::FlpError;
-use crate::ntt::ntt;
-use crate::polynomial::{ntt_get_roots, poly_ntt, PolyNttTempMemory};
-
-/// Runs NTT on `outp` using the iterative algorithm.
-pub fn benchmarked_iterative_ntt<F: NttFriendlyFieldElement>(outp: &mut [F], inp: &[F]) {
-    ntt(outp, inp, inp.len()).unwrap();
-}
-
-/// Runs NTT on `outp` using the recursive algorithm.
-pub fn benchmarked_recursive_ntt<F: NttFriendlyFieldElement>(outp: &mut [F], inp: &[F]) {
-    let roots_2n = ntt_get_roots(inp.len(), false);
-    let mut ntt_memory = PolyNttTempMemory::new(inp.len());
-    poly_ntt(outp, inp, &roots_2n, inp.len(), false, &mut ntt_memory)
-}
 
 /// Sets `outp` to `inp[0] * inp[1]`, where `inp[0]` and `inp[1]` are polynomials. This function
 /// uses NTT for multiplication.

--- a/src/ntt.rs
+++ b/src/ntt.rs
@@ -88,7 +88,7 @@ pub fn ntt<F: NttFriendlyFieldElement>(
 }
 
 /// Sets `outp` to the inverse of the DFT of `inp`.
-#[cfg(test)]
+#[cfg(any(test, all(feature = "crypto-dependencies", feature = "experimental")))]
 pub(crate) fn ntt_inv<F: NttFriendlyFieldElement>(
     outp: &mut [F],
     inp: &[F],

--- a/src/polynomial.rs
+++ b/src/polynomial.rs
@@ -10,13 +10,15 @@ use crate::ntt::{ntt, ntt_inv_finish};
 use std::convert::TryFrom;
 
 /// Temporary memory used for NTT
+#[cfg(test)]
 #[derive(Clone, Debug)]
-pub struct PolyNttTempMemory<F> {
+pub(crate) struct PolyNttTempMemory<F> {
     ntt_tmp: Vec<F>,
     ntt_y_sub: Vec<F>,
     ntt_roots_sub: Vec<F>,
 }
 
+#[cfg(test)]
 impl<F: NttFriendlyFieldElement> PolyNttTempMemory<F> {
     pub(crate) fn new(length: usize) -> Self {
         PolyNttTempMemory {
@@ -46,6 +48,7 @@ impl<F: NttFriendlyFieldElement> TestPolyAuxMemory<F> {
     }
 }
 
+#[cfg(test)]
 fn ntt_recurse<F: NttFriendlyFieldElement>(
     out: &mut [F],
     n: usize,
@@ -104,6 +107,7 @@ fn ntt_recurse<F: NttFriendlyFieldElement>(
 }
 
 /// Calculate `count` number of roots of unity of order `count`
+#[cfg(test)]
 pub(crate) fn ntt_get_roots<F: NttFriendlyFieldElement>(count: usize, invert: bool) -> Vec<F> {
     let mut roots = vec![F::zero(); count];
     let mut gen = F::generator();
@@ -125,6 +129,7 @@ pub(crate) fn ntt_get_roots<F: NttFriendlyFieldElement>(count: usize, invert: bo
     roots
 }
 
+#[cfg(test)]
 fn ntt_interpolate_raw<F: NttFriendlyFieldElement>(
     out: &mut [F],
     ys: &[F],
@@ -150,7 +155,8 @@ fn ntt_interpolate_raw<F: NttFriendlyFieldElement>(
     }
 }
 
-pub fn poly_ntt<F: NttFriendlyFieldElement>(
+#[cfg(test)]
+pub(crate) fn poly_ntt<F: NttFriendlyFieldElement>(
     points_out: &mut [F],
     points_in: &[F],
     scaled_roots: &[F],

--- a/src/vdaf/prio2.rs
+++ b/src/vdaf/prio2.rs
@@ -160,7 +160,9 @@ impl Client<16> for Prio2 {
         let copy_data = |share_data: &mut [FieldPrio2]| {
             share_data[..].clone_from_slice(&input);
         };
-        let mut leader_data = mem.prove_with(self.input_len, copy_data);
+        let mut leader_data = mem
+            .prove_with(self.input_len, copy_data)
+            .map_err(|e| VdafError::Other(Box::new(e)))?;
 
         let helper_seed = rng.random();
         let helper_prng = Prng::from_prio2_seed(&helper_seed);


### PR DESCRIPTION
This changes the Prio2 sharding routine to use the iterative NTT implementation, instead of the recursive NTT implementation. Thus, recursive NTT-related functions and structures are only needed in tests now.

<details><summary>Benchmark results</summary>

```
prio2_shard/10          time:   [7.7098 µs 7.7146 µs 7.7201 µs]
                        change: [−41.319% −40.991% −40.537%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 16 outliers among 100 measurements (16.00%)
  2 (2.00%) high mild
  14 (14.00%) high severe
prio2_shard/100         time:   [49.456 µs 49.474 µs 49.503 µs]
                        change: [−45.729% −45.678% −45.632%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 6 outliers among 100 measurements (6.00%)
  3 (3.00%) high mild
  3 (3.00%) high severe
prio2_shard/1000        time:   [482.02 µs 482.05 µs 482.09 µs]
                        change: [−46.526% −46.478% −46.440%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 6 outliers among 100 measurements (6.00%)
  2 (2.00%) high mild
  4 (4.00%) high severe

prio2_prepare_init/10   time:   [7.7907 µs 7.7926 µs 7.7949 µs]
                        change: [+0.0542% +0.1420% +0.2525%] (p = 0.00 < 0.05)
                        Change within noise threshold.
Found 21 outliers among 100 measurements (21.00%)
  3 (3.00%) high mild
  18 (18.00%) high severe
prio2_prepare_init/100  time:   [42.487 µs 42.499 µs 42.512 µs]
                        change: [+0.0357% +0.0998% +0.1550%] (p = 0.00 < 0.05)
                        Change within noise threshold.
Found 9 outliers among 100 measurements (9.00%)
  7 (7.00%) high mild
  2 (2.00%) high severe
prio2_prepare_init/1000 time:   [381.75 µs 381.82 µs 381.93 µs]
                        change: [+0.2598% +1.1420% +2.6434%] (p = 0.01 < 0.05)
                        Change within noise threshold.
Found 14 outliers among 100 measurements (14.00%)
  2 (2.00%) high mild
  12 (12.00%) high severe
```

</details>