### PR TITLE
Add wildcard audit for trusted publishing

### DIFF
--- a/supply-chain/audits.toml
+++ b/supply-chain/audits.toml
@@ -17,6 +17,13 @@ start = "2020-09-28"
 end = "2026-01-07"
 renew = false
 
+[[wildcard-audits.prio]]
+who = "David Cook <dcook@divviup.org>"
+criteria = "safe-to-deploy"
+trusted-publisher = "github:divviup/libprio-rs"
+start = "2025-11-03"
+end = "2027-02-09"
+
 [[audits.aes]]
 who = "Brandon Pitman <bran@bran.land>"
 criteria = "safe-to-deploy"


### PR DESCRIPTION
This adds a wildcard audit for `prio` versions published by our GitHub Actions workflows using trusted publishing. Closes #1365. We updated cargo-vet in #1378 to a version that supports trusted publishing.

```sh
cargo vet certify prio --wildcard github:divviup/libprio-rs --force
```