### PR TITLE
Fix documentation on type aliases

### DIFF
--- a/src/vdaf/prio3.rs
+++ b/src/vdaf/prio3.rs
@@ -148,7 +148,7 @@ impl Prio3SumVecMultithreaded {
     }
 }
 
-/// The sum type. Each measurement is an integer in `[0,2^bits)` for some `0 < bits < 64` and the
+/// The sum type. Each measurement is an integer in `[0, max_measurement]` and the
 /// aggregate is the sum.
 pub type Prio3Sum = Prio3<Sum<Field64>, XofTurboShake128, 32>;
 
@@ -344,7 +344,7 @@ impl Prio3MultihotCountVecMultithreaded {
     }
 }
 
-/// The average type. Each measurement is an integer in `[0,2^bits)` for some `0 < bits < 64` and
+/// The average type. Each measurement is an integer in `[0, max_measurement]` and
 /// the aggregate is the arithmetic average.
 pub type Prio3Average = Prio3<Average<Field128>, XofTurboShake128, 32>;
 


### PR DESCRIPTION
I noticed while working on #1349 that we have outdated information in the documentation of a couple type aliases. This PR updates them to reflect the parameters of the respective constructors.