### PR TITLE
make CI fail if clippy finds something

### DIFF
--- a/.github/workflows/ci-build.yml
+++ b/.github/workflows/ci-build.yml
@@ -95,9 +95,9 @@ jobs:
     - name: Check
       run: cargo check-all-features --workspace --all-targets
     - name: Clippy
-      run: cargo clippy --workspace --all-targets
+      run: cargo clippy --workspace --all-targets -- -Dwarnings
     - name: Clippy (all features)
-      run: cargo clippy --workspace --all-targets --all-features
+      run: cargo clippy --workspace --all-targets --all-features -- -Dwarnings
     - name: Build crate
       run: cargo build-all-features --verbose --package prio
     - name: Run tests


### PR DESCRIPTION
Run `clippy` with `-Dwarnings` so that the process exits non-zero if it finds a lint, which will cause GitHub to fail the build.