### PR TITLE
fix `clippy::useless_conversion` lint

### DIFF
--- a/src/vdaf/prio2.rs
+++ b/src/vdaf/prio2.rs
@@ -162,7 +162,7 @@ impl Client<16> for Prio2 {
 
         let helper_seed = Seed::generate()?;
         let helper_prng = Prng::from_prio2_seed(helper_seed.as_ref());
-        for (s1, d) in leader_data.iter_mut().zip(helper_prng.into_iter()) {
+        for (s1, d) in leader_data.iter_mut().zip(helper_prng) {
             *s1 -= d;
         }
 

--- a/src/vdaf/prio3_test.rs
+++ b/src/vdaf/prio3_test.rs
@@ -169,7 +169,7 @@ where
     for (test_num, p) in t.prep.iter().enumerate() {
         let output_shares = check_prep_test_vec(prio3, verify_key, test_num, p);
         for (aggregator_output_shares, output_share) in
-            all_output_shares.iter_mut().zip(output_shares.into_iter())
+            all_output_shares.iter_mut().zip(output_shares)
         {
             aggregator_output_shares.push(output_share);
         }


### PR DESCRIPTION
This appears to be causing CI failures in dependabot PRs like [1], but weren't caused by updated dependencies.

[1]: https://github.com/divviup/libprio-rs/pull/1428