### PR TITLE
Bump MSRV to 1.86

### DIFF
--- a/.github/workflows/ci-build.yml
+++ b/.github/workflows/ci-build.yml
@@ -29,7 +29,7 @@ jobs:
         rust-toolchain: [
           {
             # MSRV from Cargo.toml
-            version: "1.83",
+            version: "1.86",
             label: "MSRV",
           },
           {
@@ -57,7 +57,7 @@ jobs:
         rust-toolchain: [
           {
             # MSRV from Cargo.toml
-            version: "1.83",
+            version: "1.86",
             label: "MSRV",
           },
           {

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,7 +7,7 @@ exclude = ["/supply-chain"]
 description = "Implementation of the Prio aggregation system core: https://crypto.stanford.edu/prio/"
 license = "MPL-2.0 AND Apache-2.0 AND MIT"
 repository = "https://github.com/divviup/libprio-rs"
-rust-version = "1.83"
+rust-version = "1.86"
 resolver = "2"
 
 [dependencies]


### PR DESCRIPTION
This bumps the MSRV so that we can upgrade to criterion 0.8 in #1362. This version is currently about 8 months old.