### PR TITLE
Introduce `VariableLengthVector`

### DIFF
--- a/src/codec.rs
+++ b/src/codec.rs
@@ -10,10 +10,12 @@
 //! [1]: https://datatracker.ietf.org/doc/html/rfc8446#section-3
 
 use byteorder::{BigEndian, ReadBytesExt};
+use num_traits::{bounds::UpperBounded, ConstZero, ToBytes};
 use std::{
     convert::TryInto,
     error::Error,
     io::{Cursor, Read},
+    marker::PhantomData,
     mem::size_of,
     num::TryFromIntError,
 };
@@ -37,6 +39,15 @@ pub enum CodecError {
     /// The byte length of a vector exceeded the range of its length prefix.
     #[error("vector length exceeded range of length prefix")]
     LengthPrefixOverflow,
+
+    /// The number of items in a variable-length vector is outside of the type's range.
+    ///
+    /// In TLS presentation language, variable-length vectors declare a subrange of legal lengths
+    /// ([1]). Vectors of items whose length is outside this range are invalid.
+    ///
+    /// [1]: https://datatracker.ietf.org/doc/html/rfc8446#section-3.4
+    #[error("vector length outside of type's range")]
+    VectorLengthOutsideOfRange,
 
     /// Custom errors from [`Decode`] implementations.
     #[error("other error: {0}")]
@@ -245,6 +256,142 @@ impl Encode for u64 {
     fn encoded_len(&self) -> Option<usize> {
         Some(8)
     }
+}
+
+/// A variable-length vector of encoded items.
+///
+/// The vector has a length prefix of type `LEN`, which will be one of `u8`, `u16` or `u32`. The
+/// maximum length of the vector is the maximum value of the length prefix.
+///
+/// A TLS presentation language declaration like `opaque buf<11..2^16-1>` would be represented by
+/// `VariableLengthVector<11, u16, u8>`.
+///
+/// `ExampleType values<0..2^32-1>` would be `VariableLengthVector<0, u32, ExampleType>`, assuming a
+/// Rust type `ExampleType` corresponding to the TLS presentation language type of that name exists.
+///
+/// [1]: https://datatracker.ietf.org/doc/html/rfc8446#section-3.4
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct VariableLengthVector<const MIN_LEN: usize, LEN, E> {
+    /// Contents of the vector.
+    contents: Vec<E>,
+    phantom: PhantomData<LEN>,
+}
+
+impl<const MIN_LEN: usize, LEN, E> VariableLengthVector<MIN_LEN, LEN, E> {
+    /// Make a new variable length vector.
+    pub fn new(contents: Vec<E>) -> Self {
+        Self {
+            contents,
+            phantom: PhantomData,
+        }
+    }
+
+    /// Length of the vector
+    pub fn len(&self) -> usize {
+        self.contents.len()
+    }
+
+    /// Whether this vector is empty.
+    pub fn is_empty(&self) -> bool {
+        self.contents.is_empty()
+    }
+}
+
+impl<const MIN_LEN: usize, LEN: LengthPrefix, E: Encode> Encode
+    for VariableLengthVector<MIN_LEN, LEN, E>
+{
+    fn encode(&self, bytes: &mut Vec<u8>) -> Result<(), CodecError> {
+        if self.contents.len() < MIN_LEN
+            || self.contents.len()
+                > LEN::max_value()
+                    .try_into()
+                    .map_err(|_| CodecError::Other("prefix max length too big for usize".into()))?
+        {
+            return Err(CodecError::VectorLengthOutsideOfRange);
+        }
+
+        // Reserve space to later write length
+        let len_offset = bytes.len();
+        LEN::ZERO.encode(bytes)?;
+
+        for item in &self.contents {
+            item.encode(bytes)?;
+        }
+
+        let len = LEN::try_from(bytes.len() - len_offset - LEN::ENCODED_LEN)
+            .map_err(|_| CodecError::LengthPrefixOverflow)?;
+        bytes[len_offset..len_offset + LEN::ENCODED_LEN]
+            .copy_from_slice(len.to_be_bytes().as_ref());
+        Ok(())
+    }
+
+    fn encoded_len(&self) -> Option<usize> {
+        Some(
+            LEN::ENCODED_LEN
+                + self
+                    .contents
+                    .iter()
+                    .map(|item| item.encoded_len().unwrap_or(0))
+                    .sum::<usize>(),
+        )
+    }
+}
+
+impl<const MIN_LEN: usize, LEN: LengthPrefix, D: Decode> Decode
+    for VariableLengthVector<MIN_LEN, LEN, D>
+{
+    fn decode(bytes: &mut Cursor<&[u8]>) -> Result<Self, CodecError> {
+        // Read two bytes to get length of opaque byte vector
+        let length: usize = LEN::decode(bytes)?
+            .try_into()
+            .map_err(|_| CodecError::Other("prefix max length too big for usize".into()))?;
+
+        if length < MIN_LEN {
+            return Err(CodecError::VectorLengthOutsideOfRange);
+        }
+
+        let contents = decode_fixlen_items(length, &(), bytes)?;
+
+        Ok(contents.into())
+    }
+}
+
+impl<const MIN_LEN: usize, LEN, E> AsRef<[E]> for VariableLengthVector<MIN_LEN, LEN, E> {
+    fn as_ref(&self) -> &[E] {
+        &self.contents
+    }
+}
+
+impl<const MIN_LEN: usize, LEN, E> AsMut<[E]> for VariableLengthVector<MIN_LEN, LEN, E> {
+    fn as_mut(&mut self) -> &mut [E] {
+        &mut self.contents
+    }
+}
+
+impl<const MIN_LEN: usize, LEN, E> From<Vec<E>> for VariableLengthVector<MIN_LEN, LEN, E> {
+    fn from(contents: Vec<E>) -> Self {
+        Self::new(contents)
+    }
+}
+
+/// Marker trait for types that can be the length prefix of a [`VariableLengthVector`].
+trait LengthPrefix:
+    Encode + Decode + TryFrom<usize> + TryInto<usize> + ConstZero + UpperBounded + ToBytes
+{
+    /// Length of an encoded length prefix.
+    const ENCODED_LEN: usize;
+}
+
+impl LengthPrefix for u8 {
+    const ENCODED_LEN: usize = 1;
+}
+
+impl LengthPrefix for u16 {
+    const ENCODED_LEN: usize = 2;
+}
+
+impl LengthPrefix for u32 {
+    const ENCODED_LEN: usize = 4;
 }
 
 /// Encode `items` into `bytes` as a [fixed-length vector][1], with no length tag.
@@ -542,6 +689,11 @@ mod tests {
         assert_eq!(value, decoded);
     }
 
+    #[test]
+    fn empty_variable_length_vector() {
+        assert!(VariableLengthVector::<0, u8, u8>::new(vec![]).is_empty())
+    }
+
     fn messages_vec() -> Vec<TestMessage> {
         vec![
             TestMessage {
@@ -567,9 +719,12 @@ mod tests {
 
     #[test]
     fn roundtrip_variable_length_u8() {
-        let values = messages_vec();
+        let values = VariableLengthVector::<0, u8, _>::new(messages_vec());
         let mut bytes = vec![];
-        encode_u8_items(&mut bytes, &(), &values).unwrap();
+        values.encode(&mut bytes).unwrap();
+        let mut old_bytes = vec![];
+        encode_u8_items(&mut old_bytes, &(), &messages_vec()).unwrap();
+        assert_eq!(old_bytes, bytes);
 
         assert_eq!(
             bytes.len(),
@@ -579,15 +734,18 @@ mod tests {
             3 * TestMessage::encoded_length()
         );
 
-        let decoded = decode_u8_items(&(), &mut Cursor::new(&bytes)).unwrap();
+        let decoded = VariableLengthVector::get_decoded(&bytes).unwrap();
         assert_eq!(values, decoded);
     }
 
     #[test]
     fn roundtrip_variable_length_u16() {
-        let values = messages_vec();
+        let values = VariableLengthVector::<0, u16, _>::new(messages_vec());
         let mut bytes = vec![];
-        encode_u16_items(&mut bytes, &(), &values).unwrap();
+        values.encode(&mut bytes).unwrap();
+        let mut old_bytes = vec![];
+        encode_u16_items(&mut old_bytes, &(), &messages_vec()).unwrap();
+        assert_eq!(old_bytes, bytes);
 
         assert_eq!(
             bytes.len(),
@@ -600,15 +758,19 @@ mod tests {
         // Check endianness of encoded length
         assert_eq!(bytes[0..2], [0, 3 * TestMessage::encoded_length() as u8]);
 
-        let decoded = decode_u16_items(&(), &mut Cursor::new(&bytes)).unwrap();
+        let decoded = VariableLengthVector::get_decoded(&bytes).unwrap();
         assert_eq!(values, decoded);
     }
 
     #[test]
     fn roundtrip_variable_length_u32() {
-        let values = messages_vec();
+        let values = VariableLengthVector::<0, u32, _>::new(messages_vec());
         let mut bytes = Vec::new();
-        encode_u32_items(&mut bytes, &(), &values).unwrap();
+        values.encode(&mut bytes).unwrap();
+
+        let mut old_bytes = Vec::new();
+        encode_u32_items(&mut old_bytes, &(), &messages_vec()).unwrap();
+        assert_eq!(bytes, old_bytes);
 
         assert_eq!(bytes.len(), 4 + 3 * TestMessage::encoded_length());
 
@@ -618,8 +780,55 @@ mod tests {
             [0, 0, 0, 3 * TestMessage::encoded_length() as u8]
         );
 
-        let decoded = decode_u32_items(&(), &mut Cursor::new(&bytes)).unwrap();
+        let decoded = VariableLengthVector::get_decoded(&bytes).unwrap();
         assert_eq!(values, decoded);
+    }
+
+    #[test]
+    fn variable_length_vector_reject_too_short() {
+        assert_matches!(
+            VariableLengthVector::<2, u16, _>::new(vec![0u8])
+                .get_encoded()
+                .unwrap_err(),
+            CodecError::VectorLengthOutsideOfRange
+        );
+    }
+
+    #[test]
+    fn variable_length_vector_reject_too_long() {
+        assert_matches!(
+            VariableLengthVector::<2, u16, _>::new(vec![0u8; usize::from(u16::MAX) + 1])
+                .get_encoded()
+                .unwrap_err(),
+            CodecError::VectorLengthOutsideOfRange
+        );
+    }
+
+    #[test]
+    fn variable_length_vector_u8_encoded_len() {
+        let vlv = VariableLengthVector::<1, u8, _>::new(messages_vec());
+        assert_eq!(
+            vlv.encoded_len().unwrap(),
+            1 + 3 * TestMessage::encoded_length()
+        );
+    }
+
+    #[test]
+    fn variable_length_vector_u16_encoded_len() {
+        let vlv = VariableLengthVector::<1, u16, _>::new(messages_vec());
+        assert_eq!(
+            vlv.encoded_len().unwrap(),
+            2 + 3 * TestMessage::encoded_length()
+        );
+    }
+
+    #[test]
+    fn variable_length_vector_u32_encoded_len() {
+        let vlv = VariableLengthVector::<1, u32, _>::new(messages_vec());
+        assert_eq!(
+            vlv.encoded_len().unwrap(),
+            4 + 3 * TestMessage::encoded_length()
+        );
     }
 
     #[test]
@@ -648,16 +857,15 @@ mod tests {
 
     #[test]
     fn decode_too_short() {
-        let values = messages_vec();
-        let mut bytes = Vec::new();
-        encode_u32_items(&mut bytes, &(), &values).unwrap();
+        let values = VariableLengthVector::<0, u32, _>::new(messages_vec());
+        let encoded = values.get_encoded().unwrap();
 
         let error =
-            decode_u32_items::<_, TestMessage>(&(), &mut Cursor::new(&bytes[..3])).unwrap_err();
+            VariableLengthVector::<0, u32, TestMessage>::get_decoded(&encoded[..3]).unwrap_err();
         assert_matches!(error, CodecError::Io(e) => assert_eq!(e.kind(), ErrorKind::UnexpectedEof));
 
         let error =
-            decode_u32_items::<_, TestMessage>(&(), &mut Cursor::new(&bytes[..4])).unwrap_err();
+            VariableLengthVector::<0, u32, TestMessage>::get_decoded(&encoded[..4]).unwrap_err();
         assert_matches!(error, CodecError::LengthPrefixTooBig(_));
     }
 
@@ -729,12 +937,5 @@ mod tests {
         assert_eq!(MyMessage.encoded_len(), None);
 
         assert_eq!(MyMessage.get_encoded().unwrap(), b"Hello, world");
-    }
-
-    #[test]
-    fn encode_length_prefix_overflow() {
-        let mut bytes = Vec::new();
-        let error = encode_u8_items(&mut bytes, &(), &[1u8; u8::MAX as usize + 1]).unwrap_err();
-        assert_matches!(error, CodecError::LengthPrefixOverflow);
     }
 }

--- a/src/codec.rs
+++ b/src/codec.rs
@@ -39,7 +39,7 @@ pub enum CodecError {
     #[error("vector length exceeded range of length prefix")]
     LengthPrefixOverflow,
 
-    /// The number of items in a variable-length vector is outside of the type's range.
+    /// The number of bytes in a variable-length vector is outside of the type's range.
     ///
     /// In TLS presentation language, variable-length vectors declare a subrange of legal lengths
     /// ([1]). Vectors of items whose length is outside this range are invalid.
@@ -57,34 +57,42 @@ pub enum CodecError {
     UnexpectedValue,
 }
 
-/// Describes how to decode an object from a byte sequence.
+/// Decode an object from a byte sequence.
 pub trait Decode: Sized {
-    /// Read and decode an encoded object from `bytes`. On success, the decoded value is returned
-    /// and `bytes` is advanced by the encoded size of the value. On failure, an error is returned
-    /// and no further attempt to read from `bytes` should be made.
+    /// Read and decode an encoded object from `bytes`.
+    ///
+    /// On success, the decoded value is returned and `bytes` is advanced by the encoded size of the
+    /// value. On failure, an error is returned and no further attempt to read from `bytes` should
+    /// be made.
     fn decode(bytes: &mut Cursor<&[u8]>) -> Result<Self, CodecError>;
 
-    /// Convenience method to get a decoded value. Returns an error if [`Self::decode`] fails, or if
-    /// there are any bytes left in `bytes` after decoding a value.
+    /// Convenience method to get a decoded value.
+    ///
+    /// Returns an error if [`Self::decode`] fails, or if there are any bytes left in `bytes` after
+    /// decoding a value. On failure, no further attempt to read from `bytes` should be made.
     fn get_decoded(bytes: &[u8]) -> Result<Self, CodecError> {
         Self::get_decoded_with_param(&(), bytes)
     }
 }
 
-/// Describes how to decode an object from a byte sequence and a decoding parameter that provides
-/// additional context.
+/// Decode an object from a byte sequence and a decoding parameter that provides additional context.
 pub trait ParameterizedDecode<P>: Sized {
-    /// Read and decode an encoded object from `bytes`. `decoding_parameter` provides details of the
-    /// wire encoding such as lengths of different portions of the message. On success, the decoded
-    /// value is returned and `bytes` is advanced by the encoded size of the value. On failure, an
-    /// error is returned and no further attempt to read from `bytes` should be made.
+    /// Read and decode an encoded object from `bytes`.
+    ///
+    /// `decoding_parameter` provides details of the wire encoding such as lengths of different
+    /// portions of the message. On success, the decoded value is returned and `bytes` is advanced
+    /// by the encoded size of the value. On failure, an error is returned and no further attempt to
+    /// read from `bytes` should be made.
     fn decode_with_param(
         decoding_parameter: &P,
         bytes: &mut Cursor<&[u8]>,
     ) -> Result<Self, CodecError>;
 
-    /// Convenience method to get a decoded value. Returns an error if [`Self::decode_with_param`]
-    /// fails, or if there are any bytes left in `bytes` after decoding a value.
+    /// Convenience method to get a decoded value.
+    ///
+    /// Returns an error if [`Self::decode_with_param`] fails, or if there are any bytes left in
+    /// `bytes` after decoding a value. On failure, no further attempt to read from `bytes` should
+    /// be made.
     fn get_decoded_with_param(decoding_parameter: &P, bytes: &[u8]) -> Result<Self, CodecError> {
         let mut cursor = Cursor::new(bytes);
         let decoded = Self::decode_with_param(decoding_parameter, &mut cursor)?;
@@ -112,15 +120,22 @@ impl<D: Decode, T> ParameterizedDecode<T> for D {
 /// Describes how to encode objects into a byte sequence.
 pub trait Encode {
     /// Append the encoded form of this object to the end of `bytes`, growing the vector as needed.
+    ///
+    /// On failure, an error is returned and no further attempt to read from or write to `bytes`
+    /// should be made.
     fn encode(&self, bytes: &mut Vec<u8>) -> Result<(), CodecError>;
 
     /// Convenience method to encode a value into a new `Vec<u8>`.
+    ///
+    /// On failure, an error is returned and no further attempt to read from or write to `bytes`
+    /// should be made.
     fn get_encoded(&self) -> Result<Vec<u8>, CodecError> {
         self.get_encoded_with_param(&())
     }
 
-    /// Returns an optional hint indicating how many bytes will be required to encode this value, or
-    /// `None` by default.
+    /// Returns an optional hint indicating how many bytes will be required to encode this value.
+    ///
+    /// The default implementation returns `None`.
     fn encoded_len(&self) -> Option<usize> {
         None
     }
@@ -129,8 +144,12 @@ pub trait Encode {
 /// Describes how to encode objects into a byte sequence.
 pub trait ParameterizedEncode<P> {
     /// Append the encoded form of this object to the end of `bytes`, growing the vector as needed.
+    ///
     /// `encoding_parameter` provides details of the wire encoding, used to control how the value
     /// is encoded.
+    ///
+    /// On failure, an error is returned and no further attempt to read from or write to `bytes`
+    /// should be made.
     fn encode_with_param(
         &self,
         encoding_parameter: &P,
@@ -138,6 +157,9 @@ pub trait ParameterizedEncode<P> {
     ) -> Result<(), CodecError>;
 
     /// Convenience method to encode a value into a new `Vec<u8>`.
+    ///
+    /// On failure, an error is returned and no further attempt to read from or write to `bytes`
+    /// should be made.
     fn get_encoded_with_param(&self, encoding_parameter: &P) -> Result<Vec<u8>, CodecError> {
         let mut ret = if let Some(length) = self.encoded_len_with_param(encoding_parameter) {
             Vec::with_capacity(length)
@@ -148,8 +170,9 @@ pub trait ParameterizedEncode<P> {
         Ok(ret)
     }
 
-    /// Returns an optional hint indicating how many bytes will be required to encode this value, or
-    /// `None` by default.
+    /// Returns an optional hint indicating how many bytes will be required to encode this value.
+    ///
+    /// The default implementation returns `None`.
     fn encoded_len_with_param(&self, _encoding_parameter: &P) -> Option<usize> {
         None
     }
@@ -300,15 +323,6 @@ impl<const MIN_LEN: usize, LEN: LengthPrefix, E: Encode> Encode
     for VariableLengthVector<MIN_LEN, LEN, E>
 {
     fn encode(&self, bytes: &mut Vec<u8>) -> Result<(), CodecError> {
-        if self.contents.len() < MIN_LEN
-            || self.contents.len()
-                > LEN::max_value()
-                    .try_into()
-                    .map_err(|_| CodecError::Other("prefix max length too big for usize".into()))?
-        {
-            return Err(CodecError::VectorLengthOutsideOfRange);
-        }
-
         // Reserve space to later write length
         let len_offset = bytes.len();
         LEN::ZERO.encode(bytes)?;
@@ -317,10 +331,23 @@ impl<const MIN_LEN: usize, LEN: LengthPrefix, E: Encode> Encode
             item.encode(bytes)?;
         }
 
-        let len = LEN::try_from(bytes.len() - len_offset - LEN::ENCODED_LEN)
-            .map_err(|_| CodecError::LengthPrefixOverflow)?;
+        // Check whether the number of bytes written falls outside the type's declared range. We can
+        // only do this after encoding all the items because we can't assume `Encode::encoded_len`
+        // is implemented.
+        let encoded_len = bytes.len() - len_offset - LEN::ENCODED_LEN;
+        if encoded_len < MIN_LEN
+            || encoded_len
+                > LEN::max_value()
+                    .try_into()
+                    .map_err(|_| CodecError::Other("prefix max length too big for usize".into()))?
+        {
+            return Err(CodecError::VectorLengthOutsideOfRange);
+        }
+
+        let encoded_len =
+            LEN::try_from(encoded_len).map_err(|_| CodecError::LengthPrefixOverflow)?;
         bytes[len_offset..len_offset + LEN::ENCODED_LEN]
-            .copy_from_slice(len.to_be_bytes().as_ref());
+            .copy_from_slice(encoded_len.to_be_bytes().as_ref());
         Ok(())
     }
 
@@ -330,8 +357,8 @@ impl<const MIN_LEN: usize, LEN: LengthPrefix, E: Encode> Encode
                 + self
                     .contents
                     .iter()
-                    .map(|item| item.encoded_len().unwrap_or(0))
-                    .sum::<usize>(),
+                    .map(Encode::encoded_len)
+                    .sum::<Option<usize>>()?,
         )
     }
 }
@@ -340,7 +367,7 @@ impl<const MIN_LEN: usize, LEN: LengthPrefix, D: Decode> Decode
     for VariableLengthVector<MIN_LEN, LEN, D>
 {
     fn decode(bytes: &mut Cursor<&[u8]>) -> Result<Self, CodecError> {
-        // Read two bytes to get length of opaque byte vector
+        // Read the length prefix
         let length: usize = LEN::decode(bytes)?
             .try_into()
             .map_err(|_| CodecError::Other("prefix max length too big for usize".into()))?;
@@ -504,7 +531,7 @@ mod tests {
         assert_eq!(value, decoded);
     }
 
-    #[derive(Debug, Eq, PartialEq)]
+    #[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
     struct TestMessage {
         field_u8: u8,
         field_u16: u16,
@@ -663,7 +690,7 @@ mod tests {
     }
 
     #[test]
-    fn variable_length_vector_reject_too_short() {
+    fn variable_length_vector_reject_too_short_byte_items() {
         assert_matches!(
             VariableLengthVector::<2, u16, _>::new(vec![0u8])
                 .get_encoded()
@@ -673,11 +700,40 @@ mod tests {
     }
 
     #[test]
-    fn variable_length_vector_reject_too_long() {
+    fn variable_length_vector_reject_too_short_nontrivial_items() {
+        // Minimum length chosen to be bigger than the encoding of messages_vec()
+        const MIN_LEN: usize = 48;
+        let vlv = VariableLengthVector::<MIN_LEN, u16, _>::new(messages_vec());
+        assert!(
+            MIN_LEN > vlv.encoded_len().unwrap(),
+            "{:?}",
+            vlv.encoded_len()
+        );
+        let encoded = vlv.get_encoded();
+        assert_matches!(encoded.unwrap_err(), CodecError::VectorLengthOutsideOfRange);
+    }
+
+    #[test]
+    fn variable_length_vector_reject_too_long_byte_items() {
         assert_matches!(
-            VariableLengthVector::<2, u16, _>::new(vec![0u8; usize::from(u16::MAX) + 1])
+            VariableLengthVector::<0, u8, _>::new(vec![0u8; usize::from(u8::MAX) + 1])
                 .get_encoded()
                 .unwrap_err(),
+            CodecError::VectorLengthOutsideOfRange
+        );
+    }
+
+    #[test]
+    fn variable_length_vector_reject_too_long_nontrivial_items() {
+        // 18 is enough TestMessage items that the encoding will be more than 255 bytes
+        let vlv = VariableLengthVector::<0, u8, _>::new(vec![TestMessage::default(); 18]);
+        assert!(
+            vlv.encoded_len().unwrap() > u8::MAX as usize,
+            "{:?}",
+            vlv.encoded_len()
+        );
+        assert_matches!(
+            vlv.get_encoded().unwrap_err(),
             CodecError::VectorLengthOutsideOfRange
         );
     }
@@ -707,6 +763,24 @@ mod tests {
             vlv.encoded_len().unwrap(),
             4 + 3 * TestMessage::encoded_length()
         );
+    }
+
+    #[test]
+    fn variable_length_vector_items_have_no_encoded_len() {
+        struct NoEncodedLen;
+
+        impl Encode for NoEncodedLen {
+            fn encode(&self, bytes: &mut Vec<u8>) -> Result<(), CodecError> {
+                ().encode(bytes)
+            }
+
+            fn encoded_len(&self) -> Option<usize> {
+                None
+            }
+        }
+
+        let vlv = VariableLengthVector::<0, u16, _>::new(vec![NoEncodedLen, NoEncodedLen]);
+        assert!(vlv.encoded_len().is_none(), "{:?}", vlv.encoded_len());
     }
 
     #[test]

--- a/src/codec.rs
+++ b/src/codec.rs
@@ -17,7 +17,6 @@ use std::{
     io::{Cursor, Read},
     marker::PhantomData,
     mem::size_of,
-    num::TryFromIntError,
 };
 
 /// An error that occurred during decoding.
@@ -405,117 +404,6 @@ pub fn encode_fixlen_items<E: Encode>(bytes: &mut Vec<u8>, items: &[E]) -> Resul
     Ok(())
 }
 
-/// Encode `items` into `bytes` as a [variable-length vector][1] with a maximum length of `0xff`.
-///
-/// [1]: https://datatracker.ietf.org/doc/html/rfc8446#section-3.4
-pub fn encode_u8_items<P, E: ParameterizedEncode<P>>(
-    bytes: &mut Vec<u8>,
-    encoding_parameter: &P,
-    items: &[E],
-) -> Result<(), CodecError> {
-    // Reserve space to later write length
-    let len_offset = bytes.len();
-    bytes.push(0);
-
-    for item in items {
-        item.encode_with_param(encoding_parameter, bytes)?;
-    }
-
-    let len =
-        u8::try_from(bytes.len() - len_offset - 1).map_err(|_| CodecError::LengthPrefixOverflow)?;
-    bytes[len_offset] = len;
-    Ok(())
-}
-
-/// Decode `bytes` into a vector of `D` values, treating `bytes` as a [variable-length vector][1] of
-/// maximum length `0xff`.
-///
-/// [1]: https://datatracker.ietf.org/doc/html/rfc8446#section-3.4
-pub fn decode_u8_items<P, D: ParameterizedDecode<P>>(
-    decoding_parameter: &P,
-    bytes: &mut Cursor<&[u8]>,
-) -> Result<Vec<D>, CodecError> {
-    // Read one byte to get length of opaque byte vector
-    let length = usize::from(u8::decode(bytes)?);
-
-    decode_fixlen_items(length, decoding_parameter, bytes)
-}
-
-/// Encode `items` into `bytes` as a [variable-length vector][1] with a maximum length of `0xffff`.
-///
-/// [1]: https://datatracker.ietf.org/doc/html/rfc8446#section-3.4
-pub fn encode_u16_items<P, E: ParameterizedEncode<P>>(
-    bytes: &mut Vec<u8>,
-    encoding_parameter: &P,
-    items: &[E],
-) -> Result<(), CodecError> {
-    // Reserve space to later write length
-    let len_offset = bytes.len();
-    0u16.encode(bytes)?;
-
-    for item in items {
-        item.encode_with_param(encoding_parameter, bytes)?;
-    }
-
-    let len = u16::try_from(bytes.len() - len_offset - 2)
-        .map_err(|_| CodecError::LengthPrefixOverflow)?;
-    bytes[len_offset..len_offset + 2].copy_from_slice(&len.to_be_bytes());
-    Ok(())
-}
-
-/// Decode `bytes` into a vector of `D` values, treating `bytes` as a [variable-length vector][1] of
-/// maximum length `0xffff`.
-///
-/// [1]: https://datatracker.ietf.org/doc/html/rfc8446#section-3.4
-pub fn decode_u16_items<P, D: ParameterizedDecode<P>>(
-    decoding_parameter: &P,
-    bytes: &mut Cursor<&[u8]>,
-) -> Result<Vec<D>, CodecError> {
-    // Read two bytes to get length of opaque byte vector
-    let length = usize::from(u16::decode(bytes)?);
-
-    decode_fixlen_items(length, decoding_parameter, bytes)
-}
-
-/// Encode `items` into `bytes` as a [variable-length vector][1] with a maximum length of
-/// `0xffffffff`.
-///
-/// [1]: https://datatracker.ietf.org/doc/html/rfc8446#section-3.4
-pub fn encode_u32_items<P, E: ParameterizedEncode<P>>(
-    bytes: &mut Vec<u8>,
-    encoding_parameter: &P,
-    items: &[E],
-) -> Result<(), CodecError> {
-    // Reserve space to later write length
-    let len_offset = bytes.len();
-    0u32.encode(bytes)?;
-
-    for item in items {
-        item.encode_with_param(encoding_parameter, bytes)?;
-    }
-
-    let len = u32::try_from(bytes.len() - len_offset - 4)
-        .map_err(|_| CodecError::LengthPrefixOverflow)?;
-    bytes[len_offset..len_offset + 4].copy_from_slice(&len.to_be_bytes());
-    Ok(())
-}
-
-/// Decode `bytes` into a vector of `D` values, treating `bytes` as a [variable-length vector][1] of
-/// maximum length `0xffffffff`.
-///
-/// [1]: https://datatracker.ietf.org/doc/html/rfc8446#section-3.4
-pub fn decode_u32_items<P, D: ParameterizedDecode<P>>(
-    decoding_parameter: &P,
-    bytes: &mut Cursor<&[u8]>,
-) -> Result<Vec<D>, CodecError> {
-    // Read four bytes to get length of opaque byte vector.
-    let len: usize = u32::decode(bytes)?
-        .try_into()
-        .map_err(|err: TryFromIntError| CodecError::Other(err.into()))?;
-
-    decode_fixlen_items(len, decoding_parameter, bytes)
-}
-
 /// Decode `bytes` as a [fixed-length vector][1] into as many instances of `D` as possible.
 ///
 /// [1]: https://datatracker.ietf.org/doc/html/rfc8446#section-3.4
@@ -722,9 +610,6 @@ mod tests {
         let values = VariableLengthVector::<0, u8, _>::new(messages_vec());
         let mut bytes = vec![];
         values.encode(&mut bytes).unwrap();
-        let mut old_bytes = vec![];
-        encode_u8_items(&mut old_bytes, &(), &messages_vec()).unwrap();
-        assert_eq!(old_bytes, bytes);
 
         assert_eq!(
             bytes.len(),
@@ -743,9 +628,6 @@ mod tests {
         let values = VariableLengthVector::<0, u16, _>::new(messages_vec());
         let mut bytes = vec![];
         values.encode(&mut bytes).unwrap();
-        let mut old_bytes = vec![];
-        encode_u16_items(&mut old_bytes, &(), &messages_vec()).unwrap();
-        assert_eq!(old_bytes, bytes);
 
         assert_eq!(
             bytes.len(),
@@ -767,10 +649,6 @@ mod tests {
         let values = VariableLengthVector::<0, u32, _>::new(messages_vec());
         let mut bytes = Vec::new();
         values.encode(&mut bytes).unwrap();
-
-        let mut old_bytes = Vec::new();
-        encode_u32_items(&mut old_bytes, &(), &messages_vec()).unwrap();
-        assert_eq!(bytes, old_bytes);
 
         assert_eq!(bytes.len(), 4 + 3 * TestMessage::encoded_length());
 

--- a/src/idpf.rs
+++ b/src/idpf.rs
@@ -1131,9 +1131,7 @@ mod tests {
         IdpfPublicShare, NoCache, RingBufferCache,
     };
     use crate::{
-        codec::{
-            decode_u32_items, encode_u32_items, CodecError, Decode, Encode, ParameterizedDecode,
-        },
+        codec::{CodecError, Decode, Encode, ParameterizedDecode, VariableLengthVector},
         field::{Field128, Field255, Field64, FieldElement},
         prng::Prng,
         vdaf::{poplar1::Poplar1IdpfValue, xof::Seed},
@@ -2202,7 +2200,7 @@ mod tests {
         /// field elements. The length must be fixed before generating IDPF keys, but we assume it
         /// is not known at compile time.
         #[derive(Debug, Clone)]
-        struct MyVector(Vec<Field128>);
+        struct MyVector(VariableLengthVector<0, u32, Field128>);
 
         impl IdpfValue for MyVector {
             type ValueParameter = usize;
@@ -2215,42 +2213,45 @@ mod tests {
                 for element in output.iter_mut() {
                     *element = <Field128 as IdpfValue>::generate(seed_stream, &());
                 }
-                MyVector(output)
+                MyVector(output.into())
             }
 
             fn zero(length: &usize) -> Self {
-                MyVector(vec![<Field128 as FieldElement>::zero(); *length])
+                MyVector(vec![<Field128 as FieldElement>::zero(); *length].into())
             }
 
             fn conditional_select(a: &Self, b: &Self, choice: Choice) -> Self {
                 debug_assert_eq!(a.0.len(), b.0.len());
                 let mut output = vec![<Field128 as FieldElement>::zero(); a.0.len()];
                 for ((a_elem, b_elem), output_elem) in
-                    a.0.iter().zip(b.0.iter()).zip(output.iter_mut())
+                    a.0.as_ref()
+                        .iter()
+                        .zip(b.0.as_ref().iter())
+                        .zip(output.iter_mut())
                 {
                     *output_elem = <Field128 as ConditionallySelectable>::conditional_select(
                         a_elem, b_elem, choice,
                     );
                 }
-                MyVector(output)
+                MyVector(output.into())
             }
         }
 
         impl Encode for MyVector {
             fn encode(&self, bytes: &mut Vec<u8>) -> Result<(), CodecError> {
-                encode_u32_items(bytes, &(), &self.0)
+                self.0.encode(bytes)
             }
         }
 
         impl Decode for MyVector {
             fn decode(bytes: &mut Cursor<&[u8]>) -> Result<Self, CodecError> {
-                decode_u32_items(&(), bytes).map(MyVector)
+                VariableLengthVector::decode(bytes).map(MyVector)
             }
         }
 
         impl ConditionallyNegatable for MyVector {
             fn conditional_negate(&mut self, choice: Choice) {
-                for element in self.0.iter_mut() {
+                for element in self.0.as_mut().iter_mut() {
                     element.conditional_negate(choice);
                 }
             }
@@ -2262,19 +2263,24 @@ mod tests {
             fn add(self, rhs: Self) -> Self::Output {
                 debug_assert_eq!(self.0.len(), rhs.0.len());
                 let mut output = vec![<Field128 as FieldElement>::zero(); self.0.len()];
-                for ((left_elem, right_elem), output_elem) in
-                    self.0.iter().zip(rhs.0.iter()).zip(output.iter_mut())
+                for ((left_elem, right_elem), output_elem) in self
+                    .0
+                    .as_ref()
+                    .iter()
+                    .zip(rhs.0.as_ref().iter())
+                    .zip(output.iter_mut())
                 {
                     *output_elem = left_elem + right_elem;
                 }
-                MyVector(output)
+                MyVector(output.into())
             }
         }
 
         impl AddAssign for MyVector {
             fn add_assign(&mut self, rhs: Self) {
                 debug_assert_eq!(self.0.len(), rhs.0.len());
-                for (self_elem, right_elem) in self.0.iter_mut().zip(rhs.0.iter()) {
+                for (self_elem, right_elem) in self.0.as_mut().iter_mut().zip(rhs.0.as_ref().iter())
+                {
                     *self_elem += *right_elem;
                 }
             }
@@ -2286,12 +2292,16 @@ mod tests {
             fn sub(self, rhs: Self) -> Self::Output {
                 debug_assert_eq!(self.0.len(), rhs.0.len());
                 let mut output = vec![<Field128 as FieldElement>::zero(); self.0.len()];
-                for ((left_elem, right_elem), output_elem) in
-                    self.0.iter().zip(rhs.0.iter()).zip(output.iter_mut())
+                for ((left_elem, right_elem), output_elem) in self
+                    .0
+                    .as_ref()
+                    .iter()
+                    .zip(rhs.0.as_ref().iter())
+                    .zip(output.iter_mut())
                 {
                     *output_elem = left_elem - right_elem;
                 }
-                MyVector(output)
+                MyVector(output.into())
             }
         }
 
@@ -2303,11 +2313,9 @@ mod tests {
             .gen(
                 &IdpfInput::from_bytes(b"ae"),
                 [MyUnit; 15],
-                MyVector(Vec::from([
-                    Field128::from(1),
-                    Field128::from(2),
-                    Field128::from(3),
-                ])),
+                MyVector(
+                    Vec::from([Field128::from(1), Field128::from(2), Field128::from(3)]).into(),
+                ),
                 CTX_STR,
                 binder,
             )
@@ -2338,9 +2346,9 @@ mod tests {
         let zero_output = zero_share_0.merge(zero_share_1).unwrap();
         assert_matches!(zero_output, IdpfOutputShare::Leaf(value) => {
             assert_eq!(value.0.len(), 3);
-            assert_eq!(value.0[0], <Field128 as FieldElement>::zero());
-            assert_eq!(value.0[1], <Field128 as FieldElement>::zero());
-            assert_eq!(value.0[2], <Field128 as FieldElement>::zero());
+            assert_eq!(value.0.as_ref()[0], <Field128 as FieldElement>::zero());
+            assert_eq!(value.0.as_ref()[1], <Field128 as FieldElement>::zero());
+            assert_eq!(value.0.as_ref()[2], <Field128 as FieldElement>::zero());
         });
 
         let programmed_share_0 = idpf
@@ -2368,9 +2376,9 @@ mod tests {
         let programmed_output = programmed_share_0.merge(programmed_share_1).unwrap();
         assert_matches!(programmed_output, IdpfOutputShare::Leaf(value) => {
             assert_eq!(value.0.len(), 3);
-            assert_eq!(value.0[0], Field128::from(1));
-            assert_eq!(value.0[1], Field128::from(2));
-            assert_eq!(value.0[2], Field128::from(3));
+            assert_eq!(value.0.as_ref()[0], Field128::from(1));
+            assert_eq!(value.0.as_ref()[1], Field128::from(2));
+            assert_eq!(value.0.as_ref()[2], Field128::from(3));
         });
     }
 }

--- a/src/topology/ping_pong.rs
+++ b/src/topology/ping_pong.rs
@@ -8,7 +8,7 @@
 //! [DAP]: https://datatracker.ietf.org/doc/html/draft-ietf-ppm-dap
 
 use crate::{
-    codec::{decode_u32_items, encode_u32_items, CodecError, Decode, Encode, ParameterizedDecode},
+    codec::{CodecError, Decode, Encode, ParameterizedDecode, VariableLengthVector},
     vdaf::{Aggregator, VdafError, VerifyTransition},
 };
 use std::fmt::Debug;
@@ -57,19 +57,19 @@ pub enum PingPongMessage {
     /// Corresponds to MessageType.initialize.
     Initialize {
         /// The leader's initial verifier share.
-        verifier_share: Vec<u8>,
+        verifier_share: VariableLengthVector<0, u32, u8>,
     },
     /// Corresponds to MessageType.continue.
     Continue {
         /// The current round's verifier message.
-        verifier_message: Vec<u8>,
+        verifier_message: VariableLengthVector<0, u32, u8>,
         /// The next round's verifier share.
-        verifier_share: Vec<u8>,
+        verifier_share: VariableLengthVector<0, u32, u8>,
     },
     /// Corresponds to MessageType.finish.
     Finish {
         /// The current round's verifier message.
-        verifier_message: Vec<u8>,
+        verifier_message: VariableLengthVector<0, u32, u8>,
     },
 }
 
@@ -102,19 +102,19 @@ impl Encode for PingPongMessage {
         match self {
             Self::Initialize { verifier_share } => {
                 0u8.encode(bytes)?;
-                encode_u32_items(bytes, &(), verifier_share)?;
+                verifier_share.encode(bytes)?;
             }
             Self::Continue {
                 verifier_message,
                 verifier_share,
             } => {
                 1u8.encode(bytes)?;
-                encode_u32_items(bytes, &(), verifier_message)?;
-                encode_u32_items(bytes, &(), verifier_share)?;
+                verifier_message.encode(bytes)?;
+                verifier_share.encode(bytes)?;
             }
             Self::Finish { verifier_message } => {
                 2u8.encode(bytes)?;
-                encode_u32_items(bytes, &(), verifier_message)?;
+                verifier_message.encode(bytes)?;
             }
         }
         Ok(())
@@ -136,22 +136,16 @@ impl Decode for PingPongMessage {
     fn decode(bytes: &mut std::io::Cursor<&[u8]>) -> Result<Self, CodecError> {
         let message_type = u8::decode(bytes)?;
         Ok(match message_type {
-            0 => {
-                let verifier_share = decode_u32_items(&(), bytes)?;
-                Self::Initialize { verifier_share }
-            }
-            1 => {
-                let verifier_message = decode_u32_items(&(), bytes)?;
-                let verifier_share = decode_u32_items(&(), bytes)?;
-                Self::Continue {
-                    verifier_message,
-                    verifier_share,
-                }
-            }
-            2 => {
-                let verifier_message = decode_u32_items(&(), bytes)?;
-                Self::Finish { verifier_message }
-            }
+            0 => Self::Initialize {
+                verifier_share: VariableLengthVector::decode(bytes)?,
+            },
+            1 => Self::Continue {
+                verifier_message: VariableLengthVector::decode(bytes)?,
+                verifier_share: VariableLengthVector::decode(bytes)?,
+            },
+            2 => Self::Finish {
+                verifier_message: VariableLengthVector::decode(bytes)?,
+            },
             _ => return Err(CodecError::UnexpectedValue),
         })
     }
@@ -268,16 +262,19 @@ impl<
                 Ok(PingPongState::Continued(Continued {
                     verifier_state,
                     message: PingPongMessage::Continue {
-                        verifier_message,
+                        verifier_message: verifier_message.into(),
                         verifier_share: verifier_share
                             .get_encoded()
-                            .map_err(PingPongError::CodecVerifierShare)?,
+                            .map_err(PingPongError::CodecVerifierShare)?
+                            .into(),
                     },
                 }))
             }
             VerifyTransition::Finish(output_share) => Ok(PingPongState::FinishedWithOutbound {
                 output_share,
-                message: PingPongMessage::Finish { verifier_message },
+                message: PingPongMessage::Finish {
+                    verifier_message: verifier_message.into(),
+                },
             }),
         })
     }
@@ -610,7 +607,8 @@ impl<
                 message: PingPongMessage::Initialize {
                     verifier_share: verifier_share
                         .get_encoded()
-                        .map_err(PingPongError::CodecVerifierShare)?,
+                        .map_err(PingPongError::CodecVerifierShare)?
+                        .into(),
                 },
             })
         })
@@ -638,16 +636,17 @@ impl<
             )
             .map_err(PingPongError::VdafVerifyInit)?;
 
-        let leader_verifier_share =
-            if let PingPongMessage::Initialize { verifier_share } = leader_message {
-                Self::VerifierShare::get_decoded_with_param(&verifier_state, verifier_share)
-                    .map_err(PingPongError::CodecVerifierShare)?
-            } else {
-                return Err(PingPongError::PeerMessageMismatch {
-                    found: leader_message.variant(),
-                    expected: "initialize",
-                });
-            };
+        let leader_verifier_share = if let PingPongMessage::Initialize { verifier_share } =
+            leader_message
+        {
+            Self::VerifierShare::get_decoded_with_param(&verifier_state, verifier_share.as_ref())
+                .map_err(PingPongError::CodecVerifierShare)?
+        } else {
+            return Err(PingPongError::PeerMessageMismatch {
+                found: leader_message.variant(),
+                expected: "initialize",
+            });
+        };
 
         let current_verifier_message = self
             .verifier_shares_to_message(
@@ -713,9 +712,11 @@ impl<
             PingPongMessage::Finish { verifier_message } => (verifier_message, None),
         };
 
-        let verifier_message =
-            Self::VerifierMessage::get_decoded_with_param(&host_verifier_state, verifier_message)
-                .map_err(PingPongError::CodecVerifierMessage)?;
+        let verifier_message = Self::VerifierMessage::get_decoded_with_param(
+            &host_verifier_state,
+            verifier_message.as_ref(),
+        )
+        .map_err(PingPongError::CodecVerifierMessage)?;
         let host_verify_transition = self
             .verify_next(ctx, host_verifier_state, verifier_message)
             .map_err(PingPongError::VdafVerifyNext)?;
@@ -727,7 +728,7 @@ impl<
             ) => {
                 let next_peer_verifier_share = Self::VerifierShare::get_decoded_with_param(
                     &next_verifier_state,
-                    next_peer_verifier_share,
+                    next_peer_verifier_share.as_ref(),
                 )
                 .map_err(PingPongError::CodecVerifierShare)?;
                 let mut verifier_shares = [next_peer_verifier_share, next_host_verifier_share];
@@ -971,7 +972,7 @@ mod tests {
         let messages = [
             (
                 PingPongMessage::Initialize {
-                    verifier_share: Vec::from("verifier share"),
+                    verifier_share: Vec::from("verifier share").into(),
                 },
                 concat!(
                     "00", // enum discriminant
@@ -984,8 +985,8 @@ mod tests {
             ),
             (
                 PingPongMessage::Continue {
-                    verifier_message: Vec::from("verifier message"),
-                    verifier_share: Vec::from("verifier share"),
+                    verifier_message: Vec::from("verifier message").into(),
+                    verifier_share: Vec::from("verifier share").into(),
                 },
                 concat!(
                     "01", // enum discriminant
@@ -1003,7 +1004,7 @@ mod tests {
             ),
             (
                 PingPongMessage::Finish {
-                    verifier_message: Vec::from("verifier message"),
+                    verifier_message: Vec::from("verifier message").into(),
                 },
                 concat!(
                     "02", // enum discriminant


### PR DESCRIPTION
TLS presentation language provides fixed and variable length vectors ([1]). Variable length vectors have a minimum and maximum length and are prefixed with a length that can be 1 to 4 bytes wide.

Thus far, `prio::codec` has handled these using the `encode_u*_items` and `decode_u*_items` functions. This works, but has some drawbacks:

- Because these are free functions instead of implementations of traits `Encode, Decode`, etc. on some type, it is hard to provide convenience functions like `Decode::get_decoded` generically.
- For similar reasons, we always take an encoding parameter, which is `()` in the majority of cases.
- Callers have to deal with the encoded length of variable length vectors themselves instead of using `Encode::encoded_len`.
- The minimum length is not enforced.

This commit introduces a new struct `VariableLengthVector`. It is generic over:

- minimum length,
- the type of the length prefix,
- and the type of the items.

See the doccomments on `VariableLengthVector` for examples of how to use it to realize different TLS PR declarations. We provide `Encode` and `Decode` implementations, but not `ParameterizedEncode/Decode`, based on the observation that we would never use it here in `prio` or in Janus.

[1]: https://datatracker.ietf.org/doc/html/rfc8446#section-3.4