### PR TITLE
Update links and references to VDAF specification

### DIFF
--- a/src/flp.rs
+++ b/src/flp.rs
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: MPL-2.0
 
 //! Implementation of the generic Fully Linear Proof (FLP) system specified in
-//! [[draft-irtf-cfrg-vdaf-08]]. This is the main building block of [`Prio3`](crate::vdaf::prio3).
+//! [[draft-irtf-cfrg-vdaf-18]]. This is the main building block of [`Prio3`](crate::vdaf::prio3).
 //!
 //! The FLP is derived for any implementation of the [`Flp`] trait. Such an implementation
 //! specifies a validity circuit that defines the set of valid measurements, as well as the finite
@@ -44,7 +44,7 @@
 //! assert!(count.decide(&verifier).unwrap());
 //! ```
 //!
-//! [draft-irtf-cfrg-vdaf-08]: https://datatracker.ietf.org/doc/draft-irtf-cfrg-vdaf/08/
+//! [draft-irtf-cfrg-vdaf-18]: https://datatracker.ietf.org/doc/draft-irtf-cfrg-vdaf/18/
 
 use crate::dp::DifferentialPrivacyStrategy;
 use crate::field::{FieldElement, FieldElementWithInteger, FieldError, NttFriendlyFieldElement};

--- a/src/idpf.rs
+++ b/src/idpf.rs
@@ -1,7 +1,7 @@
 //! This module implements the incremental distributed point function (IDPF) described in
-//! [[draft-irtf-cfrg-vdaf-08]].
+//! [[draft-irtf-cfrg-vdaf-18]].
 //!
