### PR TITLE
Fix mismatched lifetime syntaxes lints, 0.17 backport

### DIFF
--- a/src/vdaf/prio2/client.rs
+++ b/src/vdaf/prio2/client.rs
@@ -138,7 +138,7 @@ pub(crate) struct UnpackedProofMut<'a, F: NttFriendlyFieldElement> {
 pub(crate) fn unpack_proof<F: NttFriendlyFieldElement>(
     proof: &[F],
     dimension: usize,
-) -> Result<UnpackedProof<F>, SerializeError> {
+) -> Result<UnpackedProof<'_, F>, SerializeError> {
     // check the proof length
     if proof.len() != proof_length(dimension) {
         return Err(SerializeError::UnpackInputSizeMismatch);
@@ -162,7 +162,7 @@ pub(crate) fn unpack_proof<F: NttFriendlyFieldElement>(
 pub(crate) fn unpack_proof_mut<F: NttFriendlyFieldElement>(
     proof: &mut [F],
     dimension: usize,
-) -> Result<UnpackedProofMut<F>, SerializeError> {
+) -> Result<UnpackedProofMut<'_, F>, SerializeError> {
     // check the share length
     if proof.len() != proof_length(dimension) {
         return Err(SerializeError::UnpackInputSizeMismatch);


### PR DESCRIPTION
This is a backport of #1307.