### PR TITLE
prepare to release `prio` 0.18.x to crates.io

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -23,16 +23,3 @@ updates:
     schedule:
       interval: "weekly"
     target-branch: release/0.16
-
-  - package-ecosystem: "cargo"
-    directory: "/"
-    schedule:
-      interval: "weekly"
-    target-branch: release/0.17
-    open-pull-requests-limit: 20
-
-  - package-ecosystem: "github-actions"
-    directory: "/"
-    schedule:
-      interval: "weekly"
-    target-branch: release/0.17

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -609,7 +609,7 @@ checksum = "eb9f9e6e233e5c4a35559a617bf40a4ec447db2e84c20b55a6f83167b7e57872"
 
 [[package]]
 name = "prio"
-version = "0.18.1"
+version = "0.18.1-alpha.1"
 dependencies = [
  "aes",
  "assert_matches",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -609,7 +609,7 @@ checksum = "eb9f9e6e233e5c4a35559a617bf40a4ec447db2e84c20b55a6f83167b7e57872"
 
 [[package]]
 name = "prio"
-version = "0.18.1-alpha.0"
+version = "0.18.1"
 dependencies = [
  "aes",
  "assert_matches",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -609,7 +609,7 @@ checksum = "eb9f9e6e233e5c4a35559a617bf40a4ec447db2e84c20b55a6f83167b7e57872"
 
 [[package]]
 name = "prio"
-version = "0.18.1-alpha.1"
+version = "0.18.1-alpha.2"
 dependencies = [
  "aes",
  "assert_matches",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "prio"
-version = "0.18.1"
+version = "0.18.1-alpha.1"
 authors = ["Josh Aas <jaas@kflag.net>", "Tim Geoghegan <timg@letsencrypt.org>", "Christopher Patton <cpatton@cloudflare.com", "Karl Tarbe <tarbe@apple.com>"]
 edition = "2021"
 exclude = ["/supply-chain"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "prio"
-version = "0.18.1-alpha.1"
+version = "0.18.1-alpha.2"
 authors = ["Josh Aas <jaas@kflag.net>", "Tim Geoghegan <timg@letsencrypt.org>", "Christopher Patton <cpatton@cloudflare.com", "Karl Tarbe <tarbe@apple.com>"]
 edition = "2021"
 exclude = ["/supply-chain"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "prio"
-version = "0.18.1-alpha.0"
+version = "0.18.1"
 authors = ["Josh Aas <jaas@kflag.net>", "Tim Geoghegan <timg@letsencrypt.org>", "Christopher Patton <cpatton@cloudflare.com", "Karl Tarbe <tarbe@apple.com>"]
 edition = "2021"
 exclude = ["/supply-chain"]

--- a/README.md
+++ b/README.md
@@ -43,8 +43,8 @@ increases (e.g., 0.10 to 0.11).
 | 0.14 | `release/0.14` | [`draft-irtf-cfrg-vdaf-06`][vdaf-06] | [`draft-ietf-ppm-dap-05`][dap-05] | Yes | Unmaintained |
 | 0.15 | `release/0.15` | [`draft-irtf-cfrg-vdaf-07`][vdaf-07] | [`draft-ietf-ppm-dap-07`][dap-07] | Yes | Unmaintained as of June 24, 2024 |
 | 0.16 | `release/0.16` | [`draft-irtf-cfrg-vdaf-08`][vdaf-08] | [`draft-ietf-ppm-dap-09`][dap-09] | Yes | Supported |
-| 0.17 | `release/0.17` | [`draft-irtf-cfrg-vdaf-13`][vdaf-13] | [`draft-ietf-ppm-dap-13`][dap-13] | Yes | Supported |
-| 0.18 | `main` | [`draft-irtf-cfrg-vdaf-15`][vdaf-15] | `draft-ietf-ppm-dap-16` (forthcoming) | [No](https://github.com/divviup/libprio-rs/issues/1266) | Supported |
+| 0.17 | `release/0.17` | [`draft-irtf-cfrg-vdaf-13`][vdaf-13] | [`draft-ietf-ppm-dap-13`][dap-13] | Yes | Unmaintained as of August 28, 2025 |
+| 0.18 | `main` | `draft-irtf-cfrg-vdaf-16` (forthcoming) | `draft-ietf-ppm-dap-16` (forthcoming) | Yes | Supported |
 
 [vdaf-01]: https://datatracker.ietf.org/doc/draft-irtf-cfrg-vdaf/01/
 [vdaf-03]: https://datatracker.ietf.org/doc/draft-irtf-cfrg-vdaf/03/
@@ -54,7 +54,6 @@ increases (e.g., 0.10 to 0.11).
 [vdaf-07]: https://datatracker.ietf.org/doc/draft-irtf-cfrg-vdaf/07/
 [vdaf-08]: https://datatracker.ietf.org/doc/draft-irtf-cfrg-vdaf/08/
 [vdaf-13]: https://datatracker.ietf.org/doc/draft-irtf-cfrg-vdaf/13/
-[vdaf-15]: https://datatracker.ietf.org/doc/draft-irtf-cfrg-vdaf/15/
 [dap-01]: https://datatracker.ietf.org/doc/draft-ietf-ppm-dap/01/
 [dap-02]: https://datatracker.ietf.org/doc/draft-ietf-ppm-dap/02/
 [dap-03]: https://datatracker.ietf.org/doc/draft-ietf-ppm-dap/03/


### PR DESCRIPTION
- updated supported draft versions in README.md
- drop support for `release/0.17` branch (no more dependabot updates)
- set crate version to 0.18.1-alpha.2 (I burned .1 by cutting the release before merging this PR)