### PR TITLE
Use crates.io trusted publishing, 0.16 backport

### DIFF
--- a/.github/workflows/publish-crate.yml
+++ b/.github/workflows/publish-crate.yml
@@ -7,6 +7,9 @@ on:
 jobs:
   crate:
     runs-on: ubuntu-latest
+    environment: release
+    permissions:
+      id-token: write
     steps:
     - uses: actions/checkout@v5
     - name: Install Rust toolchain
@@ -14,6 +17,8 @@ jobs:
       with:
         toolchain: stable
         override: true
+    - id: auth
+      uses: rust-lang/crates-io-auth-action@v1
     - run: cargo publish
       env:
-        CARGO_REGISTRY_TOKEN: ${{ secrets.DIVVIUP_GITHUB_AUTOMATION_CRATES_IO_API_TOKEN }}
+        CARGO_REGISTRY_TOKEN: ${{ steps.auth.outputs.token }}


### PR DESCRIPTION
This backports #1356 to our one active release branch.