### PR TITLE
Remove "Vet Dependencies" workflow

### DIFF
--- a/.github/workflows/supply-chain.yml
+++ b/.github/workflows/supply-chain.yml
@@ -3,12 +3,10 @@ name: supply-chain
 on:
   push:
     branches:
-     - main
-     - release/**
+     - release/0.16
   pull_request:
     branches:
-     - main
-     - release/**
+     - release/0.16
   workflow_dispatch:
 
 jobs:


### PR DESCRIPTION
The audit backlog from `cargo vet` has become unsustainable and this process is largely obsolete given the advent of cheap, high quality vulnerability scanning in tools like Claude. In order to maintain forward velocity, crate `prio` will not require all dependencies to be audited on new release branches.

Pull requests targeting `release/0.16` will still require vetted dependencies.