### PR TITLE
fix `clippy::useless_conversion` lint

### DIFF
--- a/src/vdaf/prio2.rs
+++ b/src/vdaf/prio2.rs
@@ -166,7 +166,7 @@ impl Client<16> for Prio2 {
 
         let helper_seed = rng.random();
         let helper_prng = Prng::from_prio2_seed(&helper_seed);
-        for (s1, d) in leader_data.iter_mut().zip(helper_prng.into_iter()) {
+        for (s1, d) in leader_data.iter_mut().zip(helper_prng) {
             *s1 -= d;
         }
 


### PR DESCRIPTION
This appears to be causing CI failures in dependabot PRs like [1], but weren't caused by updated dependencies.

[1]: https://github.com/divviup/libprio-rs/pull/1428