### PR TITLE
Update dependabot configuration

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -5,6 +5,8 @@ updates:
     schedule:
       interval: "weekly"
     open-pull-requests-limit: 20
+    cooldown:
+      default-days: 7
     groups:
       rand:
         patterns:
@@ -15,11 +17,15 @@ updates:
     directory: "/"
     schedule:
       interval: "weekly"
+    cooldown:
+      default-days: 7
 
   - package-ecosystem: "cargo"
     directory: "/"
     schedule:
       interval: "weekly"
+    cooldown:
+      default-days: 7
     target-branch: release/0.16
     open-pull-requests-limit: 20
 
@@ -27,4 +33,6 @@ updates:
     directory: "/"
     schedule:
       interval: "weekly"
+    cooldown:
+      default-days: 7
     target-branch: release/0.16

--- a/.github/workflows/dependabot-automerge.yml
+++ b/.github/workflows/dependabot-automerge.yml
@@ -1,0 +1,15 @@
+name: Dependabot auto-merge
+on:
+  pull_request:
+    types: [opened, reopened]
+
+jobs:
+  dependabot:
+    runs-on: ubuntu-latest
+    if: ${{ github.actor == 'dependabot[bot]' }}
+    steps:
+      - name: Approve & enable auto-merge for Dependabot PRs
+        run: gh pr review --approve -b "Auto-approving dependabot PR." "$PR_URL" && gh pr merge --auto --squash "$PR_URL"
+        env:
+          PR_URL: ${{ github.event.pull_request.html_url }}
+          GH_TOKEN: ${{ secrets.DIVVIUP_GITHUB_AUTOMATION_DEPENDABOT_APPROVER_PAT }}


### PR DESCRIPTION
Two changes to how we use dependabot in this repository:

- Since we no longer block merges to `main` on `cargo vet`, we can now enable the `dependabot-automerge` workflow we use elsewhere to reduce oncall toil. `DIVVIUP_GITHUB_AUTOMATION_DEPENDABOT_APPROVER_PAT` is an organization level secret, so it's already accessible by workflows in this repository.
- Configure dependabot cooldowns ([1]) to make it less likely we'll get caught out by a supply chain attack. Seven days seems like a reasonable starting value.

[1]: https://docs.github.com/en/code-security/reference/supply-chain-security/dependabot-options-reference#cooldown-