### PR TITLE
Ignore renewing wildcard audit

### DIFF
--- a/supply-chain/audits.toml
+++ b/supply-chain/audits.toml
@@ -646,6 +646,11 @@ who = "David Cook <dcook@divviup.org>"
 criteria = "safe-to-deploy"
 version = "0.3.0"
 
+[[audits.prio]]
+who = "David Cook <dcook@divviup.org>"
+criteria = "safe-to-deploy"
+version = "0.16.8"
+
 [[audits.proc-macro-error-attr]]
 who = "David Cook <dcook@divviup.org>"
 criteria = "safe-to-run"


### PR DESCRIPTION
As noted in #1365, we are no longer publishing to crates.io with our existing automation user. Thus, we can discontinue renewing the corresponding wildcard audit. This PR also adds a separate audit of `prio` version 0.16.8, in order to fill in first-party audits until we can publish a new wildcard audit for our publishing workflow.