-//! [draft-irtf-cfrg-vdaf-08]: https://datatracker.ietf.org/doc/draft-irtf-cfrg-vdaf/08/
+//! [draft-irtf-cfrg-vdaf-18]: https://datatracker.ietf.org/doc/draft-irtf-cfrg-vdaf/18/
 
 use crate::{
     codec::{CodecError, Decode, Encode, ParameterizedDecode},
@@ -684,7 +684,7 @@ where
     VL: Encode,
 {
     fn encode(&self, bytes: &mut Vec<u8>) -> Result<(), CodecError> {
-        // draft-irtf-cfrg-vdaf-13, Section 8.2.6.1:
+        // draft-irtf-cfrg-vdaf-18, Section 8.2.6.1:
         //
         // struct {
         //     opaque packed_control_bits[packed_len];

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -12,7 +12,7 @@
 //! Prio3 is available in the `vdaf` module as part of an implementation of [Verifiable Distributed
 //! Aggregation Functions][vdaf], along with an experimental implementation of Poplar1.
 //!
-//! [vdaf]: https://datatracker.ietf.org/doc/draft-irtf-cfrg-vdaf/05/
+//! [vdaf]: https://datatracker.ietf.org/doc/draft-irtf-cfrg-vdaf/18/
 
 pub mod codec;
 pub mod dp;

--- a/src/topology/mod.rs
+++ b/src/topology/mod.rs
@@ -2,6 +2,6 @@
 
 //! Implementations of some aggregator communication topologies specified in [VDAF].
 //!
-//! [VDAF]: https://datatracker.ietf.org/doc/html/draft-irtf-cfrg-vdaf-06#section-5.7
+//! [VDAF]: https://datatracker.ietf.org/doc/html/draft-irtf-cfrg-vdaf-18#section-5.7
 
 pub mod ping_pong;

--- a/src/topology/ping_pong.rs
+++ b/src/topology/ping_pong.rs
@@ -4,7 +4,7 @@
 //! two aggregators, designated "Leader" and "Helper". This topology is required for implementing
 //! the [Distributed Aggregation Protocol][DAP].
 //!
-//! [VDAF]: https://datatracker.ietf.org/doc/html/draft-irtf-cfrg-vdaf-15#section-5.7.1
+//! [VDAF]: https://datatracker.ietf.org/doc/html/draft-irtf-cfrg-vdaf-18#section-5.7.1
 //! [DAP]: https://datatracker.ietf.org/doc/html/draft-ietf-ppm-dap
 
 use crate::{
@@ -51,7 +51,7 @@ pub enum PingPongError {
 /// variants are opaque byte buffers. This is because the ping-pong routines take responsibility for
 /// decoding verifier shares and messages, which usually requires having the verifier state.
 ///
-/// [VDAF]: https://datatracker.ietf.org/doc/html/draft-irtf-cfrg-vdaf-15#section-5.7.1
+/// [VDAF]: https://datatracker.ietf.org/doc/html/draft-irtf-cfrg-vdaf-18#section-5.7.1
 #[derive(Clone, PartialEq, Eq)]
 pub enum PingPongMessage {
     /// Corresponds to MessageType.initialize.
@@ -158,7 +158,7 @@ impl Decode for PingPongMessage {
 }
 
 /// A continuation of a state transition in the pong-pong topology. This mostly corresponds to the
-/// `ping_pong_continue` and `ping_pong_transition` functions defined in [VDAF].
+/// `ping_pong_continued` and `ping_pong_transition` functions defined in [VDAF].
 ///
 /// # Discussion
 ///
@@ -191,7 +191,7 @@ impl Decode for PingPongMessage {
 /// and `FinishedWithOutbound`, but because we need this to also yield `Finished` in some cases, it
 /// also captures parts of `ping_pong_continued`.
 ///
-/// [VDAF]: https://datatracker.ietf.org/doc/html/draft-irtf-cfrg-vdaf-15#section-5.7.1
+/// [VDAF]: https://datatracker.ietf.org/doc/html/draft-irtf-cfrg-vdaf-18#section-5.7.1
 /// [sizes]: https://github.com/divviup/libprio-rs/pull/683/#issuecomment-1687210371
 #[derive(Clone)]
 pub struct PingPongContinuation<
@@ -415,7 +415,7 @@ enum PingPongContinuationInner<
 /// peer as input to the appropriate `PingPongTopology::{leader,helper}_continued` function to
 /// advance to the next round.
 ///
-/// [VDAF]: https://datatracker.ietf.org/doc/html/draft-irtf-cfrg-vdaf-15#section-5.7.1
+/// [VDAF]: https://datatracker.ietf.org/doc/html/draft-irtf-cfrg-vdaf-18#section-5.7.1
 #[derive(Clone, Debug, PartialEq, Eq)]
 pub struct Continued<S> {
     /// A message for the peer aggregator.
@@ -429,7 +429,7 @@ pub struct Continued<S> {
 /// code, and the `Rejected` state is represented as `std::result::Result::Err`, so this enum does
 /// not include those variants.
 ///
-/// [VDAF]: https://datatracker.ietf.org/doc/html/draft-irtf-cfrg-vdaf-15#section-5.7.1
+/// [VDAF]: https://datatracker.ietf.org/doc/html/draft-irtf-cfrg-vdaf-18#section-5.7.1
 #[derive(Clone, Debug, PartialEq, Eq)]
 pub enum PingPongState<P, O> {
     /// Verification of the report will continue.
@@ -443,7 +443,7 @@ pub enum PingPongState<P, O> {
     ///
     /// The `output_share` may be accumulated by the aggregator.
     ///
-    /// [VDAF]: https://datatracker.ietf.org/doc/html/draft-irtf-cfrg-vdaf-15#section-5.7.1
+    /// [VDAF]: https://datatracker.ietf.org/doc/html/draft-irtf-cfrg-vdaf-18#section-5.7.1
     FinishedWithOutbound {
         /// The output share this aggregator verified.
         output_share: O,
@@ -457,7 +457,7 @@ pub enum PingPongState<P, O> {
     /// The `output_share` may be accumulated by the aggregator. No message need be transmitted to
     /// the peer, which has already finished verifying the report.
     ///
-    /// [VDAF]: https://datatracker.ietf.org/doc/html/draft-irtf-cfrg-vdaf-15#section-5.7.1
+    /// [VDAF]: https://datatracker.ietf.org/doc/html/draft-irtf-cfrg-vdaf-18#section-5.7.1
     Finished {
         /// The output share this aggregator verified.
         output_share: O,
@@ -466,7 +466,7 @@ pub enum PingPongState<P, O> {
 
 /// Extension trait on [`crate::vdaf::Aggregator`] which adds the [VDAF Ping-Pong Topology][VDAF].
 ///
-/// [VDAF]: https://datatracker.ietf.org/doc/html/draft-irtf-cfrg-vdaf-15#section-5.7.1
+/// [VDAF]: https://datatracker.ietf.org/doc/html/draft-irtf-cfrg-vdaf-18#section-5.7.1
 pub trait PingPongTopology<const VERIFY_KEY_SIZE: usize, const NONCE_SIZE: usize>:
     Aggregator<VERIFY_KEY_SIZE, NONCE_SIZE>
 {
@@ -483,7 +483,7 @@ pub trait PingPongTopology<const VERIFY_KEY_SIZE: usize, const NONCE_SIZE: usize
     /// according to that item's documentation. On failure, the leader has transitioned to the
     /// `Rejected` state.
     ///
-    /// [VDAF]: https://datatracker.ietf.org/doc/html/draft-irtf-cfrg-vdaf-15#section-5.7.1
+    /// [VDAF]: https://datatracker.ietf.org/doc/html/draft-irtf-cfrg-vdaf-18#section-5.7.1
     fn leader_initialized(
         &self,
         verify_key: &[u8; VERIFY_KEY_SIZE],
@@ -506,7 +506,7 @@ pub trait PingPongTopology<const VERIFY_KEY_SIZE: usize, const NONCE_SIZE: usize
     ///
     /// `leader_message` must be `PingPongMessage::Initialize` or the function will fail.
     ///
-    /// [VDAF]: https://datatracker.ietf.org/doc/html/draft-irtf-cfrg-vdaf-15#section-5.7.1
+    /// [VDAF]: https://datatracker.ietf.org/doc/html/draft-irtf-cfrg-vdaf-18#section-5.7.1
     #[allow(clippy::too_many_arguments)]
     fn helper_initialized(
         &self,
@@ -531,7 +531,7 @@ pub trait PingPongTopology<const VERIFY_KEY_SIZE: usize, const NONCE_SIZE: usize
     ///
     /// `helper_message` must not be `PingPongMessage::Initialize` or the function will fail.
     ///
-    /// [VDAF]: https://datatracker.ietf.org/doc/html/draft-irtf-cfrg-vdaf-15#section-5.7.1
+    /// [VDAF]: https://datatracker.ietf.org/doc/html/draft-irtf-cfrg-vdaf-18#section-5.7.1
     fn leader_continued(
         &self,
         ctx: &[u8],
@@ -552,7 +552,7 @@ pub trait PingPongTopology<const VERIFY_KEY_SIZE: usize, const NONCE_SIZE: usize
     ///
     /// `leader_message` must not be `PingPongMessage::Initialize` or the function will fail.
     ///
-    /// [VDAF]: https://datatracker.ietf.org/doc/html/draft-irtf-cfrg-vdaf-15#section-5.7.1
+    /// [VDAF]: https://datatracker.ietf.org/doc/html/draft-irtf-cfrg-vdaf-18#section-5.7.1
     fn helper_continued(
         &self,
         ctx: &[u8],

--- a/src/vdaf.rs
+++ b/src/vdaf.rs
@@ -1,9 +1,9 @@
 // SPDX-License-Identifier: MPL-2.0
 
 //! Verifiable Distributed Aggregation Functions (VDAFs) as described in
-//! [[draft-irtf-cfrg-vdaf-08]].
+//! [[draft-irtf-cfrg-vdaf-18]].
 //!
-//! [draft-irtf-cfrg-vdaf-08]: https://datatracker.ietf.org/doc/draft-irtf-cfrg-vdaf/08/
+//! [draft-irtf-cfrg-vdaf-18]: https://datatracker.ietf.org/doc/draft-irtf-cfrg-vdaf/18/
 
 use crate::dp::DifferentialPrivacyStrategy;
 #[cfg(all(feature = "crypto-dependencies", feature = "experimental"))]
@@ -190,7 +190,7 @@ pub trait Client<const NONCE_SIZE: usize>: Vdaf {
     ///
     /// Implements `Vdaf::shard` from [VDAF].
     ///
-    /// [VDAF]: https://datatracker.ietf.org/doc/html/draft-irtf-cfrg-vdaf-13#section-5.1
+    /// [VDAF]: https://datatracker.ietf.org/doc/html/draft-irtf-cfrg-vdaf-18#section-5.1
     fn shard(
         &self,
         ctx: &[u8],
@@ -223,7 +223,7 @@ pub trait Aggregator<const VERIFY_KEY_SIZE: usize, const NONCE_SIZE: usize>: Vda
     ///
     /// Implements `Vdaf.verify_init` from [VDAF].
     ///
-    /// [VDAF]: https://datatracker.ietf.org/doc/html/draft-irtf-cfrg-vdaf-08#section-5.2
+    /// [VDAF]: https://datatracker.ietf.org/doc/html/draft-irtf-cfrg-vdaf-18#section-5.2
     #[allow(clippy::too_many_arguments)]
     fn verify_init(
         &self,
@@ -240,7 +240,7 @@ pub trait Aggregator<const VERIFY_KEY_SIZE: usize, const NONCE_SIZE: usize>: Vda
     ///
     /// Implements `Vdaf.verifier_shares_to_message` from [VDAF].
     ///
-    /// [VDAF]: https://datatracker.ietf.org/doc/html/draft-irtf-cfrg-vdaf-08#section-5.2
+    /// [VDAF]: https://datatracker.ietf.org/doc/html/draft-irtf-cfrg-vdaf-18#section-5.2
     fn verifier_shares_to_message<M: IntoIterator<Item = Self::VerifierShare>>(
         &self,
         ctx: &[u8],
@@ -258,7 +258,7 @@ pub trait Aggregator<const VERIFY_KEY_SIZE: usize, const NONCE_SIZE: usize>: Vda
     ///
     /// Implements `Vdaf.verify_next` from [VDAF].
     ///
-    /// [VDAF]: https://datatracker.ietf.org/doc/html/draft-irtf-cfrg-vdaf-08#section-5.2
+    /// [VDAF]: https://datatracker.ietf.org/doc/html/draft-irtf-cfrg-vdaf-18#section-5.2
     fn verify_next(
         &self,
         ctx: &[u8],

--- a/src/vdaf/dummy.rs
+++ b/src/vdaf/dummy.rs
@@ -1,9 +1,9 @@
 // SPDX-License-Identifier: MPL-2.0
 
-//! Implementation of a dummy VDAF which conforms to the specification in [draft-irtf-cfrg-vdaf-06]
+//! Implementation of a dummy VDAF which conforms to the specification in [draft-irtf-cfrg-vdaf-18]
 //! but does nothing. Useful for testing.
 //!
-//! [draft-irtf-cfrg-vdaf-06]: https://datatracker.ietf.org/doc/draft-irtf-cfrg-vdaf/06/
+//! [draft-irtf-cfrg-vdaf-18]: https://datatracker.ietf.org/doc/draft-irtf-cfrg-vdaf/18/
 
 use crate::{
     codec::{CodecError, Decode, Encode},

--- a/src/vdaf/poplar1.rs
+++ b/src/vdaf/poplar1.rs
@@ -1,8 +1,8 @@
 // SPDX-License-Identifier: MPL-2.0
 
-//! Implementation of Poplar1 as specified in [[draft-irtf-cfrg-vdaf-08]].
+//! Implementation of Poplar1 as specified in [[draft-irtf-cfrg-vdaf-18]].
 //!
-//! [draft-irtf-cfrg-vdaf-08]: https://datatracker.ietf.org/doc/draft-irtf-cfrg-vdaf/08/
+//! [draft-irtf-cfrg-vdaf-18]: https://datatracker.ietf.org/doc/draft-irtf-cfrg-vdaf/18/
 
 use crate::{
     codec::{CodecError, Decode, Encode, ParameterizedDecode},
@@ -34,9 +34,9 @@ const DST_VERIFY_RANDOMNESS: u16 = 4;
 
 impl<P, const SEED_SIZE: usize> Poplar1<P, SEED_SIZE> {
     /// Create an instance of [`Poplar1`]. The caller provides the bit length of each
-    /// measurement (`BITS` as defined in [[draft-irtf-cfrg-vdaf-08]]).
+    /// measurement (`BITS` as defined in [[draft-irtf-cfrg-vdaf-18]]).
     ///
-    /// [draft-irtf-cfrg-vdaf-08]: https://datatracker.ietf.org/doc/draft-irtf-cfrg-vdaf/08/
+    /// [draft-irtf-cfrg-vdaf-18]: https://datatracker.ietf.org/doc/draft-irtf-cfrg-vdaf/18/
     pub fn new(bits: usize) -> Self {
         Self {
             bits,
@@ -47,9 +47,9 @@ impl<P, const SEED_SIZE: usize> Poplar1<P, SEED_SIZE> {
 
 impl Poplar1<XofTurboShake128, 32> {
     /// Create an instance of [`Poplar1`] using [`XofTurboShake128`]. The caller provides the bit length of
-    /// each measurement (`BITS` as defined in [[draft-irtf-cfrg-vdaf-08]]).
+    /// each measurement (`BITS` as defined in [[draft-irtf-cfrg-vdaf-18]]).
     ///
-    /// [draft-irtf-cfrg-vdaf-08]: https://datatracker.ietf.org/doc/draft-irtf-cfrg-vdaf/08/
+    /// [draft-irtf-cfrg-vdaf-18]: https://datatracker.ietf.org/doc/draft-irtf-cfrg-vdaf/18/
     pub fn new_turboshake128(bits: usize) -> Self {
         Poplar1::new(bits)
     }
@@ -781,7 +781,7 @@ impl Poplar1AggregationParam {
 
 impl Encode for Poplar1AggregationParam {
     fn encode(&self, bytes: &mut Vec<u8>) -> Result<(), CodecError> {
-        // draft-irtf-cfrg-vdaf-13, Section 8.2.6.6:
+        // draft-irtf-cfrg-vdaf-18, Section 8.2.6.6:
         //
         // struct {
         //     uint16_t level;

--- a/src/vdaf/prio3.rs
+++ b/src/vdaf/prio3.rs
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: MPL-2.0
 
-//! Implementation of the Prio3 VDAF [[draft-irtf-cfrg-vdaf-08]].
+//! Implementation of the Prio3 VDAF [[draft-irtf-cfrg-vdaf-18]].
 //!
 //! **WARNING:** This code has not undergone significant security analysis. Use at your own risk.
 //!
@@ -9,7 +9,7 @@
 //! 2019 [[BBCG+19]], that lead to substantial improvements in terms of run time and communication
 //! cost. The security of the construction was analyzed in [[DPRS23]].
 //!
-//! Prio3 is a transformation of a Fully Linear Proof (FLP) system [[draft-irtf-cfrg-vdaf-08]] into
+//! Prio3 is a transformation of a Fully Linear Proof (FLP) system [[draft-irtf-cfrg-vdaf-18]] into
 //! a VDAF. The base type, [`Prio3`], supports a wide variety of aggregation functions, some of
 //! which are instantiated here:
 //!
@@ -17,15 +17,16 @@
 //! - [`Prio3Sum`] for copmputing the sum of integers (*)
 //! - [`Prio3SumVec`] for aggregating a vector of integers
 //! - [`Prio3Histogram`] for estimating a distribution via a histogram (*)
+//! - [`Prio3MultihotCountVec`] a generalization of histograms (*)
 //!
 //! Additional types can be constructed from [`Prio3`] as needed.
 //!
-//! (*) denotes that the type is specified in [[draft-irtf-cfrg-vdaf-08]].
+//! (*) denotes that the type is specified in [[draft-irtf-cfrg-vdaf-18]].
 //!
 //! [BBCG+19]: https://ia.cr/2019/188
 //! [CGB17]: https://crypto.stanford.edu/prio/
 //! [DPRS23]: https://ia.cr/2023/130
-//! [draft-irtf-cfrg-vdaf-08]: https://datatracker.ietf.org/doc/draft-irtf-cfrg-vdaf/08/
+//! [draft-irtf-cfrg-vdaf-18]: https://datatracker.ietf.org/doc/draft-irtf-cfrg-vdaf/18/
 
 use crate::codec::{encode_fixlen_items, CodecError, Decode, Encode, ParameterizedDecode};
 use crate::dp::DifferentialPrivacyStrategy;

--- a/src/vdaf/xof.rs
+++ b/src/vdaf/xof.rs
@@ -1,8 +1,8 @@
 // SPDX-License-Identifier: MPL-2.0
 
-//! Implementations of XOFs specified in [[draft-irtf-cfrg-vdaf-08]].
+//! Implementations of XOFs specified in [[draft-irtf-cfrg-vdaf-18]].
 //!
-//! [draft-irtf-cfrg-vdaf-08]: https://datatracker.ietf.org/doc/draft-irtf-cfrg-vdaf/08/
+//! [draft-irtf-cfrg-vdaf-18]: https://datatracker.ietf.org/doc/draft-irtf-cfrg-vdaf/18/
 
 /// Value of the domain separation byte "D" used by XofTurboShake128 when invoking TurboSHAKE128.
 const XOF_TURBO_SHAKE_128_DOMAIN_SEPARATION: u8 = 1;
@@ -124,9 +124,9 @@ impl<S: Rng> IntoFieldVec for S {
     }
 }
 
-/// An extendable output function (XOF) with the interface specified in [[draft-irtf-cfrg-vdaf-08]].
+/// An extendable output function (XOF) with the interface specified in [[draft-irtf-cfrg-vdaf-18]].
 ///
-/// [draft-irtf-cfrg-vdaf-08]: https://datatracker.ietf.org/doc/draft-irtf-cfrg-vdaf/08/
+/// [draft-irtf-cfrg-vdaf-18]: https://datatracker.ietf.org/doc/draft-irtf-cfrg-vdaf/18/
 pub trait Xof<const SEED_SIZE: usize>: Clone + Debug {
     /// The type of stream produced by this XOF.
     type SeedStream: Rng + Sized;
@@ -207,9 +207,9 @@ impl Debug for SeedStreamAes128 {
     }
 }
 
-/// The XOF based on TurboSHAKE128 as specified in [[draft-irtf-cfrg-vdaf-08]].
+/// The XOF based on TurboSHAKE128 as specified in [[draft-irtf-cfrg-vdaf-18]].
 ///
-/// [draft-irtf-cfrg-vdaf-08]: https://datatracker.ietf.org/doc/draft-irtf-cfrg-vdaf/08/
+/// [draft-irtf-cfrg-vdaf-18]: https://datatracker.ietf.org/doc/draft-irtf-cfrg-vdaf/18/
 #[derive(Clone, Debug)]
 pub struct XofTurboShake128(TurboShake128);
 
@@ -353,7 +353,7 @@ impl XofFixedKeyAes128Key {
     }
 }
 
-/// XofFixedKeyAes128 as specified in [[draft-irtf-cfrg-vdaf-08]]. This XOF is NOT RECOMMENDED for
+/// XofFixedKeyAes128 as specified in [[draft-irtf-cfrg-vdaf-18]]. This XOF is NOT RECOMMENDED for
 /// general use; see Section 9 ("Security Considerations") for details.
 ///
 /// This XOF combines TurboSHAKE128 and a fixed-key mode of operation for AES-128. The key is
@@ -361,7 +361,7 @@ impl XofFixedKeyAes128Key {
 /// binder strings, and depending on the application, these strings can be hard-coded. The seed is
 /// used to construct each block of input passed to a hash function built from AES-128.
 ///
-/// [draft-irtf-cfrg-vdaf-08]: https://datatracker.ietf.org/doc/draft-irtf-cfrg-vdaf/08/
+/// [draft-irtf-cfrg-vdaf-18]: https://datatracker.ietf.org/doc/draft-irtf-cfrg-vdaf/18/
 #[derive(Clone, Debug)]
 #[cfg(all(feature = "crypto-dependencies", feature = "experimental"))]
 #[cfg_attr(


### PR DESCRIPTION
This updates various mentions of the VDAF specification to point to the latest version. I checked the section numbers and they were all still correct. There was just one related function name to update.